### PR TITLE
0.7 fleet handoff + 0.7+ iterations + pre-0.8 cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Currently shipped:
 - `rcwl-0516` — microwave doppler motion sensor (low-power PIR alternative)
 - `ads1115` — TI 4-channel 16-bit ADC (I2C); rescues ESP32 designs from the ADC2/WiFi conflict
 - `mpu6050` — InvenSense 6-axis IMU (3-axis accel + 3-axis gyro + die temp, I2C)
+- `bmp180` — Bosch BMP180/BMP085 barometric pressure + temperature (I2C)
+- `htu21d` — TE Connectivity HTU21D temperature + humidity (I2C; covers Si7021 / SHT2x)
+- `max31855` — Maxim K-type thermocouple amplifier (SPI; -270..+1372°C)
+- `hx711` — AVIA 24-bit load-cell ADC (custom 2-wire serial)
+- `tsl2561` — AMS ambient light sensor (lux, I2C)
 
 The `gpio_input` / `gpio_output` components and the `kind: expander_pin`
 connection target together let downstream platforms hang off any expander

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Currently shipped:
 - `gpio_output` — generic switch on a GPIO or expander pin (relays, indicators)
 - `ds18b20` — Dallas 1-wire temperature sensor (single-pin bus + 4.7kΩ pull-up)
 - `rcwl-0516` — microwave doppler motion sensor (low-power PIR alternative)
+- `ads1115` — TI 4-channel 16-bit ADC (I2C); rescues ESP32 designs from the ADC2/WiFi conflict
+- `mpu6050` — InvenSense 6-axis IMU (3-axis accel + 3-axis gyro + die temp, I2C)
 
 The `gpio_input` / `gpio_output` components and the `kind: expander_pin`
 connection target together let downstream platforms hang off any expander

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Useful endpoints:
 | `GET`  | `/fleet/status` | check whether `FLEET_URL` + `FLEET_TOKEN` reach a distributed-esphome ha-addon |
 | `POST` | `/fleet/push` | render `design.json` and push it as `<device_name>.yaml` (optionally `compile: true`) |
 | `GET`  | `/fleet/jobs/{run_id}/log?offset=N` | poll the addon's build log for a compile run; returns `{log, offset, finished}` |
+| `GET`  | `/fleet/jobs/{run_id}/log/stream` | Server-Sent Events relay over the same log endpoint; ~300ms cadence, exits with `event: done` when the build finishes |
 
 The server is a thin layer over `studio.generate` — same code path the CLI
 uses, no server-side state. Permissive CORS for `localhost:5173` /

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ uses, no server-side state. Permissive CORS for `localhost:5173` /
 | [`bluesonoff.json`](examples/bluesonoff.json) | ESP-01S 1MB | Sonoff Basic relay; front button (boot strap pin) toggles a single GPIO relay |
 | [`wemosgps.json`](examples/wemosgps.json) | WeMos D1 Mini | UART GPS module — lat/lon/altitude/speed/satellites + runtime baud-rate selector |
 | [`ttgo-lora32.json`](examples/ttgo-lora32.json) | TTGO LoRa32 V1 | ESP32 + onboard SX1276 LoRa radio + onboard SSD1306 OLED + battery ADC, ESP-IDF |
+| [`multi-temp.json`](examples/multi-temp.json) | WeMos D1 Mini | Two DS18B20 temp sensors sharing a single 1-wire bus + an RCWL-0516 microwave motion sensor |
 
 Generated artifacts for each are pinned as goldens in
 [`tests/golden/`](tests/golden/).

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Currently shipped:
 - `ws2812b` — addressable RGB LED (NeoPixel/neopixelbus)
 - `gpio_input` — generic binary_sensor on a GPIO or expander pin (buttons, limit switches, door/window/motion sensors)
 - `gpio_output` — generic switch on a GPIO or expander pin (relays, indicators)
+- `ds18b20` — Dallas 1-wire temperature sensor (single-pin bus + 4.7kΩ pull-up)
+- `rcwl-0516` — microwave doppler motion sensor (low-power PIR alternative)
 
 The `gpio_input` / `gpio_output` components and the `kind: expander_pin`
 connection target together let downstream platforms hang off any expander

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ Currently shipped:
 - `gpio_output` — generic switch on a GPIO or expander pin (relays, indicators)
 - `ds18b20` — Dallas 1-wire temperature sensor (single-pin bus + 4.7kΩ pull-up)
 - `rcwl-0516` — microwave doppler motion sensor (low-power PIR alternative)
-- `ads1115` — TI 4-channel 16-bit ADC (I2C); rescues ESP32 designs from the ADC2/WiFi conflict
+- `ads1115` — TI 4-channel 16-bit ADC (I2C) hub; rescues ESP32 designs from the ADC2/WiFi conflict
+- `ads1115_channel` — one logical reading on an ADS1115 hub (multiplexer + gain + update_interval per channel)
 - `mpu6050` — InvenSense 6-axis IMU (3-axis accel + 3-axis gyro + die temp, I2C)
 - `bmp180` — Bosch BMP180/BMP085 barometric pressure + temperature (I2C)
 - `htu21d` — TE Connectivity HTU21D temperature + humidity (I2C; covers Si7021 / SHT2x)

--- a/START.md
+++ b/START.md
@@ -30,10 +30,28 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 - Full SSE/WS log relay (current 0.7+ uses HTTP polling at 1.5s intervals)
 - Drag-and-drop pinout (long-running: 0.3 already pre-flagged this as
   a follow-on iteration)
-- Library expansion: BMP180 (older I2C T/P), HTU21D (T/H), MAX31855
-  (thermocouple), HX711 (load-cell ADC), TSL2561 (lux)
 - ADS1115 hub-only mode (channels-as-separate-components) once a
   user wants to mix gain/update_interval per logical sensor
+
+**Library expansion v3 shipped (5 components).**
+- `bmp180` — older Bosch barometric T/P (I2C, fixed 0x77, no humidity).
+  Renders the deprecated-but-supported `bmp085` ESPHome platform; covers
+  legacy modules people still have on hand.
+- `htu21d` — T/H (I2C, fixed 0x40). Drop-in for designs that don't need
+  pressure; covers the Si7021 / SHT2x families on the same protocol.
+- `max31855` — K-type thermocouple amp (SPI, MISO-only). Range -270 to
+  +1372°C. Optional `reference_temperature: true` publishes the cold-
+  junction reading. CS is per-component native (`spi_cs`).
+- `hx711` — 24-bit load-cell ADC, custom 2-wire serial (DOUT + SCK on
+  free GPIOs, no bus). Channel A 128/64x or channel B 32x via the
+  `gain` param.
+- `tsl2561` — ambient light / lux (I2C). Address selectable across
+  0x29/0x39/0x49 via the ADDR pin; gain + integration_time tunables.
+
+10 new tests: 5 yaml-gen smoke (each component renders the expected
+ESPHome platform with the right pin / address / param wiring) + 5
+recommender pin tests (thermocouple, weight, lux, pressure, humidity
+all land on the right top pick).
 
 **Library expansion: ADS1115 + MPU6050 shipped.**
 - `library/components/ads1115.yaml`: 4-channel 16-bit ADC over I2C.

--- a/START.md
+++ b/START.md
@@ -29,11 +29,29 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 **Next up candidates:**
 - Drag-and-drop pinout (long-running: 0.3 already pre-flagged this as
   a follow-on iteration)
-- ADS1115 hub-only split: needs schema design first. The clean shape
-  is a new `kind: "component"` connection target that points an
-  `ads1115_channel` instance at its hub `ads1115` instance. Touches
-  schema/model/generator/pin solver/UI -- a 2-3 commit refactor that
-  wants its own focused session.
+- 0.8 enclosure suggestions
+- 0.9 KiCad schematic export (SKiDL recommended; map studio
+  components to `kicad-symbols` symbols via a new `kicad:` block per
+  library entry)
+
+**ADS1115 hub-only split shipped.** New `kind: "component"` connection
+target lets one component instance reference another by id. The
+generator surfaces the referenced instance as `parent` in the
+template's Jinja context (sibling to `bus`); the pin solver fills
+unbound `kind: component` targets by picking the first design
+component whose library_id matches the role's `parent_library_id`
+hint on the library Pin. ConnectionForm gains a `component` option
+in the kind dropdown with a sibling-instance picker.
+
+`ads1115` is now hub-only -- it registers the `ads1115:` block but
+emits no sensors. Each logical reading is a separate
+`ads1115_channel` instance with its own multiplexer/gain/update_interval
+params and a HUB connection (kind=component) pointing at the hub.
+Channels show up as first-class components in the inspector instead
+of being buried inside a `channels` array param. The schema /
+model / generator / solver / web type extension is generic; future
+hub patterns (RGB controllers, multiplexed mux chips) can reuse it
+without further surgery.
 
 **SSE log relay shipped.** New `GET /fleet/jobs/{run_id}/log/stream`
 endpoint server-side-polls the addon's `/ui/api/jobs/{id}/log` at

--- a/START.md
+++ b/START.md
@@ -28,13 +28,12 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 
 **Next up candidates:**
 - 0.8 — Enclosure suggestions (Thingiverse/Printables search;
-  parametric OpenSCAD stretch)
-- 0.9 — KiCad schematic export. SKiDL recommended (Python DSL that
-  takes parts + nets and emits `.kicad_sch` directly). Each
-  `library/components/<id>.yaml` gains a `kicad:` block mapping to
-  the matching kicad-symbols entry (BME280 -> `Sensor:BME280`,
-  ADS1115 -> `Analog_ADC:ADS1115xDGS`, etc.). Boards likewise gain
-  a kicad: block. PCB layout deferred to 1.0+.
+  parametric OpenSCAD stretch).
+- 0.9 — KiCad schematic export. Full scope in the Roadmap section
+  below; key points: SKiDL-driven, `kicad:` reference block per
+  component/board (we stay canonical for ESPHome semantics, KiCad
+  for schematic rendering), `studio/kicad/scaffold.py` helper for
+  cheap library expansion, PCB deferred to 1.0+.
 
 **Drag-and-drop pinout shipped.** New `PinoutView` component renders
 a two-column view in the component-instance inspector: left lists
@@ -533,8 +532,74 @@ immediate way in and the agent (when it arrives) lands in a working surface.
   device list to pick a target name from.
 - **0.8 — Enclosure suggestions.** Thingiverse/Printables lookup against
   the chosen board + components; parametric OpenSCAD stretch.
-- **Future — KiCad schematic + PCB layout.** Reuse the netlist; Freerouting
-  for autorouting; Gerber + JLCPCB CPL/BOM export.
+- **0.9 — KiCad schematic export.** Walk `design.json` and emit a
+  `.kicad_sch` (KiCad 6+ s-expression format) the user opens in
+  KiCad. SKiDL is the recommended path: a mature Python DSL that
+  takes parts + nets and writes the schematic for us. Concretely:
+
+  - **Library mapping, not duplication.** Our `library/components/<id>.yaml`
+    stays the canonical source for ESPHome semantics; it gains a small
+    `kicad:` block that *references* the matching `kicad-symbols`
+    entry rather than copying its pin geometry. The two libraries
+    sit at orthogonal layers -- KiCad's covers schematic rendering
+    (pin numbers, electrical types, footprint, datasheet); ours
+    covers the rest (Jinja YAML template, use_cases, required buses,
+    `params_schema`, electrical bounds, capability tags). Replacing
+    one with the other moves the data, doesn't eliminate it.
+
+    Block shape:
+    ```yaml
+    kicad:
+      symbol_lib: Sensor
+      symbol: BME280
+      footprint: Package_LGA:LGA-8_2.5x2.5mm_P0.65mm_LayoutBorder3x3y
+      pin_map:                # studio role -> KiCad pin name
+        VCC: VDD
+        GND: GND
+        SDA: SDA
+        SCL: SCL
+    ```
+
+    Pin map handles the cases where our role names differ from a
+    symbol's (e.g., our `VCC` vs Bosch's `VDD`); most parts are 1:1.
+
+  - **Boards likewise.** `library/boards/<id>.yaml` gains the same
+    `kicad:` block (e.g., WeMos D1 Mini -> `MCU_Module:WeMos_D1_mini`),
+    so the schematic gets the right module symbol, not just a sea of
+    nets.
+
+  - **Generator.** New `studio/kicad/` module: walks `design.json`,
+    converts each component instance into a SKiDL `Part(...)`, each
+    connection into a Net assignment, and either emits a SKiDL Python
+    script (the user runs it themselves) or invokes SKiDL in-process
+    to write `<design_id>.kicad_sch` directly. New endpoint
+    `POST /design/kicad` returns the artifact; CLI gets a
+    `--out-kicad` flag.
+
+  - **Scaffold helper.** Cheap tooling win: `studio/kicad/scaffold.py`
+    reads a `.kicad_sym` file and prints a starter
+    `library/components/<id>.yaml` skeleton (pin roles + voltage
+    hints prefilled from the symbol's pin electrical_types). Cuts
+    ~80% of the boilerplate when adding a new library entry. Author
+    fills in the ESPHome template + use_cases + params_schema after.
+
+  - **Coverage.** `kicad-symbols` (the libraries shipped with KiCad,
+    CC-BY-SA + GPL exception) covers nearly every component we
+    already have: BME280, BMP180, HTU21D, DS18B20, MPU6050, ADS1115,
+    TSL2561, MAX31855, HX711, SSD1306, MCP23008/17, SX127x, WS2812B,
+    plus the board modules. The PIRs (HC-SR501) and microwave radar
+    (RCWL-0516) are typically wired as 3-pin `Connector_Generic`
+    instances since they're breakouts; same for HC-SR04. SnapEDA /
+    Component Search Engine cover the remaining manufacturer parts
+    (RC522 etc.) for free.
+
+  - **PCB layout deferred to 1.0+.** SKiDL can also emit netlists
+    that feed Freerouting + KiCad's PCB editor, but auto-routed
+    boards are a per-design quality concern that wants its own
+    iteration. 0.9 ships only the schematic.
+
+- **Future — KiCad PCB layout.** Reuse the schematic's netlist;
+  Freerouting for autorouting; Gerber + JLCPCB CPL/BOM export.
 
 The UI-first ordering means 0.5's agent and 0.6's solver each have a
 visible place to land. If the agent lands first (alternative ordering),

--- a/START.md
+++ b/START.md
@@ -32,12 +32,23 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 - Drag-and-drop pinout (long-running: 0.3 already pre-flagged this as
   a follow-on iteration)
 - Library expansion: ADS1115 4-channel I2C ADC + MPU6050 6-axis IMU
-- 1-wire bus type promotion: a proper `Bus` field for the DATA pin
-  so multiple DS18B20s can share a single physical bus (today each
-  instance creates its own `<id>_bus`; works but wasteful with many
-  sensors on one wire)
-- Goldens for the new components (a one-DS18B20 + one-RCWL design
-  pinned to `tests/golden/`)
+
+**1-wire bus type promotion shipped.** The `Bus` model gains a `pin`
+field (single-pin bus, parallel to the multi-pin sets on i2c/spi).
+yaml_gen renders a top-level `one_wire:` block per 1-wire bus
+(`{platform: gpio, pin, id}`) so multiple sensors on a shared physical
+bus emit a single bus block, not one per sensor. The DS18B20 template
+no longer carries a `one_wire:` block of its own -- it reads `bus.id`
+and emits `dallas_temp` with the matching `one_wire_id`. Pin-solver
+and bus-pin compatibility checks gain a `1wire` entry; the BusList
+editor surfaces a `pin` field on 1wire cards instead of the previous
+"lives on each component" placeholder. design.ts's `neededBusTypes`
+and `defaultTargetForPin` recognise the new `onewire_data` pin kind.
+
+New `examples/multi-temp.json` + golden artifacts pin the round-trip:
+two DS18B20s with distinct ROM addresses sharing `wire0` on D6 plus
+an RCWL-0516 microwave motion sensor on D5. 4 new pytest cases (2
+yaml-gen, 1 ascii-gen golden, 1 yaml-gen single-instance smoke).
 
 **Strict-only push gate shipped.** `POST /fleet/push` now accepts
 `strict: bool` and refuses the push with the same `strict_mode_blocked`

--- a/START.md
+++ b/START.md
@@ -27,12 +27,32 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 + build clean.
 
 **Next up candidates:**
-- Drag-and-drop pinout (long-running: 0.3 already pre-flagged this as
-  a follow-on iteration)
-- 0.8 enclosure suggestions
-- 0.9 KiCad schematic export (SKiDL recommended; map studio
-  components to `kicad-symbols` symbols via a new `kicad:` block per
-  library entry)
+- 0.8 — Enclosure suggestions (Thingiverse/Printables search;
+  parametric OpenSCAD stretch)
+- 0.9 — KiCad schematic export. SKiDL recommended (Python DSL that
+  takes parts + nets and emits `.kicad_sch` directly). Each
+  `library/components/<id>.yaml` gains a `kicad:` block mapping to
+  the matching kicad-symbols entry (BME280 -> `Sensor:BME280`,
+  ADS1115 -> `Analog_ADC:ADS1115xDGS`, etc.). Boards likewise gain
+  a kicad: block. PCB layout deferred to 1.0+.
+
+**Drag-and-drop pinout shipped.** New `PinoutView` component renders
+a two-column view in the component-instance inspector: left lists
+every board GPIO with capability badges (boot strap, ADC1/ADC2,
+input-only, serial console, I2C SDA/SCL); right lists this instance's
+gpio-target connections as draggable chips. Dropping a chip onto a
+board pin rewrites the connection's target. Conflict detection paints
+the rose tone on pins another component already uses; the row that's
+currently bound (on this instance) glows emerald with a "← <role>"
+breadcrumb.
+
+The Connections section gains a Form/Pinout toggle: Form (default)
+covers every target kind including the new component target; Pinout
+is the visual shortcut for board-pin-heavy designs. Native HTML5
+drag/drop -- no library dependency, ~200 lines of TSX, ~150 lines of
+test coverage. 7 new vitest cases (empty states, capability badge
+rendering, pin-currently-here annotation, conflict detection, the
+drag-start-then-drop round trip, and the empty-payload no-op).
 
 **ADS1115 hub-only split shipped.** New `kind: "component"` connection
 target lets one component instance reference another by id. The

--- a/START.md
+++ b/START.md
@@ -27,10 +27,41 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 + build clean.
 
 **Next up candidates:**
-- Frontend RTL/jsdom component tests
 - Full SSE/WS log relay (current 0.7+ uses HTTP polling at 1.5s intervals)
-- Capability picker: per-result "alternatives" tooltip surfacing the
-  recommender's full ranking when the user wants to compare
+- More component tests: ConnectionForm (lock toggle), Inspector
+  (DesignInspector composition), PushToFleetDialog (log polling)
+- Drag-and-drop pinout (long-running: 0.3 already pre-flagged this as
+  a follow-on iteration)
+- Strict-mode toggle that promotes pin-conflict warnings to render
+  errors (today everything is permissive)
+
+**Capability picker alternatives disclosure shipped.** Each match in
+the picker now carries a small "▸ N alternatives" toggle below its
+metadata row. Clicking expands an inline list of the OTHER currently-
+visible matches (filtered through the same bus filter) with their
+score and the delta against the row -- emerald-tinted when an
+alternative beats the row's score, muted-zinc when it's worse.
+Single-expanded-at-a-time policy: opening one closes the previous so
+the result list never grows multiple stacked alternatives panels.
+
+**RTL/jsdom component tests scaffolded.** New `vitest.config.ts`
+extends the existing vite config with `environment: "jsdom"` and a
+setup file that imports `@testing-library/jest-dom` matchers. First
+two suites cover the surfaces with the most state machinery:
+- `BusList.test.tsx`: rename draft commits on Enter, reverts on
+  Escape (caught and fixed a real bug -- the previous Escape handler
+  blurred the input, racing the queued state reset and leaking the
+  stale draft through commitRename), rejects collision with another
+  bus's id, inline compat warnings filter to the matching card.
+- `CapabilityPickerDialog.test.tsx`: alternatives disclosure shows
+  "N alternatives" toggle on every multi-match list, expansion is
+  single-row-at-a-time with aria-expanded synchronised, score delta
+  carries the sign and the right tint, bus filter hides + counter
+  surface and the unhide path. Plus an Add round-trip that confirms
+  onAdd receives the library_id and the row flips to the affirmation.
+
+15 new vitest cases (53 -> 68 -> 83); the network surface is mocked
+at the api/client boundary so the suite stays fast (2.4s for all 83).
 
 **Bus rename propagation + inline bus card warnings shipped.** New
 `renameBus(d, oldId, newId)` helper rewrites the bus's id and every

--- a/START.md
+++ b/START.md
@@ -27,13 +27,35 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 + build clean.
 
 **Next up candidates:**
-- Bus editor in the UI
 - Frontend RTL/jsdom component tests
 - Full SSE/WS log relay (current 0.7+ uses HTTP polling at 1.5s intervals)
 - Capability picker: per-result "alternatives" tooltip surfacing the
   recommender's full ranking when the user wants to compare
-- Pin-lock UI: per-component "lock to pin X" toggle in the inspector that
-  writes `locked_pins[role]` rather than asking users to hand-edit JSON
+- Bus rename propagation: when the user renames `i2c0 -> shared_i2c`,
+  rewrite every `connection.target.bus_id == "i2c0"` automatically
+  (today the connection's stale reference becomes "(invalid)" until
+  the user re-points it)
+- Bus editor: surface bus-pin compatibility warnings (boot strap, no_i2c)
+  inline on the bus card
+
+**Pin-lock inspector toggle shipped.** Connection rows in the inspector
+gain a 🔓/🔒 button next to the gpio pin selector. Click 🔓 lock to
+write `locked_pins[role]` for the currently bound pin; click 🔒 to
+clear it. The lock badge turns amber when the bound pin diverges from
+the lock and an inline "solver will flag a mismatch" hint surfaces
+the discrepancy without leaving the row. Reads/writes go through new
+`readConnections.locked_pin` and `setLockedPin` helpers in
+`web/src/lib/design.ts`.
+
+**Bus editor shipped.** Design Inspector now has a Buses section with
+one card per bus. Each card lets the user rename the id, edit the
+type's pin slots (`sda`/`scl` for i2c, `clk`/`miso`/`mosi` for spi,
+`tx`/`rx` for uart, `lrclk`/`bclk` for i2s) plus the type's tunable
+(frequency_hz / baud_rate). Pin selectors are populated from the
+board's `gpio_capabilities`; an "+ add bus" picker creates a fresh bus
+seeded from `board.default_buses` when present. Removing a bus
+intentionally leaves connections that target it dangling so the
+render-time error makes the inconsistency loud.
 
 **Pin locks shipped (permissive).** `Component.locked_pins` is no
 longer dead code:

--- a/START.md
+++ b/START.md
@@ -28,10 +28,42 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 
 **Next up candidates:**
 - Full SSE/WS log relay (current 0.7+ uses HTTP polling at 1.5s intervals)
-- Inspector composition tests (DesignInspector wiring)
 - Drag-and-drop pinout (long-running: 0.3 already pre-flagged this as
   a follow-on iteration)
-- Library expansion: ADS1115 4-channel I2C ADC + MPU6050 6-axis IMU
+- Library expansion: BMP180 (older I2C T/P), HTU21D (T/H), MAX31855
+  (thermocouple), HX711 (load-cell ADC), TSL2561 (lux)
+- ADS1115 hub-only mode (channels-as-separate-components) once a
+  user wants to mix gain/update_interval per logical sensor
+
+**Library expansion: ADS1115 + MPU6050 shipped.**
+- `library/components/ads1115.yaml`: 4-channel 16-bit ADC over I2C.
+  Renders an `ads1115:` hub block + per-channel `sensor:` entries
+  driven by a `channels` param (multiplexer, name, gain, update_
+  interval). Address selectable via the ADDR pin maps to 0x48-0x4B.
+  Solves the ADC2/WiFi conflict on classic ESP32 by giving the
+  chip a known-good external ADC.
+- `library/components/mpu6050.yaml`: 6-axis IMU (3-axis accel +
+  3-axis gyro + die temp). All seven channels emitted in one
+  `sensor:` entry; AD0 selects 0x68/0x69. The INT pin isn't modeled
+  yet -- a binary_sensor in esphome_extras handles motion-wake until
+  someone needs richer support.
+- 4 new yaml-gen tests (per-channel rendering, hub-with-no-channels
+  smoke, full IMU axis emission, both parts sharing a single I2C
+  bus) + 2 new recommender tests (adc query lands on ads1115, IMU
+  queries land on mpu6050).
+
+**Inspector composition tests shipped.** New `Inspector.test.tsx`
+(9 tests) covers the DesignInspector composition: null-design
+fallback, component row rendering with id+label+library_id, section
+counts (Components/Buses/Requirements/Warnings) reflecting the design,
+selection callback firing with `kind: "component_instance"` when a
+row is clicked, the per-row ✕ wiring through to onRemoveComponent,
+the Compatibility section's hide/show on warning presence, the Fleet
+section's gate on the design's fleet block, and the empty-components
+affordance. api.getComponent is mocked at the boundary; no real
+network calls.
+
+228 pytest (+6), 105 vitest (+9), ruff + tsc + vite build clean.
 
 **1-wire bus type promotion shipped.** The `Bus` model gains a `pin`
 field (single-pin bus, parallel to the multi-pin sets on i2c/spi).

--- a/START.md
+++ b/START.md
@@ -28,12 +28,39 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 
 **Next up candidates:**
 - Full SSE/WS log relay (current 0.7+ uses HTTP polling at 1.5s intervals)
-- More component tests: ConnectionForm (lock toggle), Inspector
-  (DesignInspector composition), PushToFleetDialog (log polling)
+- Inspector composition tests (DesignInspector wiring)
 - Drag-and-drop pinout (long-running: 0.3 already pre-flagged this as
   a follow-on iteration)
-- Strict-mode toggle that promotes pin-conflict warnings to render
-  errors (today everything is permissive)
+- Push-to-fleet "strict-only" mode: refuse the push when strict-mode
+  is on AND the design has pending warn/error compat hits
+- Library expansion: more sensor categories (DS18B20 1-wire temp,
+  RCWL-0516 microwave motion, ADS1115 ADC, MPU6050 IMU)
+
+**ConnectionForm + PushToFleetDialog component tests shipped.** New
+`ConnectionForm.test.tsx` (7 tests) covers the LockToggle's three
+states (unlocked / locked-in-sync / locked-diverged), the disabled
+state when no pin is bound, the onLockedPinChange round-trip, the
+inline mismatch hint, and the non-render guard for non-gpio targets.
+New `PushToFleetDialog.test.tsx` (6 tests) covers the status fetch
+gating Push, the device-name round-trip in the fleetPush payload,
+no-run_id-no-log-viewer, single-shot finished-on-first-poll, and
+`vi.useFakeTimers` driven multi-chunk polling that confirms the
+1.5s gap is honoured and the second poll fetches at the offset
+returned by the first. Plus an error-path test that surfaces
+"log error: addon disconnected" and stops the loop.
+
+**Strict-mode toggle shipped.** `POST /design/render?strict=true`
+now refuses to produce YAML/ASCII when any compatibility entry of
+severity warn or error remains; the response is a 422 with detail
+shape `{error: "strict_mode_blocked", message, warnings[]}`. Header
+gains a "strict" checkbox (amber-tinted when on, plain when off);
+flipping it re-fires the debounced render with the new flag in the
+deps array. The existing renderError banner gets a small upgrade to
+recognise the `strict_mode_blocked` envelope and surface the count
+instead of dumping the JSON envelope. info-severity entries are
+deliberately left as a permissive signal -- they're educational
+(voltage_limit on D1 Mini A0, current-budget guidance) and don't
+block. 3 new pytest cases pin the gate.
 
 **Capability picker alternatives disclosure shipped.** Each match in
 the picker now carries a small "▸ N alternatives" toggle below its

--- a/START.md
+++ b/START.md
@@ -31,10 +31,42 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 - Inspector composition tests (DesignInspector wiring)
 - Drag-and-drop pinout (long-running: 0.3 already pre-flagged this as
   a follow-on iteration)
-- Push-to-fleet "strict-only" mode: refuse the push when strict-mode
-  is on AND the design has pending warn/error compat hits
-- Library expansion: more sensor categories (DS18B20 1-wire temp,
-  RCWL-0516 microwave motion, ADS1115 ADC, MPU6050 IMU)
+- Library expansion: ADS1115 4-channel I2C ADC + MPU6050 6-axis IMU
+- 1-wire bus type promotion: a proper `Bus` field for the DATA pin
+  so multiple DS18B20s can share a single physical bus (today each
+  instance creates its own `<id>_bus`; works but wasteful with many
+  sensors on one wire)
+- Goldens for the new components (a one-DS18B20 + one-RCWL design
+  pinned to `tests/golden/`)
+
+**Strict-only push gate shipped.** `POST /fleet/push` now accepts
+`strict: bool` and refuses the push with the same `strict_mode_blocked`
+envelope that `/design/render?strict=true` uses when any warn/error
+compat entry remains. The studio app threads its global strict-mode
+toggle into `PushToFleetDialog` as a prop; the dialog renders an
+amber notice when strict is on and the result-banner formatter
+recognises the envelope so the user sees the friendly message
+instead of the raw JSON. 2 new pytest cases pin the gate.
+
+**Library expansion: RCWL-0516 + DS18B20 shipped.**
+- `library/components/rcwl-0516.yaml`: microwave doppler motion sensor.
+  Same VCC/GND/OUT pin set as the HC-SR501 PIR but draws ~3 mA peak
+  vs ~50 mA, so it complements the PIR for battery builds. No params
+  (sensitivity/on-time live on the SMD resistors). Recommender ranks
+  it alongside the PIR for `motion`/`occupancy`/`presence` queries.
+- `library/components/ds18b20.yaml`: first 1-wire library citizen.
+  VCC/GND/DATA + the canonical 4.7kΩ pull-up between DATA and VCC
+  encoded in `passives`. Each instance renders its own
+  `one_wire: [{ id: <comp>_bus }]` block plus a `dallas_temp` sensor
+  pointing at it; the existing `_deep_merge` of list-typed top-level
+  blocks means N independent DS18B20s on N different pins coexist
+  cleanly. Sharing a single physical bus among multiple sensors is
+  noted in the component's `notes` field but not yet wired -- that's
+  a 1-wire-bus promotion candidate above. Params expose `address`
+  (ROM), `update_interval`, `resolution` (9-12 bits).
+
+7 new pytest cases (yaml gen for both + recommender ranks both +
+strict push). 220 pytest, 96 vitest, ruff + tsc + build clean.
 
 **ConnectionForm + PushToFleetDialog component tests shipped.** New
 `ConnectionForm.test.tsx` (7 tests) covers the LockToggle's three

--- a/START.md
+++ b/START.md
@@ -28,13 +28,34 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 
 **Next up candidates:**
 - Bus editor in the UI
-- Strict-mode pin locks (`locked_pins` already in schema)
 - Frontend RTL/jsdom component tests
 - Full SSE/WS log relay (current 0.7+ uses HTTP polling at 1.5s intervals)
-- Capability picker: bus-aware constraint pre-fill (auto-set required_bus
-  from the design's existing buses so I2C designs don't surface SPI parts)
 - Capability picker: per-result "alternatives" tooltip surfacing the
   recommender's full ranking when the user wants to compare
+- Pin-lock UI: per-component "lock to pin X" toggle in the inspector that
+  writes `locked_pins[role]` rather than asking users to hand-edit JSON
+
+**Pin locks shipped (permissive).** `Component.locked_pins` is no
+longer dead code:
+- Solver applies locks before solving. Empty gpio targets get filled
+  from the lock; bound targets that disagree surface a
+  `locked_pin_mismatch` warning (the bound pin stays put — divergence
+  might be intentional). Lock keys that aren't real roles on the
+  library component surface a `locked_pin_unknown_role` warning.
+  Locks against non-gpio targets surface `locked_pin_wrong_kind`.
+- compatibility.py validates the lock's target pin against the role's
+  required capability; a `locked_pin_invalid` (severity: error) fires
+  when, say, an `analog_in` lock lands on a pin without `adc`.
+- 6 new tests pin all paths.
+
+**Capability picker bus filter shipped.** Dialog now receives the
+design's bus types (i2c/spi/uart/i2s/1wire) and offers a "match my
+buses" checkbox (default on). When on, ranked matches whose
+`required_components` include a bus the design lacks are dropped
+from the visible list with a "N hidden by the bus filter" note.
+Uncheck to see everything (e.g., when the user is happy to add a
+new bus). The agent's recommend tool is unchanged — this is a
+UI-side filter only.
 
 **Capability-driven "Add by function" picker shipped.** New backend
 endpoint `GET /library/use_cases` aggregates the library's canonical

--- a/START.md
+++ b/START.md
@@ -27,11 +27,33 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 + build clean.
 
 **Next up candidates:**
-- Full SSE/WS log relay (current 0.7+ uses HTTP polling at 1.5s intervals)
 - Drag-and-drop pinout (long-running: 0.3 already pre-flagged this as
   a follow-on iteration)
-- ADS1115 hub-only mode (channels-as-separate-components) once a
-  user wants to mix gain/update_interval per logical sensor
+- ADS1115 hub-only split: needs schema design first. The clean shape
+  is a new `kind: "component"` connection target that points an
+  `ads1115_channel` instance at its hub `ads1115` instance. Touches
+  schema/model/generator/pin solver/UI -- a 2-3 commit refactor that
+  wants its own focused session.
+
+**SSE log relay shipped.** New `GET /fleet/jobs/{run_id}/log/stream`
+endpoint server-side-polls the addon's `/ui/api/jobs/{id}/log` at
+~300ms (vs the browser-driven 1.5s) and emits Server-Sent Events:
+`data:` frames carry `{log, offset, finished}` chunks; an
+`event: done` frame caps a successful run; an `event: error` frame
+surfaces logical failures (unknown run_id) so the client knows not
+to retry. `interval_ms` query param tunes the cadence with a 100ms
+floor.
+
+PushToFleetDialog tries `EventSource` first; on transport error it
+closes and falls back to the existing 1.5s `setTimeout` polling
+loop, picking up at the offset of the last accepted chunk so no log
+bytes are lost. The status pill shows `(stream)` or `(poll)` so
+testers can see which path is in use. EventSource isn't on jsdom by
+default, so the existing polling tests stay green; the SSE path got
+3 new tests using a FakeEventSource stub (chunk -> done flow,
+transport-error fallback to polling, server-emitted error event).
+
+241 pytest (+3), 108 vitest (+3), ruff + tsc + vite build clean.
 
 **Library expansion v3 shipped (5 components).**
 - `bmp180` — older Bosch barometric T/P (I2C, fixed 0x77, no humidity).

--- a/START.md
+++ b/START.md
@@ -31,12 +31,20 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 - Full SSE/WS log relay (current 0.7+ uses HTTP polling at 1.5s intervals)
 - Capability picker: per-result "alternatives" tooltip surfacing the
   recommender's full ranking when the user wants to compare
-- Bus rename propagation: when the user renames `i2c0 -> shared_i2c`,
-  rewrite every `connection.target.bus_id == "i2c0"` automatically
-  (today the connection's stale reference becomes "(invalid)" until
-  the user re-points it)
-- Bus editor: surface bus-pin compatibility warnings (boot strap, no_i2c)
-  inline on the bus card
+
+**Bus rename propagation + inline bus card warnings shipped.** New
+`renameBus(d, oldId, newId)` helper rewrites the bus's id and every
+`connection.target.bus_id == oldId` atomically. The bus card's id
+input now keeps a local draft and commits on blur or Enter (Esc
+reverts) so a mid-typing intermediate like "" or "i" doesn't briefly
+orphan connections; the field tints amber while dirty and red on a
+collision with another bus's id. `updateBus` silently strips an `id`
+key from its patch so nothing else sneaks past renameBus. Each bus
+card now also filters whole-design compatibility warnings down to
+its own (matched on `component_id`) and renders them inline below
+the pin grid in severity-tinted rows -- so a boot-strap warning on
+`spi0.CLK` shows up on the spi0 card, not just under the design's
+Compatibility section.
 
 **Pin-lock inspector toggle shipped.** Connection rows in the inspector
 gain a 🔓/🔒 button next to the gpio pin selector. Click 🔓 lock to

--- a/examples/multi-temp.json
+++ b/examples/multi-temp.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "0.1",
+  "id": "multi-temp",
+  "name": "Multi-zone DS18B20 temperatures",
+  "description": "ESP8266 D1 Mini with two DS18B20 1-wire sensors sharing a single GPIO bus. Demonstrates the 1-wire bus type and the per-sensor ROM addressing pattern. Adds an RCWL-0516 microwave motion sensor on a separate GPIO so the controller can suppress polling when the room is empty.",
+  "created_at": "2026-05-04T00:00:00Z",
+  "updated_at": "2026-05-04T00:00:00Z",
+
+  "board": {
+    "library_id": "wemos-d1-mini",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-rt9013",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "two temperature readings on a single bus" },
+    { "id": "r2", "kind": "capability", "text": "occupancy hint via microwave radar" }
+  ],
+
+  "components": [
+    {
+      "id": "supply_temp",
+      "library_id": "ds18b20",
+      "label": "Boiler supply",
+      "role": "temperature_sensor",
+      "params": {
+        "address": "0x1c0000031edd2a28",
+        "update_interval": "30s",
+        "resolution": 12
+      }
+    },
+    {
+      "id": "return_temp",
+      "library_id": "ds18b20",
+      "label": "Boiler return",
+      "role": "temperature_sensor",
+      "params": {
+        "address": "0xa20000031e1c2828",
+        "update_interval": "30s",
+        "resolution": 12
+      }
+    },
+    {
+      "id": "radar1",
+      "library_id": "rcwl-0516",
+      "label": "Boiler room presence",
+      "role": "occupancy_sensor",
+      "params": {}
+    }
+  ],
+
+  "buses": [
+    { "id": "wire0", "type": "1wire", "pin": "D6" }
+  ],
+
+  "connections": [
+    { "component_id": "supply_temp", "pin_role": "VCC",  "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "supply_temp", "pin_role": "GND",  "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "supply_temp", "pin_role": "DATA", "target": { "kind": "bus",  "bus_id": "wire0" } },
+
+    { "component_id": "return_temp", "pin_role": "VCC",  "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "return_temp", "pin_role": "GND",  "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "return_temp", "pin_role": "DATA", "target": { "kind": "bus",  "bus_id": "wire0" } },
+
+    { "component_id": "radar1", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "radar1", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "radar1", "pin_role": "OUT", "target": { "kind": "gpio", "pin": "D5" } }
+  ],
+
+  "passives": [
+    { "id": "r1", "kind": "resistor", "value": "4.7k",
+      "between": ["wire0", "3V3"],
+      "purpose": "1-wire bus pull-up (shared by both DS18B20s)" }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "multi-temp",
+    "tags": ["indoor", "temperature", "occupancy"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/library/components/ads1115.yaml
+++ b/library/components/ads1115.yaml
@@ -1,5 +1,5 @@
 id: ads1115
-name: ADS1115 4-channel 16-bit ADC (I2C)
+name: ADS1115 4-channel 16-bit ADC hub (I2C)
 category: sensor
 use_cases: [adc, analog_in, voltage, current_sense]
 aliases: ["ads1015", "ti adc", "external adc"]
@@ -31,17 +31,6 @@ esphome:
     {%- if params.continuous_mode is defined %}
         continuous_mode: {{ params.continuous_mode | tojson }}
     {%- endif %}
-    {% if params.channels is defined %}
-    sensor:
-    {%- for ch in params.channels %}
-      - platform: ads1115
-        ads1115_id: {{ id }}_hub
-        multiplexer: {{ ch.multiplexer }}
-        gain: {{ ch.gain | default('6.144') }}
-        name: "{{ ch.name }}"
-        update_interval: {{ ch.update_interval | default('60s') }}
-    {%- endfor %}
-    {%- endif %}
 
 params_schema:
   address:
@@ -52,20 +41,13 @@ params_schema:
   continuous_mode:
     type: boolean
     description: "Continuous conversion vs single-shot. Continuous wakes the chip on every sample."
-  channels:
-    type: array
-    description: |
-      One sensor entry per ADC reading. Each item:
-        - multiplexer: A0_GND|A1_GND|A2_GND|A3_GND|A0_A1|A0_A3|A1_A3|A2_A3
-        - name: <ESPHome sensor name>
-        - gain: 6.144|4.096|2.048|1.024|0.512|0.256 (default 6.144)
-        - update_interval: optional (default 60s)
 
 notes: |
-  4-channel 16-bit ADC over I2C. Rescues ESP32 designs from the
-  ADC2/WiFi conflict and gives ESP8266 a wider dynamic range than its
-  10-bit ADC. The ADDR pin selects between four bus addresses; pull it
-  to GND/VDD/SDA/SCL for 0x48/0x49/0x4A/0x4B respectively.
-  Single-ended (Ax_GND) and differential (Ax_Ay) modes are both
-  supported via the per-channel `multiplexer` setting. Default gain
-  6.144 covers 0-VDD (set ADC_FSR ≥ Vmax to avoid clipping).
+  Hub-only component. Each logical analog reading is a separate
+  `ads1115_channel` instance pointing at this hub via a HUB connection
+  -- that lets each channel have its own gain, update_interval, and
+  inspector row instead of being buried inside a `channels` array
+  param. ADDR pin selects between four bus addresses; pull it to
+  GND/VDD/SDA/SCL for 0x48/0x49/0x4A/0x4B respectively. 4-channel
+  16-bit ADC over I2C; rescues ESP32 designs from the ADC2/WiFi
+  conflict and gives ESP8266 a wider dynamic range than its 10-bit ADC.

--- a/library/components/ads1115.yaml
+++ b/library/components/ads1115.yaml
@@ -1,0 +1,71 @@
+id: ads1115
+name: ADS1115 4-channel 16-bit ADC (I2C)
+category: sensor
+use_cases: [adc, analog_in, voltage, current_sense]
+aliases: ["ads1015", "ti adc", "external adc"]
+
+electrical:
+  vcc_min: 2.0
+  vcc_max: 5.5
+  current_ma_typical: 1
+  current_ma_peak: 2
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - role: SDA
+      kind: i2c_sda
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - role: SCL
+      kind: i2c_scl
+      pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    ads1115:
+      - id: {{ id }}_hub
+        address: "{{ params.address | default('0x48') }}"
+        i2c_id: {{ bus.id }}
+    {%- if params.continuous_mode is defined %}
+        continuous_mode: {{ params.continuous_mode | tojson }}
+    {%- endif %}
+    {% if params.channels is defined %}
+    sensor:
+    {%- for ch in params.channels %}
+      - platform: ads1115
+        ads1115_id: {{ id }}_hub
+        multiplexer: {{ ch.multiplexer }}
+        gain: {{ ch.gain | default('6.144') }}
+        name: "{{ ch.name }}"
+        update_interval: {{ ch.update_interval | default('60s') }}
+    {%- endfor %}
+    {%- endif %}
+
+params_schema:
+  address:
+    type: string
+    enum: ["0x48", "0x49", "0x4A", "0x4B"]
+    default: "0x48"
+    description: "ADDR pin: GND=0x48, VDD=0x49, SDA=0x4A, SCL=0x4B"
+  continuous_mode:
+    type: boolean
+    description: "Continuous conversion vs single-shot. Continuous wakes the chip on every sample."
+  channels:
+    type: array
+    description: |
+      One sensor entry per ADC reading. Each item:
+        - multiplexer: A0_GND|A1_GND|A2_GND|A3_GND|A0_A1|A0_A3|A1_A3|A2_A3
+        - name: <ESPHome sensor name>
+        - gain: 6.144|4.096|2.048|1.024|0.512|0.256 (default 6.144)
+        - update_interval: optional (default 60s)
+
+notes: |
+  4-channel 16-bit ADC over I2C. Rescues ESP32 designs from the
+  ADC2/WiFi conflict and gives ESP8266 a wider dynamic range than its
+  10-bit ADC. The ADDR pin selects between four bus addresses; pull it
+  to GND/VDD/SDA/SCL for 0x48/0x49/0x4A/0x4B respectively.
+  Single-ended (Ax_GND) and differential (Ax_Ay) modes are both
+  supported via the per-channel `multiplexer` setting. Default gain
+  6.144 covers 0-VDD (set ADC_FSR ≥ Vmax to avoid clipping).

--- a/library/components/ads1115_channel.yaml
+++ b/library/components/ads1115_channel.yaml
@@ -1,0 +1,60 @@
+id: ads1115_channel
+name: ADS1115 channel
+category: sensor
+use_cases: [adc, analog_in, voltage, current_sense]
+aliases: ["ads1115_sensor", "adc channel"]
+
+electrical:
+  current_ma_typical: 0
+  current_ma_peak: 0
+  pins:
+    # Logical "connection" to the hub. No physical wire; the connection
+    # target rewrites to {kind: component, component_id: <hub>} which
+    # the generator surfaces as `parent.id` in the template context.
+    - role: HUB
+      kind: hub_ref
+      parent_library_id: ads1115
+  passives: []
+
+esphome:
+  required_components: []
+  yaml_template: |
+    sensor:
+      - platform: ads1115
+        ads1115_id: {{ parent.id }}_hub
+        multiplexer: {{ params.multiplexer | default('A0_GND') }}
+        gain: {{ params.gain | default('6.144') }}
+        name: "{{ label }}"
+        update_interval: {{ params.update_interval | default('60s') }}
+
+params_schema:
+  multiplexer:
+    type: string
+    enum:
+      - A0_GND
+      - A1_GND
+      - A2_GND
+      - A3_GND
+      - A0_A1
+      - A0_A3
+      - A1_A3
+      - A2_A3
+    default: A0_GND
+    description: "Single-ended (Ax_GND) or differential (Ax_Ay) channel select"
+  gain:
+    type: string
+    enum: ["6.144", "4.096", "2.048", "1.024", "0.512", "0.256"]
+    default: "6.144"
+    description: "Full-scale range in volts. Lower = higher resolution but less headroom."
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  One logical reading from an ADS1115 hub. Add an `ads1115` first, then
+  add as many `ads1115_channel` instances as you need readings; each
+  one's HUB connection auto-binds to the (single) hub in the design.
+  Single-ended modes use Ax_GND (Ax referenced to ground); differential
+  modes Ax_Ay use the two pins as a differential pair. Gain is the
+  full-scale range in volts -- pick the lowest one ≥ your expected
+  signal range to maximise resolution.

--- a/library/components/bmp180.yaml
+++ b/library/components/bmp180.yaml
@@ -1,0 +1,46 @@
+id: bmp180
+name: BMP180 / BMP085 barometric pressure + temperature (I2C)
+category: sensor
+use_cases: [temperature, pressure, weather, altitude]
+aliases: ["bmp085", "barometric"]
+
+electrical:
+  vcc_min: 1.8
+  vcc_max: 3.6
+  current_ma_typical: 0.005
+  current_ma_peak: 1
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - role: SDA
+      kind: i2c_sda
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - role: SCL
+      kind: i2c_scl
+      pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: bmp085
+        i2c_id: {{ bus.id }}
+        update_interval: {{ params.update_interval | default('60s') }}
+        temperature:
+          name: "{{ label }} Temperature"
+        pressure:
+          name: "{{ label }} Pressure"
+
+params_schema:
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  Older sibling of the BME280 -- temperature + pressure but no humidity,
+  fixed address 0x77, 3.3V only. The bmp085 ESPHome platform covers both
+  BMP085 and BMP180 (hardware-compatible). Worth keeping for legacy
+  modules people already have on hand; pick the BMP280 / BME280 for new
+  builds.

--- a/library/components/ds18b20.yaml
+++ b/library/components/ds18b20.yaml
@@ -1,0 +1,59 @@
+id: ds18b20
+name: DS18B20 1-wire temperature sensor
+category: sensor
+use_cases: [temperature]
+aliases: ["dallas", "1-wire temp", "onewire", "ds1820"]
+
+electrical:
+  vcc_min: 3.0
+  vcc_max: 5.5
+  current_ma_typical: 1
+  current_ma_peak: 2
+  pins:
+    - {role: VCC,  kind: power}
+    - {role: GND,  kind: ground}
+    - {role: DATA, kind: digital_in, voltage: 3.3}
+  passives:
+    - {kind: resistor, value: "4.7k", between: ["DATA", "VCC"], purpose: "1-wire bus pull-up"}
+
+esphome:
+  required_components: []
+  yaml_template: |
+    one_wire:
+      - platform: gpio
+        pin: {{ pins.DATA | tojson }}
+        id: {{ id }}_bus
+
+    sensor:
+      - platform: dallas_temp
+        one_wire_id: {{ id }}_bus
+        name: "{{ label }}"
+    {%- if params.address is defined %}
+        address: {{ params.address }}
+    {%- endif %}
+        update_interval: {{ params.update_interval | default('60s') }}
+    {%- if params.resolution is defined %}
+        resolution: {{ params.resolution }}
+    {%- endif %}
+
+params_schema:
+  address:
+    type: string
+    description: "ROM address (e.g., 0x1c0000031edd2a28). Omit for single-sensor buses."
+  update_interval:
+    type: string
+    default: "60s"
+  resolution:
+    type: integer
+    enum: [9, 10, 11, 12]
+    description: "Bits of resolution (9 = 0.5°C / fast, 12 = 0.0625°C / slow)"
+
+notes: |
+  1-wire bus: needs a single 4.7kΩ pull-up between DATA and VCC. Each
+  instance creates its own one_wire bus block so the YAML renders cleanly
+  even with multiple DS18B20s on different pins. To share a single
+  physical bus among multiple sensors, give them the same DATA pin AND
+  set distinct `address` params (left blank, ESPHome auto-discovers but
+  emits a warning when more than one device is on the bus). Output is
+  3.3V-compatible. Parasite power is supported by ESPHome but not
+  modeled here -- wire VCC.

--- a/library/components/ds18b20.yaml
+++ b/library/components/ds18b20.yaml
@@ -12,24 +12,19 @@ electrical:
   pins:
     - {role: VCC,  kind: power}
     - {role: GND,  kind: ground}
-    - {role: DATA, kind: digital_in, voltage: 3.3}
+    - {role: DATA, kind: onewire_data, voltage: 3.3}
   passives:
     - {kind: resistor, value: "4.7k", between: ["DATA", "VCC"], purpose: "1-wire bus pull-up"}
 
 esphome:
-  required_components: []
+  required_components: ["1wire"]
   yaml_template: |
-    one_wire:
-      - platform: gpio
-        pin: {{ pins.DATA | tojson }}
-        id: {{ id }}_bus
-
     sensor:
       - platform: dallas_temp
-        one_wire_id: {{ id }}_bus
+        one_wire_id: {{ bus.id }}
         name: "{{ label }}"
     {%- if params.address is defined %}
-        address: {{ params.address }}
+        address: "{{ params.address }}"
     {%- endif %}
         update_interval: {{ params.update_interval | default('60s') }}
     {%- if params.resolution is defined %}
@@ -39,7 +34,7 @@ esphome:
 params_schema:
   address:
     type: string
-    description: "ROM address (e.g., 0x1c0000031edd2a28). Omit for single-sensor buses."
+    description: "ROM address (e.g., 0x1c0000031edd2a28). Required when more than one DS18B20 shares a bus."
   update_interval:
     type: string
     default: "60s"
@@ -49,11 +44,11 @@ params_schema:
     description: "Bits of resolution (9 = 0.5°C / fast, 12 = 0.0625°C / slow)"
 
 notes: |
-  1-wire bus: needs a single 4.7kΩ pull-up between DATA and VCC. Each
-  instance creates its own one_wire bus block so the YAML renders cleanly
-  even with multiple DS18B20s on different pins. To share a single
-  physical bus among multiple sensors, give them the same DATA pin AND
-  set distinct `address` params (left blank, ESPHome auto-discovers but
-  emits a warning when more than one device is on the bus). Output is
-  3.3V-compatible. Parasite power is supported by ESPHome but not
+  Connects via a 1-wire bus -- the bus carries the DATA pin and any
+  number of DS18B20 (and other 1-wire devices) can share it. Needs a
+  4.7kΩ pull-up between the bus pin and VCC. When two or more sensors
+  share a wire, give each instance a distinct `address` param (the
+  factory-burned ROM); ESPHome auto-discovers but emits a warning
+  about ambiguous read order when the addresses are missing. Output
+  is 3.3V-compatible. Parasite power is supported by ESPHome but not
   modeled here -- wire VCC.

--- a/library/components/htu21d.yaml
+++ b/library/components/htu21d.yaml
@@ -1,0 +1,45 @@
+id: htu21d
+name: HTU21D temperature + humidity (I2C)
+category: sensor
+use_cases: [temperature, humidity, weather]
+aliases: ["si7021", "htu20d", "shtxx"]
+
+electrical:
+  vcc_min: 1.5
+  vcc_max: 3.6
+  current_ma_typical: 0.5
+  current_ma_peak: 1
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - role: SDA
+      kind: i2c_sda
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - role: SCL
+      kind: i2c_scl
+      pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: htu21d
+        i2c_id: {{ bus.id }}
+        update_interval: {{ params.update_interval | default('60s') }}
+        temperature:
+          name: "{{ label }} Temperature"
+        humidity:
+          name: "{{ label }} Humidity"
+
+params_schema:
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  Drop-in T/H replacement for the BME280 when humidity matters but
+  pressure doesn't -- cheaper, lower current draw, fixed 0x40 address.
+  3.3V only. The Si7021 / SHT2x families speak the same protocol so
+  this template covers them too.

--- a/library/components/hx711.yaml
+++ b/library/components/hx711.yaml
@@ -1,0 +1,52 @@
+id: hx711
+name: HX711 24-bit load-cell ADC
+category: sensor
+use_cases: [weight, load_cell, force, scale, strain]
+aliases: ["scale adc", "load cell amp"]
+
+electrical:
+  vcc_min: 2.6
+  vcc_max: 5.5
+  current_ma_typical: 1.5
+  current_ma_peak: 1.7
+  pins:
+    - {role: VCC,  kind: power}
+    - {role: GND,  kind: ground}
+    - {role: DOUT, kind: digital_in,  voltage: 3.3}
+    - {role: SCK,  kind: digital_out, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+    - {kind: capacitor, value: "10uF",  between: [VCC, GND], purpose: "bulk decoupling for the analog front-end"}
+
+esphome:
+  required_components: []
+  yaml_template: |
+    sensor:
+      - platform: hx711
+        name: "{{ label }}"
+        dout_pin: {{ pins.DOUT | tojson }}
+        clk_pin: {{ pins.SCK | tojson }}
+        gain: {{ params.gain | default(128) }}
+        update_interval: {{ params.update_interval | default('60s') }}
+    {%- if params.filters is defined %}
+        filters: {{ params.filters | tojson }}
+    {%- endif %}
+
+params_schema:
+  gain:
+    type: integer
+    enum: [32, 64, 128]
+    default: 128
+    description: "PGA gain. 128 = channel A high-sensitivity, 64 = channel A low, 32 = channel B"
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  Custom 2-wire serial protocol -- not I2C, not SPI. The MCU clocks
+  data out one bit at a time on SCK and reads DOUT. Raw counts come
+  out the back; calibrate with `filters: [calibrate_linear: ...]` or
+  let the user dial in the slope/offset post-build. PGA gain selects
+  channel A (128 or 64x) or channel B (32x); most load cells live on
+  channel A. 3.3V or 5V supply -- DOUT swings to whatever VCC is, so
+  keep a 5V HX711 off a 3.3V GPIO without a level shifter.

--- a/library/components/max31855.yaml
+++ b/library/components/max31855.yaml
@@ -1,0 +1,51 @@
+id: max31855
+name: MAX31855 thermocouple amplifier (SPI, K-type)
+category: sensor
+use_cases: [temperature, thermocouple, high_temperature, hot]
+aliases: ["k-type", "max6675", "kiln"]
+
+electrical:
+  vcc_min: 3.0
+  vcc_max: 3.6
+  current_ma_typical: 1.5
+  current_ma_peak: 2
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - {role: CLK, kind: spi_clk}
+    - {role: MISO, kind: spi_miso}
+    - {role: CS,   kind: spi_cs}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+    - {kind: capacitor, value: "10nF",  between: [T+, T-],   purpose: "thermocouple noise filter (optional)"}
+
+esphome:
+  required_components: [spi]
+  yaml_template: |
+    sensor:
+      - platform: max31855
+        spi_id: {{ bus.id }}
+        cs_pin: {{ pins.CS | tojson }}
+        name: "{{ label }} Thermocouple"
+        update_interval: {{ params.update_interval | default('60s') }}
+    {%- if params.reference_temperature is defined %}
+        reference_temperature:
+          name: "{{ label }} Cold Junction"
+    {%- endif %}
+
+params_schema:
+  update_interval:
+    type: string
+    default: "60s"
+  reference_temperature:
+    type: boolean
+    description: "Also publish the cold-junction (board) temperature reading"
+
+notes: |
+  K-type thermocouple amp on SPI. Read-only -- no MOSI line, just CLK,
+  CS, and MISO. Range -270 to +1372°C with 0.25°C resolution; great
+  for kilns, smokers, espresso boilers. The cold-junction temperature
+  (the chip's own die, used for compensation) can also be published
+  via `reference_temperature: true`. 3.3V only -- a 5V MCU needs a
+  level shifter on the SPI lines. Keep the thermocouple wires twisted
+  and the optional 10nF noise cap close to the screw terminals.

--- a/library/components/mpu6050.yaml
+++ b/library/components/mpu6050.yaml
@@ -1,0 +1,65 @@
+id: mpu6050
+name: MPU6050 6-axis IMU (accel + gyro, I2C)
+category: sensor
+use_cases: [imu, accelerometer, gyroscope, motion, orientation, vibration]
+aliases: ["mpu-6050", "gy-521", "invensense imu"]
+
+electrical:
+  vcc_min: 2.375
+  vcc_max: 3.46
+  current_ma_typical: 4
+  current_ma_peak: 6
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - role: SDA
+      kind: i2c_sda
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - role: SCL
+      kind: i2c_scl
+      pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: mpu6050
+        address: "{{ params.address | default('0x68') }}"
+        i2c_id: {{ bus.id }}
+        update_interval: {{ params.update_interval | default('60s') }}
+        accel_x:
+          name: "{{ label }} Accel X"
+        accel_y:
+          name: "{{ label }} Accel Y"
+        accel_z:
+          name: "{{ label }} Accel Z"
+        gyro_x:
+          name: "{{ label }} Gyro X"
+        gyro_y:
+          name: "{{ label }} Gyro Y"
+        gyro_z:
+          name: "{{ label }} Gyro Z"
+        temperature:
+          name: "{{ label }} Die Temp"
+
+params_schema:
+  address:
+    type: string
+    enum: ["0x68", "0x69"]
+    default: "0x68"
+    description: "AD0 pin: GND=0x68, VCC=0x69"
+  update_interval:
+    type: string
+    default: "60s"
+    description: "How often to publish a fresh reading. The chip itself samples at its configured ODR regardless."
+
+notes: |
+  6-axis IMU (3-axis accelerometer + 3-axis gyroscope) plus an on-die
+  temperature sensor. 3.3V part -- common breakout boards (GY-521) ship
+  with an onboard regulator and accept 5V on the VCC pin, but the bare
+  chip needs 3.3V. AD0 selects 0x68 (default, AD0 to GND) or 0x69
+  (AD0 to VCC). The INT pin is supported by ESPHome but not modeled
+  here -- wire it to a free GPIO and attach a binary_sensor in
+  esphome_extras if you need motion-wake.

--- a/library/components/rcwl-0516.yaml
+++ b/library/components/rcwl-0516.yaml
@@ -1,0 +1,44 @@
+id: rcwl-0516
+name: RCWL-0516 microwave motion sensor
+category: binary_sensor
+use_cases: [motion, occupancy, presence]
+aliases: ["microwave radar", "doppler motion", "rcwl"]
+
+electrical:
+  vcc_min: 4.0
+  vcc_max: 28.0
+  current_ma_typical: 3
+  current_ma_peak: 4
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - {role: OUT, kind: digital_out, voltage: 3.3}
+  passives: []
+
+esphome:
+  required_components: []
+  yaml_template: |
+    binary_sensor:
+      - platform: gpio
+        pin: {{ pins.OUT | tojson }}
+        name: "{{ label }}"
+        device_class: motion
+    {%- if params.filters is defined %}
+        filters: {{ params.filters | tojson }}
+    {%- endif %}
+    {%- if params.on_press is defined %}
+        on_press: {{ params.on_press | tojson }}
+    {%- endif %}
+    {%- if params.on_release is defined %}
+        on_release: {{ params.on_release | tojson }}
+    {%- endif %}
+
+params_schema: {}
+
+notes: |
+  Microwave doppler alternative to a PIR. Detects through thin walls and
+  glass, has a wider sensing arc, and draws ~3 mA against the HC-SR501's
+  ~50 mA so it suits battery-backed builds. The OUT line is 3.3V CMOS,
+  safe for any ESP GPIO. Sensitivity and on-time are set by SMD resistors
+  (R-CDS, R-GN) rather than ESPHome params. Treat the 5V VIN as a hard
+  minimum -- 3.3V supply works in practice but spec'd at 4V+.

--- a/library/components/tsl2561.yaml
+++ b/library/components/tsl2561.yaml
@@ -1,0 +1,60 @@
+id: tsl2561
+name: TSL2561 ambient light sensor (lux, I2C)
+category: sensor
+use_cases: [light, illuminance, lux, ambient_light, brightness]
+aliases: ["tsl2591", "lux meter"]
+
+electrical:
+  vcc_min: 2.7
+  vcc_max: 3.6
+  current_ma_typical: 0.24
+  current_ma_peak: 0.6
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - role: SDA
+      kind: i2c_sda
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - role: SCL
+      kind: i2c_scl
+      pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: tsl2561
+        i2c_id: {{ bus.id }}
+        address: "{{ params.address | default('0x39') }}"
+        name: "{{ label }} Illuminance"
+        update_interval: {{ params.update_interval | default('60s') }}
+    {%- if params.gain is defined %}
+        gain: {{ params.gain }}
+    {%- endif %}
+    {%- if params.integration_time is defined %}
+        integration_time: {{ params.integration_time }}
+    {%- endif %}
+
+params_schema:
+  address:
+    type: string
+    enum: ["0x29", "0x39", "0x49"]
+    default: "0x39"
+    description: "ADDR pin: GND=0x29, FLOAT=0x39 (default), VDD=0x49"
+  gain:
+    type: string
+    enum: ["1x", "16x"]
+    description: "Photodiode gain. 16x for low-light scenes; 1x for sunlight."
+  integration_time:
+    type: string
+    enum: ["13ms", "101ms", "402ms"]
+    description: "Longer integration = lower noise + slower readings."
+
+notes: |
+  Two-channel ambient light sensor with built-in IR rejection. Reports
+  illuminance in lux directly (the chip handles the spectrum math).
+  Three I2C addresses are selectable via the ADDR pin; default 0x39
+  works for the bare chip floating ADDR. 3.3V only -- 5V MCUs need a
+  level shifter on SDA/SCL.

--- a/schema/design.schema.json
+++ b/schema/design.schema.json
@@ -143,6 +143,15 @@
                   "mode": { "type": "string", "enum": ["INPUT", "INPUT_PULLUP", "INPUT_PULLDOWN", "OUTPUT", "OUTPUT_OPEN_DRAIN"] },
                   "inverted": { "type": "boolean" }
                 }
+              },
+              {
+                "type": "object",
+                "required": ["kind", "component_id"],
+                "additionalProperties": false,
+                "properties": {
+                  "kind": { "const": "component" },
+                  "component_id": { "type": "string" }
+                }
               }
             ]
           }

--- a/schema/design.schema.json
+++ b/schema/design.schema.json
@@ -88,7 +88,8 @@
           "rx": { "type": "string" },
           "tx": { "type": "string" },
           "lrclk": { "type": "string" },
-          "bclk": { "type": "string" }
+          "bclk": { "type": "string" },
+          "pin": { "type": "string" }
         }
       }
     },

--- a/studio/api/app.py
+++ b/studio/api/app.py
@@ -410,6 +410,28 @@ def create_app(
         except (FileNotFoundError, ValueError) as e:
             raise HTTPException(status_code=422, detail=str(e)) from e
 
+        # Strict-only push: refuse to ship when any warn/error compatibility
+        # entry remains. Mirrors the /design/render?strict=true gate so a
+        # client can use the same envelope to surface the same warnings.
+        if req.strict:
+            blocking = [
+                w for w in check_pin_compatibility(req.design, lib)
+                if w.severity in ("warn", "error")
+            ]
+            if blocking:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "error": "strict_mode_blocked",
+                        "message": (
+                            f"strict mode refused the push: "
+                            f"{len(blocking)} compatibility issue"
+                            f"{'s' if len(blocking) != 1 else ''} need attention"
+                        ),
+                        "warnings": [w.model_dump() for w in _wire_compat(blocking)],
+                    },
+                )
+
         # Filename precedence: explicit override > fleet.device_name > design.id.
         device_name = (
             req.device_name

--- a/studio/api/app.py
+++ b/studio/api/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -473,6 +474,64 @@ def create_app(
             raise HTTPException(status_code=502, detail=str(e)) from e
         return FleetJobLogResponse(
             log=chunk.log, offset=chunk.offset, finished=chunk.finished,
+        )
+
+    @app.get("/fleet/jobs/{run_id}/log/stream", tags=["fleet"])
+    def fleet_job_log_stream(run_id: str, offset: int = 0, interval_ms: int = 300):
+        """Server-Sent Events relay over the addon's HTTP log endpoint.
+
+        Polls `fc.get_job_log(run_id)` server-side at ~300ms (vs the 1.5s
+        the browser-driven loop uses) and streams each chunk to the client
+        as an SSE event of shape `data: {"log": "...", "offset": N,
+        "finished": bool}`. The stream emits a final `event: done` frame
+        when the addon reports finished and exits. Errors yield an
+        `event: error` frame and exit.
+
+        EventSource connections die on browser tab close; the polling
+        loop sees the resulting transport error and exits cleanly. The
+        addon's polling endpoint is idempotent so a reconnect with a
+        fresh offset just resumes.
+        """
+        fc = make_fleet()
+        if not fc.is_configured():
+            raise HTTPException(
+                status_code=503,
+                detail="fleet not configured (set FLEET_URL and FLEET_TOKEN)",
+            )
+        # Cap the lower bound so a malicious / mistaken caller can't tar-pit
+        # the studio + addon by polling at 1ms.
+        sleep_seconds = max(0.1, interval_ms / 1000.0)
+
+        def _events():
+            current = offset
+            while True:
+                try:
+                    chunk = fc.get_job_log(run_id, offset=current)
+                except FleetUnavailable as e:
+                    yield (
+                        "event: error\n"
+                        f"data: {json.dumps({'message': str(e)})}\n\n"
+                    )
+                    return
+                payload = {
+                    "log": chunk.log,
+                    "offset": chunk.offset,
+                    "finished": chunk.finished,
+                }
+                yield f"data: {json.dumps(payload)}\n\n"
+                current = chunk.offset
+                if chunk.finished:
+                    yield "event: done\ndata: {}\n\n"
+                    return
+                time.sleep(sleep_seconds)
+
+        return StreamingResponse(
+            _events(),
+            media_type="text/event-stream",
+            # Disable any intermediate buffering so the chunks land
+            # incrementally rather than getting batched at the proxy
+            # layer (Vite + nginx both honour this).
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
 
     @app.get("/agent/status", tags=["agent"])

--- a/studio/api/app.py
+++ b/studio/api/app.py
@@ -233,7 +233,16 @@ def create_app(
         )
 
     @app.post("/design/render", response_model=RenderResponse, tags=["design"])
-    def render(design: dict) -> RenderResponse:
+    def render(design: dict, strict: bool = False) -> RenderResponse:
+        """Render a design to YAML + ASCII.
+
+        Permissive by default: compatibility warnings travel back in the
+        `compatibility_warnings` field for the UI to surface non-blocking
+        guidance. With `?strict=true`, any compatibility entry of severity
+        `warn` or `error` instead 422s -- the same gate the
+        distributed-esphome push path can use to refuse to ship a design
+        with unresolved hardware risks.
+        """
         try:
             d = Design.model_validate(design)
         except ValidationError as e:
@@ -248,10 +257,29 @@ def create_app(
             # Surfaced from the generator for incomplete-but-validating designs:
             # missing bus matching a `kind: bus` connection, etc.
             raise HTTPException(status_code=422, detail=str(e)) from e
+        compat = check_pin_compatibility(design, lib)
+        if strict:
+            blocking = [w for w in compat if w.severity in ("warn", "error")]
+            if blocking:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "error": "strict_mode_blocked",
+                        "message": (
+                            f"strict mode rejected the render: "
+                            f"{len(blocking)} compatibility issue"
+                            f"{'s' if len(blocking) != 1 else ''} need attention"
+                        ),
+                        # HTTPException JSON-encodes its detail with the
+                        # standard json module, which doesn't know about
+                        # Pydantic models -- pre-dump.
+                        "warnings": [w.model_dump() for w in _wire_compat(blocking)],
+                    },
+                )
         return RenderResponse(
             yaml=yaml_text,
             ascii=ascii_text,
-            compatibility_warnings=_wire_compat(check_pin_compatibility(design, lib)),
+            compatibility_warnings=_wire_compat(compat),
         )
 
     @app.get("/examples", response_model=list[ExampleSummary], tags=["examples"])

--- a/studio/api/schemas.py
+++ b/studio/api/schemas.py
@@ -186,6 +186,7 @@ class FleetPushRequest(_S):
     design: dict
     compile: bool = False
     device_name: Optional[str] = None  # override; defaults to fleet.device_name or design.id
+    strict: bool = False  # refuse when warn/error compat entries remain
 
 
 class FleetPushResponse(_S):

--- a/studio/csp/compatibility.py
+++ b/studio/csp/compatibility.py
@@ -13,6 +13,9 @@ restrictions that conflict with the use:
 - `adc2_wifi_conflict`  -- analog_in landed on an `adc2`-tagged pin on a
                             classic ESP32 board; the WiFi driver claims ADC2
                             so reads return errors / stale values
+- `locked_pin_invalid`  -- a component's `locked_pins[role]` points at a
+                            board pin whose capabilities don't satisfy the
+                            library role's required kind
 
 Pure: doesn't mutate the design, doesn't render, doesn't hit the network.
 Cheap enough to run on every render call.
@@ -231,6 +234,66 @@ def check_pin_compatibility(design: dict, library: Library) -> list[Compatibilit
     # capability (no_i2c) and serial-console pins.
     out.extend(_bus_pin_warnings(design, board))
 
+    # 7. locked_pins capability validation. A user-locked pin should
+    # actually be able to play the role's library kind (analog_in lock
+    # on a non-ADC pin is a mistake worth surfacing).
+    out.extend(_locked_pin_warnings(components_by_id, lib_components, board))
+
+    return out
+
+
+# Mirror of pin_solver's required-cap map. Kept local to avoid an import
+# cycle and because the two modules are deliberately independent.
+_LOCKED_PIN_REQUIRED_CAPS: dict[str, set[str]] = {
+    "analog_in": {"adc"},
+    # digital_in / digital_out / spi_cs all just need `gpio`; the lock is
+    # validated against the same set the solver uses.
+    "digital_in":  {"gpio"},
+    "digital_out": {"gpio"},
+    "spi_cs":      {"gpio"},
+    "i2s_dout":    {"gpio"},
+}
+
+
+def _locked_pin_warnings(
+    components_by_id: dict[str, dict],
+    lib_components: dict[str, LibraryComponent],
+    board,
+) -> list[CompatibilityWarning]:
+    out: list[CompatibilityWarning] = []
+    for cid, comp in components_by_id.items():
+        locked = comp.get("locked_pins") or {}
+        if not isinstance(locked, dict) or not locked:
+            continue
+        lib_comp = lib_components.get(cid)
+        if lib_comp is None:
+            continue
+        for role, pin_name in locked.items():
+            lib_pin = next(
+                (p for p in lib_comp.electrical.pins if p.role == role), None,
+            )
+            if lib_pin is None:
+                # The solver already flags unknown roles; skip here.
+                continue
+            caps = set(board.gpio_capabilities.get(str(pin_name), []))
+            if not caps:
+                # Unknown pin name: solver/schema territory, not capability.
+                continue
+            required = _LOCKED_PIN_REQUIRED_CAPS.get(lib_pin.kind, set())
+            if required and not required.issubset(caps):
+                missing = ", ".join(sorted(required - caps))
+                out.append(CompatibilityWarning(
+                    severity="error",
+                    code="locked_pin_invalid",
+                    pin=str(pin_name),
+                    component_id=cid,
+                    pin_role=role,
+                    message=(
+                        f"{cid}.{role} is locked to {pin_name}, but that pin "
+                        f"lacks {missing} which {lib_pin.kind} requires. "
+                        f"Pick a different pin or remove the lock."
+                    ),
+                ))
     return out
 
 

--- a/studio/csp/compatibility.py
+++ b/studio/csp/compatibility.py
@@ -305,10 +305,17 @@ def _bus_pin_warnings(design: dict, board) -> list[CompatibilityWarning]:
     # role -> ("out" | "in") direction for each bus type. The MCU drives the
     # output side; serial console and no_i2c apply to any pin assigned.
     bus_roles: dict[str, dict[str, str]] = {
-        "i2c":  {"sda": "io",  "scl": "out"},
-        "spi":  {"clk": "out", "mosi": "out", "miso": "in", "cs": "out"},
-        "uart": {"tx": "out",  "rx": "in"},
-        "i2s":  {"lrclk": "out", "bclk": "out"},
+        "i2c":   {"sda": "io",  "scl": "out"},
+        "spi":   {"clk": "out", "mosi": "out", "miso": "in", "cs": "out"},
+        "uart":  {"tx": "out",  "rx": "in"},
+        "i2s":   {"lrclk": "out", "bclk": "out"},
+        # 1-wire is bidirectional on a single line; the master holds the
+        # pull-up high and either side drops it. We tag direction "io"
+        # because the boot-strap warnings on the master side still apply
+        # (the host configures the pin) but input-only pins are usable
+        # in slave-only configurations -- we leave that nuance for a
+        # later pass and treat the pin like the i2c sda case.
+        "1wire": {"pin": "io"},
     }
 
     for bus in design.get("buses") or []:

--- a/studio/csp/pin_solver.py
+++ b/studio/csp/pin_solver.py
@@ -202,6 +202,16 @@ def solve_pins(design_in: dict, library: Library) -> SolveResult:
     assigned: list[PinAssignment] = []
     unresolved: list[SolverWarning] = []
 
+    # Apply locked_pins first. The user's manual pin choices override the
+    # solver's preferences; we either fill an empty target with the locked
+    # pin or flag a divergence between the bound target and the lock. Locks
+    # only apply to gpio targets today (the dict value is a board pin name);
+    # bus/expander locks are not yet defined.
+    lock_warnings = _apply_locked_pins(
+        design, components_by_id, library_components, used_gpios, assigned,
+    )
+    unresolved.extend(lock_warnings)
+
     for conn in design.get("connections", []):
         target = conn.get("target") or {}
         if not _is_unbound(target):
@@ -303,6 +313,101 @@ def _solve_gpio(board: LibraryBoard, lib_pin: Pin, used: set[str]) -> Optional[s
         if candidate not in used:
             return candidate
     return None
+
+
+def _apply_locked_pins(
+    design: dict,
+    components_by_id: dict[str, dict],
+    library_components: dict[str, "LibraryComponent"],
+    used_gpios: set[str],
+    assigned: list[PinAssignment],
+) -> list[SolverWarning]:
+    """Walk every connection and reconcile it against its component's
+    `locked_pins` map (role -> board pin). Mutates ``design`` (in place
+    via the connection dict) and ``used_gpios``/``assigned``. Returns
+    any warnings produced."""
+    warnings: list[SolverWarning] = []
+
+    # First pass: surface lock entries that don't correspond to any role
+    # the library component declares. The connection loop below would skip
+    # these silently because nothing matches `conn.pin_role == role`.
+    for cid, comp in components_by_id.items():
+        locked = comp.get("locked_pins") or {}
+        if not isinstance(locked, dict):
+            continue
+        lib_comp = library_components.get(cid)
+        if lib_comp is None:
+            continue
+        valid_roles = {p.role for p in lib_comp.electrical.pins}
+        for role, locked_pin in locked.items():
+            if role not in valid_roles:
+                warnings.append(SolverWarning(
+                    level="warn", code="locked_pin_unknown_role",
+                    text=(
+                        f"{cid}.{role} is locked to '{locked_pin}' but the "
+                        f"role does not exist on library component "
+                        f"'{comp.get('library_id')}'."
+                    ),
+                ))
+
+    for conn in design.get("connections", []):
+        comp = components_by_id.get(conn.get("component_id"))
+        if not comp:
+            continue
+        locked = comp.get("locked_pins") or {}
+        if not isinstance(locked, dict) or not locked:
+            continue
+        role = conn.get("pin_role")
+        if role not in locked:
+            continue
+        locked_pin = str(locked[role])
+
+        # The lock is meaningless when the connection isn't a gpio target.
+        # We surface this so authors don't expect the solver to honour it.
+        target = conn.get("target") or {}
+        if target.get("kind") != "gpio":
+            warnings.append(SolverWarning(
+                level="warn", code="locked_pin_wrong_kind",
+                text=(
+                    f"{comp['id']}.{role} has locked_pins='{locked_pin}' but its "
+                    f"connection target is kind='{target.get('kind')}', not gpio. "
+                    f"The lock is being ignored."
+                ),
+            ))
+            continue
+
+        # The unknown-role check ran in the first pass above. compatibility.py
+        # handles the deeper capability check (locked pin lacks required caps).
+        existing = target.get("pin") or ""
+        if existing == locked_pin:
+            # Already aligned with the lock; ensure it's reserved so the
+            # downstream solver doesn't try to hand the same pin to a
+            # different unbound connection.
+            used_gpios.add(locked_pin)
+            continue
+
+        if existing and existing != locked_pin:
+            warnings.append(SolverWarning(
+                level="warn", code="locked_pin_mismatch",
+                text=(
+                    f"{comp['id']}.{role} is bound to '{existing}' but locked_pins "
+                    f"says '{locked_pin}'. Update the lock or the connection so "
+                    f"they agree."
+                ),
+            ))
+            # Don't auto-rewrite a bound pin -- the divergence might be
+            # intentional and the user needs to decide. Just reserve the
+            # locked pin to keep the rest of the solver out of conflict.
+            used_gpios.add(locked_pin)
+            continue
+
+        # Empty/unbound target -> apply the lock as the assignment.
+        old = dict(target)
+        new = {"kind": "gpio", "pin": locked_pin}
+        conn["target"] = new
+        used_gpios.add(locked_pin)
+        assigned.append(PinAssignment(comp["id"], role, old, new))
+    return warnings
 
 
 def _bus_type_for_pin(kind: str) -> Optional[str]:

--- a/studio/csp/pin_solver.py
+++ b/studio/csp/pin_solver.py
@@ -419,6 +419,8 @@ def _bus_type_for_pin(kind: str) -> Optional[str]:
         return "i2s"
     if kind in ("uart_rx", "uart_tx"):
         return "uart"
+    if kind == "onewire_data":
+        return "1wire"
     return None
 
 

--- a/studio/csp/pin_solver.py
+++ b/studio/csp/pin_solver.py
@@ -122,6 +122,8 @@ def _is_unbound(target: dict) -> bool:
         return not target.get("bus_id")
     if kind == "expander_pin":
         return not target.get("expander_id")
+    if kind == "component":
+        return not target.get("component_id")
     return False
 
 
@@ -302,6 +304,31 @@ def solve_pins(design_in: dict, library: Library) -> SolveResult:
             new = {**target, "expander_id": ex_id, "number": number}
             conn["target"] = new
             used_expander_pins.add(chosen)
+            assigned.append(PinAssignment(comp["id"], conn["pin_role"], old, new))
+
+        elif kind == "component":
+            # Pick the first component instance whose library_id matches
+            # the role's `parent_library_id` hint. The hint lives on the
+            # library Pin so a hub-relative role (ads1115_channel.HUB)
+            # binds to the correct hub kind, not a random other component.
+            wanted = getattr(lib_pin, "parent_library_id", None)
+            options = [
+                cid for cid, c in components_by_id.items()
+                if c.get("library_id") == wanted and cid != comp["id"]
+            ] if wanted else []
+            if not options:
+                unresolved.append(SolverWarning(
+                    level="warn", code="no_parent_component",
+                    text=(
+                        f"{comp['id']}.{conn['pin_role']} needs a "
+                        f"{wanted or 'parent'} component but the design has none"
+                    ),
+                ))
+                continue
+            choice = options[0]
+            old = dict(target)
+            new = {"kind": "component", "component_id": choice}
+            conn["target"] = new
             assigned.append(PinAssignment(comp["id"], conn["pin_role"], old, new))
 
     warnings = list(_static_warnings(design, board, library_components))

--- a/studio/generate/yaml_gen.py
+++ b/studio/generate/yaml_gen.py
@@ -45,6 +45,23 @@ def _bus_for(component_id: str, design: Design) -> Bus | None:
     return None
 
 
+def _parent_for(component_id: str, design: Design) -> dict[str, Any] | None:
+    """Return the component-instance dict referenced by a kind:component
+    connection on this component, or None if there is no such target.
+
+    Used by hub-relative templates (e.g., ads1115_channel pointing at
+    its ads1115 hub). The returned dict carries id + library_id +
+    label + params so templates can read `{{ parent.id }}_hub` or
+    `{{ parent.params.address }}` without re-walking the design.
+    """
+    for c in design.connections:
+        if c.component_id == component_id and c.target.kind == "component":
+            for inst in design.components:
+                if inst.id == c.target.component_id:
+                    return inst.model_dump()
+    return None
+
+
 def _pins_for(component_id: str, design: Design) -> dict[str, Any]:
     """Return a dict of pin_role -> pin spec.
 
@@ -92,12 +109,14 @@ def _render_component(comp: Component, design: Design, library: Library) -> dict
     if not template_str.strip():
         return {}
     bus = _bus_for(comp.id, design)
+    parent = _parent_for(comp.id, design)
     ctx = {
         "id": comp.id,
         "label": comp.label,
         "params": dict(comp.params),
         "pins": _pins_for(comp.id, design),
         "bus": bus.model_dump() if bus else None,
+        "parent": parent,
     }
     try:
         rendered = _jinja.from_string(template_str).render(**ctx)

--- a/studio/generate/yaml_gen.py
+++ b/studio/generate/yaml_gen.py
@@ -187,6 +187,17 @@ def build_yaml_dict(design: Design, library: Library) -> dict[str, Any]:
             if bus.baud_rate:
                 uart_entry["baud_rate"] = bus.baud_rate
             out.setdefault("uart", []).append(uart_entry)
+        elif bus.type == "1wire":
+            # Single-pin bus. ESPHome's `one_wire:` block lists each
+            # physical wire by id; multiple DS18B20s on the same wire
+            # share an id, so we emit the bus block here and the
+            # component templates only refer to it via one_wire_id.
+            wire_entry: dict[str, Any] = {
+                "platform": "gpio",
+                "pin": bus.pin,
+                "id": bus.id,
+            }
+            out.setdefault("one_wire", []).append(wire_entry)
 
     for comp in design.components:
         _deep_merge(out, _render_component(comp, design, library))

--- a/studio/library.py
+++ b/studio/library.py
@@ -22,6 +22,12 @@ class Pin(_Strict):
     kind: str
     voltage: Optional[float] = None
     pull_up: Optional[PullUp] = None
+    # When kind == "hub_ref", names the library_id of the parent component
+    # this pin must connect to (e.g., ads1115_channel.HUB has
+    # parent_library_id: ads1115). The pin solver uses this to filter
+    # candidates and the bus editor / inspector use it to render a
+    # parent-instance dropdown.
+    parent_library_id: Optional[str] = None
 
 
 class PassiveSpec(_Strict):

--- a/studio/model.py
+++ b/studio/model.py
@@ -81,8 +81,20 @@ class ExpanderPinTarget(_Strict):
     inverted: bool = False
 
 
+class ComponentTarget(_Strict):
+    """Connection target referencing another component instance.
+
+    Used when a component is logically a child of a hub it shares no
+    physical pins with -- e.g., an `ads1115_channel` references its
+    `ads1115` hub by component id, and the generated YAML pulls the
+    hub's id into the channel's sensor entry.
+    """
+    kind: Literal["component"]
+    component_id: str
+
+
 ConnectionTarget = Annotated[
-    Union[RailTarget, GpioTarget, BusTarget, ExpanderPinTarget],
+    Union[RailTarget, GpioTarget, BusTarget, ExpanderPinTarget, ComponentTarget],
     Field(discriminator="kind"),
 ]
 

--- a/studio/model.py
+++ b/studio/model.py
@@ -53,6 +53,9 @@ class Bus(_Strict):
     tx: Optional[str] = None
     lrclk: Optional[str] = None
     bclk: Optional[str] = None
+    # 1-wire data pin. Single-wire bus, so the bus carries one pin field
+    # rather than the multi-pin sets the synchronous buses use.
+    pin: Optional[str] = None
 
 
 class RailTarget(_Strict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,5 +94,10 @@ def ttgo_lora32_design() -> Design:
 
 
 @pytest.fixture
+def multi_temp_design() -> Design:
+    return Design.model_validate(json.loads((REPO_ROOT / "examples" / "multi-temp.json").read_text()))
+
+
+@pytest.fixture
 def golden_dir() -> Path:
     return Path(__file__).parent / "golden"

--- a/tests/golden/multi-temp.txt
+++ b/tests/golden/multi-temp.txt
@@ -1,0 +1,34 @@
++-----------------------------------------------------------------------------------------+
+|  WeMos D1 Mini  ---  multi-temp                                                         |
++-----------------------------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                                    |
+|                                                                                         |
+|  supply_temp  [DS18B20 1-wire temperature sensor]  -- Boiler supply                     |
+|    VCC   -> rail 3V3                                                                    |
+|    GND   -> rail GND                                                                    |
+|    DATA  -> wire0 (1wire)                                                               |
+|                                                                                         |
+|  return_temp  [DS18B20 1-wire temperature sensor]  -- Boiler return                     |
+|    VCC   -> rail 3V3                                                                    |
+|    GND   -> rail GND                                                                    |
+|    DATA  -> wire0 (1wire)                                                               |
+|                                                                                         |
+|  radar1  [RCWL-0516 microwave motion sensor]  -- Boiler room presence                   |
+|    VCC   -> rail 5V                                                                     |
+|    GND   -> rail GND                                                                    |
+|    OUT   -> D5                                                                          |
+|                                                                                         |
+|  Passives:                                                                              |
+|    r1: 4.7k resistor, wire0  <->  3V3   (1-wire bus pull-up (shared by both DS18B20s))  |
+|                                                                                         |
+|  BOM:                                                                                   |
+|    - WeMos D1 Mini                                                                      |
+|    - DS18B20 1-wire temperature sensor  (supply_temp)                                   |
+|    - DS18B20 1-wire temperature sensor  (return_temp)                                   |
+|    - RCWL-0516 microwave motion sensor  (radar1)                                        |
+|    - 1x 4.7k resistor                                                                   |
+|                                                                                         |
+|  Power: ~5mA typical, ~8mA peak (budget 500mA)  OK                                      |
+|                                                                                         |
+|  Warnings: none                                                                         |
++-----------------------------------------------------------------------------------------+

--- a/tests/golden/multi-temp.yaml
+++ b/tests/golden/multi-temp.yaml
@@ -1,0 +1,35 @@
+esphome:
+  name: multi-temp
+esp8266:
+  board: d1_mini
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+one_wire:
+- platform: gpio
+  pin: D6
+  id: wire0
+sensor:
+- platform: dallas_temp
+  one_wire_id: wire0
+  name: Boiler supply
+  address: '0x1c0000031edd2a28'
+  update_interval: 30s
+  resolution: 12
+- platform: dallas_temp
+  one_wire_id: wire0
+  name: Boiler return
+  address: '0xa20000031e1c2828'
+  update_interval: 30s
+  resolution: 12
+binary_sensor:
+- platform: gpio
+  pin: D5
+  name: Boiler room presence
+  device_class: motion

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -132,6 +132,57 @@ def test_render_unknown_library_id_returns_422(client):
     assert r.status_code == 422
 
 
+def test_render_strict_mode_clean_design_passes(client):
+    """A design with no compatibility hits renders normally under strict."""
+    design = json.loads((EXAMPLES_DIR / "garage-motion.json").read_text())
+    r = client.post("/design/render?strict=true", json=design)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["yaml"].startswith("esphome:")
+
+
+def test_render_strict_mode_blocks_on_compat_warning(client):
+    """A design with a known boot-strap warning (TTGO LoRa32 has one)
+    422s with the strict_mode_blocked detail under strict=true, but
+    still renders fine in permissive mode."""
+    design = json.loads((EXAMPLES_DIR / "ttgo-lora32.json").read_text())
+
+    # Permissive (default) -> 200, warnings travel in the body.
+    permissive = client.post("/design/render", json=design)
+    assert permissive.status_code == 200
+    assert any(
+        w["severity"] in ("warn", "error")
+        for w in permissive.json()["compatibility_warnings"]
+    )
+
+    # Strict -> 422 with the warnings in detail.
+    strict = client.post("/design/render?strict=true", json=design)
+    assert strict.status_code == 422
+    detail = strict.json()["detail"]
+    assert detail["error"] == "strict_mode_blocked"
+    assert "compatibility issue" in detail["message"]
+    assert len(detail["warnings"]) >= 1
+    assert all(
+        w["severity"] in ("warn", "error") for w in detail["warnings"]
+    )
+
+
+def test_render_strict_mode_ignores_info_severity(client):
+    """info-severity entries (like the D1 Mini A0 voltage_limit) should
+    NOT trip strict mode -- they're educational, not blocking. We use
+    the real bluemotion example which is known to have no warn/error
+    entries; if this regresses, the strict test above will fire instead."""
+    design = json.loads((EXAMPLES_DIR / "bluemotion.json").read_text())
+    permissive = client.post("/design/render", json=design).json()
+    severities = {w["severity"] for w in permissive["compatibility_warnings"]}
+    assert "warn" not in severities and "error" not in severities, (
+        "bluemotion gained a warn/error compat entry; pick a different example "
+        "for the info-passes-strict test"
+    )
+    r = client.post("/design/render?strict=true", json=design)
+    assert r.status_code == 200
+
+
 def test_render_missing_bus_returns_422_with_message(client):
     """A design that validates but references a non-existent bus
     (e.g. a freshly-added I2C component before the user adds an i2c bus)

--- a/tests/test_ascii_gen.py
+++ b/tests/test_ascii_gen.py
@@ -134,3 +134,8 @@ def test_long_warning_text_wrapped(bluesonoff_design, library):
     assert len(widths) == 1
     # Pre-wrap, the box ballooned to ~260 chars; wrapping caps it.
     assert max(widths) < 130
+
+
+def test_multi_temp_matches_golden(multi_temp_design, library, golden_dir):
+    expected = (golden_dir / "multi-temp.txt").read_text().rstrip("\n")
+    assert render_ascii(multi_temp_design, library) == expected

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -269,6 +269,31 @@ def test_adc1_pin_for_analog_in_silent(lib):
     assert _by_code(warnings, "adc2_wifi_conflict") == []
 
 
+def test_locked_pin_invalid_when_lock_lacks_required_cap(lib):
+    """An analog_in lock on a non-ADC pin should be flagged as an error."""
+    d = _esp32_design_with_analog("GPIO34")  # GPIO34 is ADC1 -- valid baseline
+    # Lock GAIN to a non-ADC pin (GPIO16 has only 'gpio' cap).
+    amp = next(c for c in d["components"] if c["id"] == "amp")
+    amp["locked_pins"] = {"GAIN": "GPIO16"}
+    warnings = check_pin_compatibility(d, lib)
+    invalid = _by_code(warnings, "locked_pin_invalid")
+    assert len(invalid) == 1
+    assert invalid[0].pin == "GPIO16"
+    assert invalid[0].component_id == "amp"
+    assert invalid[0].pin_role == "GAIN"
+    assert invalid[0].severity == "error"
+    assert "adc" in invalid[0].message.lower()
+
+
+def test_locked_pin_invalid_silent_when_lock_matches_cap(lib):
+    """A lock that does satisfy the role's required capability is silent."""
+    d = _esp32_design_with_analog("GPIO34")
+    amp = next(c for c in d["components"] if c["id"] == "amp")
+    amp["locked_pins"] = {"GAIN": "GPIO34"}  # ADC1, satisfies analog_in
+    warnings = check_pin_compatibility(d, lib)
+    assert _by_code(warnings, "locked_pin_invalid") == []
+
+
 def test_adc2_warning_does_not_fire_on_digital_in(lib):
     """A digital_in pin on an adc2-tagged GPIO is fine; ADC2 only matters
     when the library pin's kind is analog_in."""

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -306,6 +306,39 @@ def test_fleet_push_invalid_device_name_returns_422(monkeypatch, tmp_path, garag
     assert r.status_code == 422
 
 
+def test_fleet_push_strict_clean_design_passes(monkeypatch, tmp_path, garage_motion_design):
+    """garage-motion is warning-clean; strict push goes through."""
+    addon = FakeFleetAddon()
+    client = _make_client(monkeypatch, tmp_path, addon=addon)
+    r = client.post(
+        "/fleet/push",
+        json={"design": garage_motion_design, "strict": True},
+    )
+    assert r.status_code == 200
+    assert r.json()["created"] is True
+
+
+def test_fleet_push_strict_blocks_on_compat_warning(monkeypatch, tmp_path):
+    """ttgo-lora32 has a known boot_strap_output warning; strict push 422s
+    with the same envelope as /design/render?strict=true so the UI can
+    surface it the same way. The non-strict path still ships the file."""
+    design = json.loads((EXAMPLES_DIR / "ttgo-lora32.json").read_text())
+    addon = FakeFleetAddon()
+    client = _make_client(monkeypatch, tmp_path, addon=addon)
+
+    permissive = client.post("/fleet/push", json={"design": design})
+    assert permissive.status_code == 200, permissive.json()
+
+    strict = client.post("/fleet/push", json={"design": design, "strict": True})
+    assert strict.status_code == 422
+    detail = strict.json()["detail"]
+    assert detail["error"] == "strict_mode_blocked"
+    assert "compatibility issue" in detail["message"]
+    assert all(w["severity"] in ("warn", "error") for w in detail["warnings"])
+    # The push must NOT have hit the addon when strict refuses.
+    assert len(addon.compile_runs) == 0
+
+
 # ---------------------------------------------------------------------------
 # Build log polling
 # ---------------------------------------------------------------------------

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -401,3 +401,61 @@ def test_fleet_job_log_unknown_run_id_returns_502(monkeypatch, tmp_path):
     client = _make_client(monkeypatch, tmp_path, addon=addon)
     r = client.get("/fleet/jobs/nope/log")
     assert r.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# SSE log relay
+# ---------------------------------------------------------------------------
+
+def _parse_sse(body: str) -> list[dict]:
+    """Parse the studio's SSE stream into a list of {event, data} entries."""
+    events: list[dict] = []
+    for raw in body.split("\n\n"):
+        if not raw.strip():
+            continue
+        ev: dict = {"event": "message"}
+        for line in raw.splitlines():
+            if line.startswith("event: "):
+                ev["event"] = line[len("event: "):]
+            elif line.startswith("data: "):
+                ev["data"] = json.loads(line[len("data: "):])
+        events.append(ev)
+    return events
+
+
+def test_fleet_job_log_stream_emits_chunks_then_done(monkeypatch, tmp_path):
+    addon = FakeFleetAddon()
+    addon.job_logs["run-1"] = {"log": "compiling...\nlinking...\nbuild ok\n", "finished": True}
+    client = _make_client(monkeypatch, tmp_path, addon=addon)
+    # interval_ms=0 (clamped to 100ms by the server) is fine; the loop
+    # exits on the first iteration since finished=True from the start.
+    r = client.get("/fleet/jobs/run-1/log/stream?interval_ms=0")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/event-stream")
+    events = _parse_sse(r.text)
+    # At least one data frame and a final done frame.
+    assert events[0]["event"] == "message"
+    assert events[0]["data"]["log"].startswith("compiling")
+    assert events[0]["data"]["finished"] is True
+    assert events[-1]["event"] == "done"
+
+
+def test_fleet_job_log_stream_unconfigured_returns_503(monkeypatch, tmp_path):
+    client = _make_client(monkeypatch, tmp_path, addon=None)
+    r = client.get("/fleet/jobs/run-1/log/stream")
+    assert r.status_code == 503
+
+
+def test_fleet_job_log_stream_unknown_run_id_emits_error_event(monkeypatch, tmp_path):
+    """The addon returns 404 for unknown run_ids; the SSE relay surfaces
+    that as an `event: error` frame and exits, rather than 502'ing the
+    whole stream (HTTP status is already committed by the time the
+    polling loop sees the failure)."""
+    addon = FakeFleetAddon()
+    client = _make_client(monkeypatch, tmp_path, addon=addon)
+    r = client.get("/fleet/jobs/nope/log/stream?interval_ms=0")
+    assert r.status_code == 200
+    events = _parse_sse(r.text)
+    assert any(e["event"] == "error" for e in events), events
+    err = next(e for e in events if e["event"] == "error")
+    assert "nope" in err["data"]["message"]

--- a/tests/test_pin_solver.py
+++ b/tests/test_pin_solver.py
@@ -197,6 +197,59 @@ def test_solver_prefers_non_strap_pins(library):
     assert chosen not in ("D3", "D4", "D8")  # strap-tagged pins on wemos-d1-mini
 
 
+def test_locked_pin_fills_unbound_connection(library):
+    """A component's `locked_pins` entry should populate an unbound gpio
+    target with the locked pin even if the solver would have picked
+    something else."""
+    d = _load("wasserpir")
+    pir = next(c for c in d["components"] if c["id"] == "pir1")
+    pir["locked_pins"] = {"OUT": "D6"}
+    _connection(d, "pir1", "OUT")["target"] = {"kind": "gpio", "pin": ""}
+    result = solve_pins(d, library)
+    assigned = next(a for a in result.assigned if a.pin_role == "OUT")
+    assert assigned.new_target == {"kind": "gpio", "pin": "D6"}
+    assert _connection(result.design, "pir1", "OUT")["target"]["pin"] == "D6"
+
+
+def test_locked_pin_mismatch_emits_warning(library):
+    """A bound connection whose pin disagrees with the lock must surface
+    so the user can decide which side to update."""
+    d = _load("wasserpir")
+    pir = next(c for c in d["components"] if c["id"] == "pir1")
+    pir["locked_pins"] = {"OUT": "D6"}
+    _connection(d, "pir1", "OUT")["target"] = {"kind": "gpio", "pin": "D5"}
+    result = solve_pins(d, library)
+    mismatches = [u for u in result.unresolved if u.code == "locked_pin_mismatch"]
+    assert len(mismatches) == 1
+    assert "D5" in mismatches[0].text and "D6" in mismatches[0].text
+    # The bound pin is left in place; the lock doesn't silently rewrite it.
+    assert _connection(result.design, "pir1", "OUT")["target"]["pin"] == "D5"
+
+
+def test_locked_pin_unknown_role_warns(library):
+    """A lock whose key is not a real role on the library component is a
+    typo or a stale lock; surface it rather than silently doing nothing."""
+    d = _load("wasserpir")
+    pir = next(c for c in d["components"] if c["id"] == "pir1")
+    pir["locked_pins"] = {"NOT_A_REAL_ROLE": "D6"}
+    result = solve_pins(d, library)
+    unknown = [u for u in result.unresolved if u.code == "locked_pin_unknown_role"]
+    assert len(unknown) == 1
+    assert "NOT_A_REAL_ROLE" in unknown[0].text
+
+
+def test_locked_pin_already_aligned_is_silent(library):
+    """When the bound target already matches the lock, the solver should
+    not produce a warning OR a redundant assignment."""
+    d = _load("wasserpir")
+    pir = next(c for c in d["components"] if c["id"] == "pir1")
+    bound = _connection(d, "pir1", "OUT")["target"]["pin"]
+    pir["locked_pins"] = {"OUT": bound}
+    result = solve_pins(d, library)
+    assert [u for u in result.unresolved if u.code.startswith("locked_pin_")] == []
+    assert [a for a in result.assigned if a.pin_role == "OUT"] == []
+
+
 def test_solver_prefers_adc1_over_adc2_for_analog_in(library):
     """On classic ESP32, analog_in should land on an ADC1 pin (GPIO32-39)
     rather than an ADC2 pin (which conflicts with WiFi at runtime)."""

--- a/tests/test_recommend.py
+++ b/tests/test_recommend.py
@@ -32,6 +32,23 @@ def test_motion_query_ranks_pir_first(lib):
     assert "motion" in out[0].rationale
 
 
+def test_motion_query_surfaces_rcwl_alongside_pir(lib):
+    """RCWL-0516 advertises the same use_cases as the PIR but is the
+    microwave alternative, so it should appear in the top 3 motion picks."""
+    out = recommend_components(lib, "motion")
+    ids = [r.library_id for r in out[:3]]
+    assert "rcwl-0516" in ids
+
+
+def test_temperature_query_surfaces_ds18b20(lib):
+    """DS18B20 is the canonical 1-wire temp sensor; recommending
+    'temperature' must include it (BME280 still wins on 'temperature
+    humidity' because it covers both, but DS18B20 should be visible)."""
+    out = recommend_components(lib, "temperature")
+    ids = [r.library_id for r in out]
+    assert "ds18b20" in ids
+
+
 def test_temperature_humidity_query_returns_bme280(lib):
     out = recommend_components(lib, "temperature humidity")
     ids = [r.library_id for r in out]

--- a/tests/test_recommend.py
+++ b/tests/test_recommend.py
@@ -49,6 +49,22 @@ def test_temperature_query_surfaces_ds18b20(lib):
     assert "ds18b20" in ids
 
 
+def test_adc_query_surfaces_ads1115(lib):
+    """ADC queries should land on the ADS1115 -- it's the only library
+    component carrying the `adc` use_case today."""
+    out = recommend_components(lib, "adc")
+    ids = [r.library_id for r in out]
+    assert ids and ids[0] == "ads1115"
+
+
+def test_imu_query_surfaces_mpu6050(lib):
+    """IMU/accelerometer/gyroscope queries should land on the MPU6050."""
+    for q in ("imu", "accelerometer", "gyroscope"):
+        out = recommend_components(lib, q)
+        ids = [r.library_id for r in out]
+        assert "mpu6050" in ids, f"{q!r} did not surface mpu6050; got {ids}"
+
+
 def test_temperature_humidity_query_returns_bme280(lib):
     out = recommend_components(lib, "temperature humidity")
     ids = [r.library_id for r in out]

--- a/tests/test_recommend.py
+++ b/tests/test_recommend.py
@@ -65,6 +65,31 @@ def test_imu_query_surfaces_mpu6050(lib):
         assert "mpu6050" in ids, f"{q!r} did not surface mpu6050; got {ids}"
 
 
+def test_thermocouple_query_lands_on_max31855(lib):
+    out = recommend_components(lib, "thermocouple")
+    assert out and out[0].library_id == "max31855"
+
+
+def test_weight_query_lands_on_hx711(lib):
+    out = recommend_components(lib, "weight scale")
+    assert out and out[0].library_id == "hx711"
+
+
+def test_lux_query_lands_on_tsl2561(lib):
+    out = recommend_components(lib, "lux ambient light")
+    assert out and out[0].library_id == "tsl2561"
+
+
+def test_pressure_query_includes_bmp180(lib):
+    out = recommend_components(lib, "pressure")
+    assert "bmp180" in [r.library_id for r in out]
+
+
+def test_humidity_query_includes_htu21d(lib):
+    out = recommend_components(lib, "humidity")
+    assert "htu21d" in [r.library_id for r in out]
+
+
 def test_temperature_humidity_query_returns_bme280(lib):
     out = recommend_components(lib, "temperature humidity")
     ids = [r.library_id for r in out]

--- a/tests/test_yaml_gen.py
+++ b/tests/test_yaml_gen.py
@@ -471,3 +471,115 @@ def test_ads1115_and_mpu6050_share_one_i2c_bus(library):
     sensor_platforms = {s["platform"] for s in parsed["sensor"]}
     assert "ads1115" in sensor_platforms
     assert "mpu6050" in sensor_platforms
+
+
+# ---------------------------------------------------------------------------
+# Library expansion v3: BMP180, HTU21D, MAX31855, HX711, TSL2561
+# ---------------------------------------------------------------------------
+
+def _esp32_with_spi(components: list[dict], extra_connections: list[dict]) -> dict:
+    return {
+        "schema_version": "0.1",
+        "id": "spi-fixture",
+        "name": "SPI fixture",
+        "board": {"library_id": "esp32-devkitc-v4", "mcu": "esp32"},
+        "fleet": {"device_name": "spi-fixture", "tags": []},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": components,
+        "buses": [{"id": "spi0", "type": "spi",
+                    "clk": "GPIO18", "miso": "GPIO19", "mosi": "GPIO23"}],
+        "connections": extra_connections,
+        "requirements": [],
+        "warnings": [],
+    }
+
+
+def test_bmp180_renders_temperature_and_pressure(library):
+    design_dict = _esp32_with_i2c(
+        components=[{"id": "weather", "library_id": "bmp180", "label": "Weather", "params": {}}],
+        extra_connections=[
+            {"component_id": "weather", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "weather", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "weather", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "weather", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    bmp = next(s for s in parsed["sensor"] if s.get("platform") == "bmp085")
+    assert bmp["i2c_id"] == "i2c0"
+    assert bmp["temperature"]["name"] == "Weather Temperature"
+    assert bmp["pressure"]["name"] == "Weather Pressure"
+
+
+def test_htu21d_renders_temperature_and_humidity(library):
+    design_dict = _esp32_with_i2c(
+        components=[{"id": "th1", "library_id": "htu21d", "label": "Indoor", "params": {}}],
+        extra_connections=[
+            {"component_id": "th1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "th1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "th1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "th1", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    htu = next(s for s in parsed["sensor"] if s.get("platform") == "htu21d")
+    assert htu["temperature"]["name"] == "Indoor Temperature"
+    assert htu["humidity"]["name"] == "Indoor Humidity"
+
+
+def test_max31855_renders_with_spi_bus_and_cs(library):
+    design_dict = _esp32_with_spi(
+        components=[{"id": "tc1", "library_id": "max31855", "label": "Smoker probe",
+                     "params": {"reference_temperature": True}}],
+        extra_connections=[
+            {"component_id": "tc1", "pin_role": "VCC",  "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "tc1", "pin_role": "GND",  "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "tc1", "pin_role": "CLK",  "target": {"kind": "bus",  "bus_id": "spi0"}},
+            {"component_id": "tc1", "pin_role": "MISO", "target": {"kind": "bus",  "bus_id": "spi0"}},
+            {"component_id": "tc1", "pin_role": "CS",   "target": {"kind": "gpio", "pin": "GPIO5"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    tc = next(s for s in parsed["sensor"] if s.get("platform") == "max31855")
+    assert tc["spi_id"] == "spi0"
+    assert tc["cs_pin"] == "GPIO5"
+    assert tc["name"] == "Smoker probe Thermocouple"
+    assert tc["reference_temperature"]["name"] == "Smoker probe Cold Junction"
+
+
+def test_hx711_renders_with_dout_and_clk_pins(library):
+    design_dict = _esp32_with_i2c(
+        components=[{"id": "scale", "library_id": "hx711", "label": "Coffee scale",
+                     "params": {"gain": 64}}],
+        extra_connections=[
+            {"component_id": "scale", "pin_role": "VCC",  "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "scale", "pin_role": "GND",  "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "scale", "pin_role": "DOUT", "target": {"kind": "gpio", "pin": "GPIO16"}},
+            {"component_id": "scale", "pin_role": "SCK",  "target": {"kind": "gpio", "pin": "GPIO17"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    hx = next(s for s in parsed["sensor"] if s.get("platform") == "hx711")
+    assert hx["dout_pin"] == "GPIO16"
+    assert hx["clk_pin"] == "GPIO17"
+    assert hx["gain"] == 64
+    assert hx["name"] == "Coffee scale"
+
+
+def test_tsl2561_renders_with_address_override(library):
+    design_dict = _esp32_with_i2c(
+        components=[{"id": "lux1", "library_id": "tsl2561", "label": "Window",
+                     "params": {"address": "0x49", "gain": "16x", "integration_time": "402ms"}}],
+        extra_connections=[
+            {"component_id": "lux1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "lux1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "lux1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "lux1", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    tsl = next(s for s in parsed["sensor"] if s.get("platform") == "tsl2561")
+    assert tsl["address"] == "0x49"
+    assert tsl["gain"] == "16x"
+    assert tsl["integration_time"] == "402ms"
+    assert tsl["name"] == "Window Illuminance"

--- a/tests/test_yaml_gen.py
+++ b/tests/test_yaml_gen.py
@@ -371,18 +371,13 @@ def _esp32_with_i2c(components: list[dict], extra_connections: list[dict]) -> di
     return base
 
 
-def test_ads1115_renders_hub_and_per_channel_sensors(library):
+def test_ads1115_hub_alone_emits_no_sensors(library):
+    """The hub component is hub-only after the split: it registers the
+    `ads1115:` block but emits no `sensor:` entries. Channels live in
+    separate ads1115_channel components."""
     design_dict = _esp32_with_i2c(
-        components=[{
-            "id": "adc1", "library_id": "ads1115", "label": "Power monitor",
-            "params": {
-                "address": "0x49",
-                "channels": [
-                    {"multiplexer": "A0_GND", "name": "Bus A", "gain": 4.096},
-                    {"multiplexer": "A1_GND", "name": "Bus B"},
-                ],
-            },
-        }],
+        components=[{"id": "adc1", "library_id": "ads1115", "label": "Hub",
+                     "params": {"address": "0x49"}}],
         extra_connections=[
             {"component_id": "adc1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
             {"component_id": "adc1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
@@ -395,33 +390,71 @@ def test_ads1115_renders_hub_and_per_channel_sensors(library):
     assert hub["id"] == "adc1_hub"
     assert hub["address"] == "0x49"
     assert hub["i2c_id"] == "i2c0"
-    channels = [s for s in parsed["sensor"] if s.get("platform") == "ads1115"]
-    assert len(channels) == 2
-    assert channels[0]["multiplexer"] == "A0_GND"
-    assert channels[0]["gain"] == 4.096
-    assert channels[0]["name"] == "Bus A"
-    # The second channel inherits the default 6.144 gain.
-    assert channels[1]["multiplexer"] == "A1_GND"
-    assert channels[1]["gain"] == 6.144
+    assert "sensor" not in parsed or all(
+        s.get("platform") != "ads1115" for s in parsed["sensor"]
+    )
 
 
-def test_ads1115_with_no_channels_still_emits_hub(library):
-    """An ADS1115 added with no channels should still register the hub
-    block -- a future channel addition just fills in sensor entries."""
+def test_ads1115_channel_renders_sensor_pointing_at_hub(library):
+    """An ads1115_channel with HUB target = component:adc1 emits a
+    `sensor:` entry whose ads1115_id matches the hub's `<id>_hub`
+    handle. Each channel's params (multiplexer/gain/update_interval)
+    flow through independently."""
     design_dict = _esp32_with_i2c(
-        components=[{"id": "adc1", "library_id": "ads1115", "label": "Power", "params": {}}],
+        components=[
+            {"id": "adc1", "library_id": "ads1115", "label": "Hub", "params": {}},
+            {"id": "bat",  "library_id": "ads1115_channel", "label": "Battery V",
+             "params": {"multiplexer": "A0_GND", "gain": "4.096", "update_interval": "10s"}},
+            {"id": "load", "library_id": "ads1115_channel", "label": "Load V",
+             "params": {"multiplexer": "A1_GND", "gain": "2.048"}},
+        ],
         extra_connections=[
             {"component_id": "adc1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
             {"component_id": "adc1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
             {"component_id": "adc1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
             {"component_id": "adc1", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "bat",  "pin_role": "HUB", "target": {"kind": "component", "component_id": "adc1"}},
+            {"component_id": "load", "pin_role": "HUB", "target": {"kind": "component", "component_id": "adc1"}},
         ],
     )
     parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
-    assert parsed["ads1115"][0]["id"] == "adc1_hub"
-    assert "sensor" not in parsed or all(
-        s.get("platform") != "ads1115" for s in parsed["sensor"]
+    sensors = [s for s in parsed["sensor"] if s.get("platform") == "ads1115"]
+    by_name = {s["name"]: s for s in sensors}
+    assert set(by_name) == {"Battery V", "Load V"}
+    assert by_name["Battery V"]["ads1115_id"] == "adc1_hub"
+    assert by_name["Battery V"]["multiplexer"] == "A0_GND"
+    # YAML un-quoting parses "4.096" as a float; assert via string equality
+    # on the original render.
+    assert by_name["Battery V"]["gain"] == 4.096
+    assert by_name["Battery V"]["update_interval"] == "10s"
+    assert by_name["Load V"]["ads1115_id"] == "adc1_hub"
+    assert by_name["Load V"]["update_interval"] == "60s"  # default
+
+
+def test_ads1115_channel_solver_auto_binds_to_hub(library):
+    """An unbound HUB target on an ads1115_channel resolves to the only
+    ads1115 hub in the design via the new `kind: component` solve path."""
+    from studio.csp.pin_solver import solve_pins
+    from studio.library import default_library
+    lib = default_library()
+    design_dict = _esp32_with_i2c(
+        components=[
+            {"id": "adc1", "library_id": "ads1115", "label": "Hub", "params": {}},
+            {"id": "bat",  "library_id": "ads1115_channel", "label": "Battery V",
+             "params": {"multiplexer": "A0_GND"}},
+        ],
+        extra_connections=[
+            {"component_id": "adc1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "adc1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "adc1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "adc1", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            # Unbound: solver must fill in component_id.
+            {"component_id": "bat",  "pin_role": "HUB", "target": {"kind": "component", "component_id": ""}},
+        ],
     )
+    result = solve_pins(design_dict, lib)
+    bat_conn = next(c for c in result.design["connections"] if c["component_id"] == "bat")
+    assert bat_conn["target"] == {"kind": "component", "component_id": "adc1"}
 
 
 def test_mpu6050_renders_six_axes_plus_die_temp(library):
@@ -445,12 +478,14 @@ def test_mpu6050_renders_six_axes_plus_die_temp(library):
 
 
 def test_ads1115_and_mpu6050_share_one_i2c_bus(library):
-    """Both new I2C parts on the same bus emit a single i2c block + the
-    ads1115 hub + the mpu6050 sensor -- no duplication."""
+    """ADS1115 hub + an ADS1115 channel + MPU6050 on the same bus emit
+    a single i2c block, single ads1115 hub block, plus channel and
+    mpu6050 sensors -- no duplication."""
     design_dict = _esp32_with_i2c(
         components=[
-            {"id": "adc1", "library_id": "ads1115", "label": "ADC",
-             "params": {"channels": [{"multiplexer": "A0_GND", "name": "Bat"}]}},
+            {"id": "adc1", "library_id": "ads1115", "label": "ADC", "params": {}},
+            {"id": "bat",  "library_id": "ads1115_channel", "label": "Bat",
+             "params": {"multiplexer": "A0_GND"}},
             {"id": "imu1", "library_id": "mpu6050", "label": "IMU", "params": {}},
         ],
         extra_connections=[
@@ -458,6 +493,7 @@ def test_ads1115_and_mpu6050_share_one_i2c_bus(library):
             {"component_id": "adc1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
             {"component_id": "adc1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
             {"component_id": "adc1", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "bat",  "pin_role": "HUB", "target": {"kind": "component", "component_id": "adc1"}},
             {"component_id": "imu1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
             {"component_id": "imu1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
             {"component_id": "imu1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},

--- a/tests/test_yaml_gen.py
+++ b/tests/test_yaml_gen.py
@@ -348,3 +348,126 @@ def test_rcwl_0516_renders_motion_binary_sensor(library):
     assert bs["pin"] == "D7"
     assert bs["name"] == "Hall radar"
     assert bs["device_class"] == "motion"
+
+
+# ---------------------------------------------------------------------------
+# ADS1115 + MPU6050 (library expansion v2)
+# ---------------------------------------------------------------------------
+
+def _esp32_with_i2c(components: list[dict], extra_connections: list[dict]) -> dict:
+    base = {
+        "schema_version": "0.1",
+        "id": "i2c-fixture",
+        "name": "I2C fixture",
+        "board": {"library_id": "esp32-devkitc-v4", "mcu": "esp32"},
+        "fleet": {"device_name": "i2c-fixture", "tags": []},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": components,
+        "buses": [{"id": "i2c0", "type": "i2c", "sda": "GPIO21", "scl": "GPIO22"}],
+        "connections": extra_connections,
+        "requirements": [],
+        "warnings": [],
+    }
+    return base
+
+
+def test_ads1115_renders_hub_and_per_channel_sensors(library):
+    design_dict = _esp32_with_i2c(
+        components=[{
+            "id": "adc1", "library_id": "ads1115", "label": "Power monitor",
+            "params": {
+                "address": "0x49",
+                "channels": [
+                    {"multiplexer": "A0_GND", "name": "Bus A", "gain": 4.096},
+                    {"multiplexer": "A1_GND", "name": "Bus B"},
+                ],
+            },
+        }],
+        extra_connections=[
+            {"component_id": "adc1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "adc1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "adc1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "adc1", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    hub = parsed["ads1115"][0]
+    assert hub["id"] == "adc1_hub"
+    assert hub["address"] == "0x49"
+    assert hub["i2c_id"] == "i2c0"
+    channels = [s for s in parsed["sensor"] if s.get("platform") == "ads1115"]
+    assert len(channels) == 2
+    assert channels[0]["multiplexer"] == "A0_GND"
+    assert channels[0]["gain"] == 4.096
+    assert channels[0]["name"] == "Bus A"
+    # The second channel inherits the default 6.144 gain.
+    assert channels[1]["multiplexer"] == "A1_GND"
+    assert channels[1]["gain"] == 6.144
+
+
+def test_ads1115_with_no_channels_still_emits_hub(library):
+    """An ADS1115 added with no channels should still register the hub
+    block -- a future channel addition just fills in sensor entries."""
+    design_dict = _esp32_with_i2c(
+        components=[{"id": "adc1", "library_id": "ads1115", "label": "Power", "params": {}}],
+        extra_connections=[
+            {"component_id": "adc1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "adc1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "adc1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "adc1", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    assert parsed["ads1115"][0]["id"] == "adc1_hub"
+    assert "sensor" not in parsed or all(
+        s.get("platform") != "ads1115" for s in parsed["sensor"]
+    )
+
+
+def test_mpu6050_renders_six_axes_plus_die_temp(library):
+    design_dict = _esp32_with_i2c(
+        components=[{"id": "imu1", "library_id": "mpu6050", "label": "Door tilt", "params": {}}],
+        extra_connections=[
+            {"component_id": "imu1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "imu1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "imu1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "imu1", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    imu = next(s for s in parsed["sensor"] if s.get("platform") == "mpu6050")
+    assert imu["address"] == "0x68"
+    assert imu["i2c_id"] == "i2c0"
+    # Six axes + die temp.
+    for ax in ("accel_x", "accel_y", "accel_z", "gyro_x", "gyro_y", "gyro_z"):
+        assert ax in imu and imu[ax]["name"].startswith("Door tilt")
+    assert imu["temperature"]["name"] == "Door tilt Die Temp"
+
+
+def test_ads1115_and_mpu6050_share_one_i2c_bus(library):
+    """Both new I2C parts on the same bus emit a single i2c block + the
+    ads1115 hub + the mpu6050 sensor -- no duplication."""
+    design_dict = _esp32_with_i2c(
+        components=[
+            {"id": "adc1", "library_id": "ads1115", "label": "ADC",
+             "params": {"channels": [{"multiplexer": "A0_GND", "name": "Bat"}]}},
+            {"id": "imu1", "library_id": "mpu6050", "label": "IMU", "params": {}},
+        ],
+        extra_connections=[
+            {"component_id": "adc1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "adc1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "adc1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "adc1", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "imu1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "imu1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "imu1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "imu1", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    assert len(parsed["i2c"]) == 1
+    assert parsed["i2c"][0]["id"] == "i2c0"
+    assert len(parsed["ads1115"]) == 1
+    sensor_platforms = {s["platform"] for s in parsed["sensor"]}
+    assert "ads1115" in sensor_platforms
+    assert "mpu6050" in sensor_platforms

--- a/tests/test_yaml_gen.py
+++ b/tests/test_yaml_gen.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import yaml
 
 from studio.generate.yaml_gen import render_yaml
+from studio.model import Design
 
 
 def test_garage_motion_matches_golden(garage_motion_design, library, golden_dir):
@@ -251,3 +252,84 @@ def test_awning_uses_expander_pins_not_extras(awning_control_design, library):
     assert len(switches) == 2  # awning_power, motor_enable
     for s in switches:
         assert s["pin"]["mcp23008"] == "mcp23008_hub"
+
+
+# ---------------------------------------------------------------------------
+# DS18B20 + RCWL-0516 (library expansion)
+# ---------------------------------------------------------------------------
+
+def _wemos_d1_mini_skeleton(components: list[dict], connections: list[dict]) -> dict:
+    """Minimal-but-valid design.json scaffold the new-component tests build on."""
+    base = {
+        "schema_version": "0.1",
+        "id": "fixture",
+        "name": "Fixture",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266"},
+        "fleet": {"device_name": "fixture", "tags": []},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": components,
+        "buses": [],
+        "connections": connections,
+        "requirements": [],
+        "warnings": [],
+    }
+    return base
+
+
+def test_ds18b20_renders_one_wire_and_dallas_blocks(library):
+    design_dict = _wemos_d1_mini_skeleton(
+        components=[{"id": "temp1", "library_id": "ds18b20", "label": "Temp 1", "params": {}}],
+        connections=[
+            {"component_id": "temp1", "pin_role": "VCC",  "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "temp1", "pin_role": "GND",  "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "temp1", "pin_role": "DATA", "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    assert parsed["one_wire"] == [{"platform": "gpio", "pin": "D6", "id": "temp1_bus"}]
+    sensors = [s for s in parsed.get("sensor") or [] if s.get("platform") == "dallas_temp"]
+    assert len(sensors) == 1
+    assert sensors[0]["one_wire_id"] == "temp1_bus"
+    assert sensors[0]["update_interval"] == "60s"
+
+
+def test_two_ds18b20_instances_merge_one_wire_lists(library):
+    """Two DS18B20s on different pins each contribute their own one_wire
+    and dallas_temp entries; _deep_merge concatenates the lists rather
+    than dropping one."""
+    design_dict = _wemos_d1_mini_skeleton(
+        components=[
+            {"id": "temp1", "library_id": "ds18b20", "label": "Temp 1", "params": {}},
+            {"id": "temp2", "library_id": "ds18b20", "label": "Temp 2", "params": {}},
+        ],
+        connections=[
+            {"component_id": "temp1", "pin_role": "VCC",  "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "temp1", "pin_role": "GND",  "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "temp1", "pin_role": "DATA", "target": {"kind": "gpio", "pin": "D5"}},
+            {"component_id": "temp2", "pin_role": "VCC",  "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "temp2", "pin_role": "GND",  "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "temp2", "pin_role": "DATA", "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    bus_ids = {b["id"] for b in parsed["one_wire"]}
+    assert bus_ids == {"temp1_bus", "temp2_bus"}
+    sensors = [s for s in parsed["sensor"] if s.get("platform") == "dallas_temp"]
+    assert {s["one_wire_id"] for s in sensors} == {"temp1_bus", "temp2_bus"}
+
+
+def test_rcwl_0516_renders_motion_binary_sensor(library):
+    design_dict = _wemos_d1_mini_skeleton(
+        components=[{"id": "radar", "library_id": "rcwl-0516", "label": "Hall radar", "params": {}}],
+        connections=[
+            {"component_id": "radar", "pin_role": "VCC", "target": {"kind": "rail", "rail": "5V"}},
+            {"component_id": "radar", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "radar", "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D7"}},
+        ],
+    )
+    parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
+    bs = parsed["binary_sensor"][0]
+    assert bs["platform"] == "gpio"
+    assert bs["pin"] == "D7"
+    assert bs["name"] == "Hall radar"
+    assert bs["device_class"] == "motion"

--- a/tests/test_yaml_gen.py
+++ b/tests/test_yaml_gen.py
@@ -276,46 +276,61 @@ def _wemos_d1_mini_skeleton(components: list[dict], connections: list[dict]) -> 
     return base
 
 
-def test_ds18b20_renders_one_wire_and_dallas_blocks(library):
+def test_multi_temp_matches_golden(multi_temp_design, library, golden_dir):
+    expected = (golden_dir / "multi-temp.yaml").read_text()
+    actual = render_yaml(multi_temp_design, library)
+    assert actual == expected
+
+
+def test_ds18b20_renders_dallas_temp_pointing_at_bus(library):
+    """A DS18B20 wired to a 1-wire bus emits dallas_temp with one_wire_id
+    matching the bus id; the bus block itself comes from yaml_gen's
+    bus-rendering loop (the component template no longer contains it)."""
     design_dict = _wemos_d1_mini_skeleton(
         components=[{"id": "temp1", "library_id": "ds18b20", "label": "Temp 1", "params": {}}],
         connections=[
             {"component_id": "temp1", "pin_role": "VCC",  "target": {"kind": "rail", "rail": "3V3"}},
             {"component_id": "temp1", "pin_role": "GND",  "target": {"kind": "rail", "rail": "GND"}},
-            {"component_id": "temp1", "pin_role": "DATA", "target": {"kind": "gpio", "pin": "D6"}},
+            {"component_id": "temp1", "pin_role": "DATA", "target": {"kind": "bus", "bus_id": "wire0"}},
         ],
     )
+    design_dict["buses"] = [{"id": "wire0", "type": "1wire", "pin": "D6"}]
     parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
-    assert parsed["one_wire"] == [{"platform": "gpio", "pin": "D6", "id": "temp1_bus"}]
+    assert parsed["one_wire"] == [{"platform": "gpio", "pin": "D6", "id": "wire0"}]
     sensors = [s for s in parsed.get("sensor") or [] if s.get("platform") == "dallas_temp"]
     assert len(sensors) == 1
-    assert sensors[0]["one_wire_id"] == "temp1_bus"
+    assert sensors[0]["one_wire_id"] == "wire0"
     assert sensors[0]["update_interval"] == "60s"
 
 
-def test_two_ds18b20_instances_merge_one_wire_lists(library):
-    """Two DS18B20s on different pins each contribute their own one_wire
-    and dallas_temp entries; _deep_merge concatenates the lists rather
-    than dropping one."""
+def test_two_ds18b20_instances_share_a_single_one_wire_bus(library):
+    """Two DS18B20s wired to the same 1-wire bus emit a SINGLE one_wire
+    block and two dallas_temp sensors pointing at it. This is the
+    primary motivation for promoting 1-wire to a real bus type."""
     design_dict = _wemos_d1_mini_skeleton(
         components=[
-            {"id": "temp1", "library_id": "ds18b20", "label": "Temp 1", "params": {}},
-            {"id": "temp2", "library_id": "ds18b20", "label": "Temp 2", "params": {}},
+            {"id": "temp1", "library_id": "ds18b20", "label": "Temp 1",
+             "params": {"address": "0x1c0000031edd2a28"}},
+            {"id": "temp2", "library_id": "ds18b20", "label": "Temp 2",
+             "params": {"address": "0xa20000031e1c2828"}},
         ],
         connections=[
             {"component_id": "temp1", "pin_role": "VCC",  "target": {"kind": "rail", "rail": "3V3"}},
             {"component_id": "temp1", "pin_role": "GND",  "target": {"kind": "rail", "rail": "GND"}},
-            {"component_id": "temp1", "pin_role": "DATA", "target": {"kind": "gpio", "pin": "D5"}},
+            {"component_id": "temp1", "pin_role": "DATA", "target": {"kind": "bus", "bus_id": "wire0"}},
             {"component_id": "temp2", "pin_role": "VCC",  "target": {"kind": "rail", "rail": "3V3"}},
             {"component_id": "temp2", "pin_role": "GND",  "target": {"kind": "rail", "rail": "GND"}},
-            {"component_id": "temp2", "pin_role": "DATA", "target": {"kind": "gpio", "pin": "D6"}},
+            {"component_id": "temp2", "pin_role": "DATA", "target": {"kind": "bus", "bus_id": "wire0"}},
         ],
     )
+    design_dict["buses"] = [{"id": "wire0", "type": "1wire", "pin": "D6"}]
     parsed = yaml.unsafe_load(render_yaml(Design.model_validate(design_dict), library))
-    bus_ids = {b["id"] for b in parsed["one_wire"]}
-    assert bus_ids == {"temp1_bus", "temp2_bus"}
+    assert parsed["one_wire"] == [{"platform": "gpio", "pin": "D6", "id": "wire0"}]
     sensors = [s for s in parsed["sensor"] if s.get("platform") == "dallas_temp"]
-    assert {s["one_wire_id"] for s in sensors} == {"temp1_bus", "temp2_bus"}
+    assert len(sensors) == 2
+    assert {s["one_wire_id"] for s in sensors} == {"wire0"}
+    # Each sensor renders its own address.
+    assert {s["address"] for s in sensors} == {"0x1c0000031edd2a28", "0xa20000031e1c2828"}
 
 
 def test_rcwl_0516_renders_motion_binary_sensor(library):

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,6 +15,9 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.2.4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -23,12 +26,71 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.5.0",
+        "jsdom": "^29.1.1",
         "tailwindcss": "^4.2.4",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.2",
         "vite": "^8.0.10",
         "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -222,6 +284,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -268,6 +340,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -430,6 +655,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1120,6 +1363,96 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1130,6 +1463,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1622,6 +1963,41 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1659,6 +2035,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1761,12 +2147,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1786,12 +2207,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1802,6 +2240,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.349",
@@ -1822,6 +2268,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2232,6 +2691,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2250,6 +2722,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-extglob": {
@@ -2275,6 +2757,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2298,6 +2787,57 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2657,6 +3197,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2665,6 +3216,23 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -2790,6 +3358,19 @@
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2876,6 +3457,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2905,6 +3502,38 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -2947,6 +3576,19 @@
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -3018,6 +3660,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
@@ -3081,6 +3743,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3151,6 +3859,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3369,6 +4087,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3411,6 +4177,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,9 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.2.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -27,6 +30,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4.2.4",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.2",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,6 +25,7 @@ import {
   isDirty,
   prepareBusesForLib,
   readBuses,
+  setLockedPin,
   removeComponent,
   updateComponentParam,
   updateConnectionTarget,
@@ -188,6 +189,10 @@ export default function App() {
 
   function handleConnectionChange(connectionIndex: number, target: ConnectionTarget) {
     setDesign((d) => (d ? updateConnectionTarget(d, connectionIndex, target) : d));
+  }
+
+  function handleLockedPinChange(componentId: string, pinRole: string, pin: string | null) {
+    setDesign((d) => (d ? setLockedPin(d, componentId, pinRole, pin) : d));
   }
 
   function handleDesignChange(updater: (d: Design) => Design) {
@@ -457,6 +462,7 @@ export default function App() {
           onSelect={setSelection}
           onParamChange={handleParamChange}
           onConnectionChange={handleConnectionChange}
+          onLockedPinChange={handleLockedPinChange}
           onDesignChange={handleDesignChange}
           onAddComponent={handleAddComponent}
           onRemoveComponent={handleRemoveComponent}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -47,6 +47,12 @@ export default function App() {
   const [render, setRender] = useState<RenderResponse | null>(null);
   const [renderError, setRenderError] = useState<string | null>(null);
   const [rendering, setRendering] = useState(false);
+  /** Strict mode: when true, the render endpoint refuses to produce
+   *  YAML/ASCII while compatibility warnings of severity warn or error
+   *  remain. Useful as a pre-deploy gate -- the design has to be clean
+   *  before push-to-fleet. Default permissive so the user isn't blocked
+   *  while editing. */
+  const [strictMode, setStrictMode] = useState<boolean>(false);
 
   const [boardData, setBoardData] = useState<unknown | null>(null);
 
@@ -146,22 +152,35 @@ export default function App() {
     setRendering(true);
     (async () => {
       try {
-        const r = await api.render(debouncedDesign);
+        const r = await api.render(debouncedDesign, { strict: strictMode });
         if (cancelled) return;
         setRender(r);
         setRenderError(null);
       } catch (e) {
         if (cancelled) return;
-        const msg = e instanceof ApiError
-          ? `${e.status}: ${e.message}`
-          : e instanceof Error ? e.message : String(e);
+        let msg: string;
+        if (e instanceof ApiError) {
+          // Strict-mode rejection: detail = { error, message, warnings: [...] }.
+          // Surface the message + count instead of the raw JSON blob.
+          const body = e.body as
+            | { detail?: { error?: string; message?: string; warnings?: unknown[] } }
+            | undefined;
+          const detail = body?.detail;
+          if (detail?.error === "strict_mode_blocked" && detail.message) {
+            msg = `${e.status}: ${detail.message}`;
+          } else {
+            msg = `${e.status}: ${e.message}`;
+          }
+        } else {
+          msg = e instanceof Error ? e.message : String(e);
+        }
         setRenderError(msg);
       } finally {
         if (!cancelled) setRendering(false);
       }
     })();
     return () => { cancelled = true; };
-  }, [debouncedDesign]);
+  }, [debouncedDesign, strictMode]);
 
   function handleReset() {
     if (!originalDesign) return;
@@ -384,6 +403,22 @@ export default function App() {
           >
             {solving ? "Solving..." : "Solve pins"}
           </button>
+          <label
+            className={`flex cursor-pointer items-center gap-1 rounded border px-2 py-1 text-xs transition-colors ${
+              strictMode
+                ? "border-amber-600/50 bg-amber-900/20 text-amber-100"
+                : "border-zinc-800 text-zinc-300 hover:bg-zinc-900"
+            }`}
+            title="Strict mode: render fails when compatibility warnings of severity warn or error remain. Use as a pre-deploy gate."
+          >
+            <input
+              type="checkbox"
+              checked={strictMode}
+              onChange={(e) => setStrictMode(e.target.checked)}
+              className="h-3 w-3"
+            />
+            strict
+          </label>
           <button
             onClick={() => setShowUsbDialog(true)}
             className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-900"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -485,6 +485,7 @@ export default function App() {
       {showCapabilityDialog && (
         <CapabilityPickerDialog
           designReady={!!design}
+          designBusTypes={Array.from(new Set(readBuses(design).map((b) => b.type)))}
           onAdd={async (libraryId) => {
             await handleAddComponent(libraryId);
           }}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -520,6 +520,7 @@ export default function App() {
       {showFleetDialog && design && (
         <PushToFleetDialog
           design={design}
+          strict={strictMode}
           onClose={() => setShowFleetDialog(false)}
         />
       )}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -69,8 +69,11 @@ export const api = {
 
   validate: (design: Design) =>
     request<ValidateResponse>("/design/validate", { method: "POST", body: JSON.stringify(design) }),
-  render: (design: Design) =>
-    request<RenderResponse>("/design/render", { method: "POST", body: JSON.stringify(design) }),
+  render: (design: Design, opts: { strict?: boolean } = {}) =>
+    request<RenderResponse>(
+      `/design/render${opts.strict ? "?strict=true" : ""}`,
+      { method: "POST", body: JSON.stringify(design) },
+    ),
   solvePins: (design: Design) =>
     request<SolvePinsResponse>("/design/solve_pins", { method: "POST", body: JSON.stringify(design) }),
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -99,7 +99,7 @@ export const api = {
     }),
 
   fleetStatus: () => request<FleetStatus>("/fleet/status"),
-  fleetPush: (body: { design: Design; compile?: boolean; device_name?: string }) =>
+  fleetPush: (body: { design: Design; compile?: boolean; device_name?: string; strict?: boolean }) =>
     request<FleetPushResponse>("/fleet/push", {
       method: "POST",
       body: JSON.stringify(body),

--- a/web/src/components/BusList.test.tsx
+++ b/web/src/components/BusList.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * Component tests for BusList. Covers the surface that has non-trivial
+ * state: the rename draft (commit on blur, revert on Esc, reject on
+ * collision) and the inline compatibility-warning rendering.
+ *
+ * Render-only smoke tests (does the empty state appear, does the add
+ * button enqueue the right type) are intentionally light -- BusList is
+ * a thin presentation layer over the design.ts helpers, which already
+ * have full unit coverage.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { BusList } from "./BusList";
+import type { CompatibilityWarning, Design } from "../types/api";
+
+function makeDesign(overrides: Partial<Design> = {}): Design {
+  return {
+    schema_version: "0.1",
+    id: "t",
+    name: "t",
+    board: { library_id: "wemos-d1-mini", mcu: "esp8266" },
+    components: [
+      { id: "bme1", library_id: "bme280", label: "BME", params: {} },
+    ],
+    buses: [{ id: "i2c0", type: "i2c", sda: "D2", scl: "D1" }],
+    connections: [
+      { component_id: "bme1", pin_role: "SDA", target: { kind: "bus", bus_id: "i2c0" } },
+    ],
+    requirements: [],
+    warnings: [],
+    fleet: { device_name: "t", tags: [] },
+    ...overrides,
+  };
+}
+
+describe("BusList rendering", () => {
+  it("shows empty state when there are no buses", () => {
+    render(
+      <BusList
+        design={makeDesign({ buses: [] })}
+        gpioPins={["D1", "D2"]}
+        defaultBuses={{}}
+        compatibilityWarnings={[]}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("No buses.")).toBeInTheDocument();
+  });
+
+  it("renders one card per bus with id + type pill", () => {
+    render(
+      <BusList
+        design={makeDesign()}
+        gpioPins={["D1", "D2"]}
+        defaultBuses={{}}
+        compatibilityWarnings={[]}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByDisplayValue("i2c0")).toBeInTheDocument();
+    // The type pill is a <span> beside the id input. The add-bus type
+    // <select> also contains an "i2c" <option>, so disambiguate by tag.
+    const i2cMatches = screen.getAllByText("i2c");
+    expect(i2cMatches.some((n) => n.tagName === "SPAN")).toBe(true);
+  });
+});
+
+describe("BusList rename draft", () => {
+  it("commits on Enter and produces a renameBus call", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <BusList
+        design={makeDesign()}
+        gpioPins={["D1", "D2"]}
+        defaultBuses={{}}
+        compatibilityWarnings={[]}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByDisplayValue("i2c0") as HTMLInputElement;
+    await user.tripleClick(input);
+    await user.keyboard("shared_i2c{Enter}");
+
+    // onChange is called with an updater; apply it to a known-good design
+    // and verify the bus + targeting connection both follow the rename.
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updater = onChange.mock.calls[0][0] as (d: Design) => Design;
+    const next = updater(makeDesign());
+    expect((next.buses as Array<Record<string, unknown>>)[0].id).toBe("shared_i2c");
+    const conn = (next.connections as Array<{ target: { kind: string; bus_id?: string } }>)[0];
+    expect(conn.target.bus_id).toBe("shared_i2c");
+  });
+
+  it("reverts on Escape without firing onChange", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <BusList
+        design={makeDesign()}
+        gpioPins={["D1", "D2"]}
+        defaultBuses={{}}
+        compatibilityWarnings={[]}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByDisplayValue("i2c0") as HTMLInputElement;
+    await user.tripleClick(input);
+    await user.keyboard("shared_i2c{Escape}");
+    expect(input.value).toBe("i2c0");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("rejects a collision with another bus's id", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const design = makeDesign({
+      buses: [
+        { id: "i2c0", type: "i2c", sda: "D2", scl: "D1" },
+        { id: "spi0", type: "spi", clk: "D5" },
+      ],
+    });
+    render(
+      <BusList
+        design={design}
+        gpioPins={["D1", "D2", "D5"]}
+        defaultBuses={{}}
+        compatibilityWarnings={[]}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByDisplayValue("i2c0") as HTMLInputElement;
+    await user.tripleClick(input);
+    await user.keyboard("spi0");
+    // Trigger commit by tabbing away to blur.
+    await user.tab();
+    expect(onChange).not.toHaveBeenCalled();
+    // Field reverts to the canonical id.
+    expect(input.value).toBe("i2c0");
+  });
+
+  it("ignores a no-op rename to the same id", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <BusList
+        design={makeDesign()}
+        gpioPins={["D1", "D2"]}
+        defaultBuses={{}}
+        compatibilityWarnings={[]}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByDisplayValue("i2c0");
+    await user.click(input);
+    await user.tab();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("BusList inline compat warnings", () => {
+  const warning: CompatibilityWarning = {
+    severity: "warn",
+    code: "boot_strap_output",
+    pin: "GPIO5",
+    component_id: "spi0",
+    pin_role: "CLK",
+    message: "GPIO5 must be HIGH at boot.",
+  };
+
+  it("filters warnings to the matching bus card", () => {
+    const design = makeDesign({
+      buses: [
+        { id: "i2c0", type: "i2c", sda: "D2", scl: "D1" },
+        { id: "spi0", type: "spi", clk: "GPIO5" },
+      ],
+    });
+    render(
+      <BusList
+        design={design}
+        gpioPins={["D1", "D2", "GPIO5"]}
+        defaultBuses={{}}
+        compatibilityWarnings={[warning]}
+        onChange={() => {}}
+      />,
+    );
+    // Warning text appears once, under the spi0 card. Use the message as
+    // the search anchor since it's stable.
+    const found = screen.getByText(/GPIO5 must be HIGH at boot/i);
+    expect(found).toBeInTheDocument();
+  });
+
+  it("does not render a warning that doesn't match any bus", () => {
+    render(
+      <BusList
+        design={makeDesign()}
+        gpioPins={["D1", "D2"]}
+        defaultBuses={{}}
+        compatibilityWarnings={[
+          { ...warning, component_id: "ghost_bus" },
+        ]}
+        onChange={() => {}}
+      />,
+    );
+    expect(
+      screen.queryByText(/GPIO5 must be HIGH at boot/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/BusList.tsx
+++ b/web/src/components/BusList.tsx
@@ -23,7 +23,8 @@ const PIN_SLOTS_BY_TYPE: Record<BusType, string[]> = {
   spi:   ["clk", "miso", "mosi"],
   uart:  ["tx", "rx"],
   i2s:   ["lrclk", "bclk"],
-  "1wire": [],
+  // Single-pin 1-wire bus. Multiple slaves (DS18B20s, etc.) share it.
+  "1wire": ["pin"],
 };
 
 export function BusList({
@@ -184,11 +185,7 @@ function BusCard({
       </div>
 
       {slots.length === 0 ? (
-        <div className="text-[11px] text-zinc-500">
-          {type === "1wire"
-            ? "1-wire pin lives on each component's connection target, not on the bus."
-            : "no bus-level pins"}
-        </div>
+        <div className="text-[11px] text-zinc-500">no bus-level pins</div>
       ) : (
         <div className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-1">
           {slots.map((slot) => (

--- a/web/src/components/BusList.tsx
+++ b/web/src/components/BusList.tsx
@@ -4,14 +4,15 @@
  * for the type; removing leaves any connection targeting the bus
  * dangling (the inspector's render warnings surface that).
  */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   type BusType,
   addBus,
   removeBus,
+  renameBus,
   updateBus,
 } from "../lib/design";
-import type { Design } from "../types/api";
+import type { CompatibilityWarning, Design } from "../types/api";
 
 const ALL_BUS_TYPES: BusType[] = ["i2c", "spi", "uart", "i2s", "1wire"];
 
@@ -26,7 +27,7 @@ const PIN_SLOTS_BY_TYPE: Record<BusType, string[]> = {
 };
 
 export function BusList({
-  design, gpioPins, defaultBuses, onChange,
+  design, gpioPins, defaultBuses, compatibilityWarnings, onChange,
 }: {
   design: Design;
   /** Pin names from the current board's gpio_capabilities, used to populate
@@ -36,6 +37,9 @@ export function BusList({
   /** board.default_buses if any -- used when adding a fresh bus so I2C
    *  lands on the board's canonical SDA/SCL out of the box. */
   defaultBuses: Record<string, Record<string, string>>;
+  /** Whole-design compat warnings; bus warnings carry the bus id in
+   *  `component_id`, so the card filters down to its own. */
+  compatibilityWarnings: CompatibilityWarning[];
   onChange: (updater: (d: Design) => Design) => void;
 }) {
   const buses = ((design.buses as Array<Record<string, unknown>> | undefined) ?? []).map((b) => ({
@@ -43,6 +47,7 @@ export function BusList({
     type: String(b.type) as BusType,
     raw: b,
   }));
+  const allBusIds = new Set(buses.map((b) => b.id));
 
   const [pickedType, setPickedType] = useState<BusType>("i2c");
 
@@ -58,6 +63,9 @@ export function BusList({
                 bus={b.raw}
                 type={b.type}
                 gpioPins={gpioPins}
+                warnings={compatibilityWarnings.filter((w) => w.component_id === b.id)}
+                otherBusIds={new Set([...allBusIds].filter((x) => x !== b.id))}
+                onRename={(newId) => onChange((d) => renameBus(d, b.id, newId))}
                 onChange={(patch) => onChange((d) => updateBus(d, b.id, patch))}
                 onRemove={() => onChange((d) => removeBus(d, b.id))}
               />
@@ -89,11 +97,16 @@ export function BusList({
 }
 
 function BusCard({
-  bus, type, gpioPins, onChange, onRemove,
+  bus, type, gpioPins, warnings, otherBusIds, onRename, onChange, onRemove,
 }: {
   bus: Record<string, unknown>;
   type: BusType;
   gpioPins: string[];
+  warnings: CompatibilityWarning[];
+  /** Ids of every other bus in the design; used to refuse a rename that
+   *  would collide. */
+  otherBusIds: Set<string>;
+  onRename: (newId: string) => void;
   onChange: (patch: Partial<Record<string, unknown>>) => void;
   onRemove: () => void;
 }) {
@@ -102,15 +115,56 @@ function BusCard({
   const freq = bus.frequency_hz as number | undefined;
   const baud = bus.baud_rate as number | undefined;
 
+  // Local draft id while the user is typing. We commit on blur or Enter
+  // so an intermediate value like "i" or "" doesn't tear the connections
+  // table apart. The effect below resyncs the draft when the canonical
+  // id changes from outside (e.g., a render-driven design refresh).
+  const [draftId, setDraftId] = useState(id);
+  useEffect(() => { setDraftId(id); }, [id]);
+
+  function commitRename() {
+    const next = draftId.trim();
+    if (next === "" || next === id || otherBusIds.has(next)) {
+      // Reject and revert -- the caller's onRename guards against the
+      // collision case anyway, but we want to clear the visual drift.
+      setDraftId(id);
+      return;
+    }
+    onRename(next);
+  }
+
+  const draftDirty = draftId.trim() !== id;
+  const draftCollides = otherBusIds.has(draftId.trim());
+
   return (
     <div className="rounded border border-zinc-800 bg-zinc-900/30 p-2">
       <div className="mb-1.5 flex items-center justify-between gap-2">
         <div className="flex items-baseline gap-2">
           <input
             type="text"
-            value={id}
-            onChange={(e) => onChange({ id: e.target.value })}
-            className="w-28 rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 font-mono text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
+            value={draftId}
+            onChange={(e) => setDraftId(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.currentTarget.blur();
+              } else if (e.key === "Escape") {
+                setDraftId(id);
+                e.currentTarget.blur();
+              }
+            }}
+            title={
+              draftCollides
+                ? `Another bus already uses '${draftId.trim()}'.`
+                : "Press Enter or click away to apply. Esc to revert."
+            }
+            className={`w-28 rounded border bg-zinc-950 px-1.5 py-0.5 font-mono text-xs focus:outline-none ${
+              draftCollides
+                ? "border-red-500/50 text-red-200 focus:border-red-500"
+                : draftDirty
+                  ? "border-amber-500/50 text-amber-100 focus:border-amber-400"
+                  : "border-zinc-800 text-zinc-100 focus:border-zinc-600"
+            }`}
           />
           <span className="rounded border border-zinc-800 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-zinc-400">
             {type}
@@ -163,6 +217,26 @@ function BusCard({
             className="w-32 rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
           />
         </div>
+      )}
+
+      {warnings.length > 0 && (
+        <ul className="mt-1.5 space-y-0.5">
+          {warnings.map((w, i) => (
+            <li
+              key={`${w.code}:${w.pin_role}:${i}`}
+              className={`rounded px-1.5 py-1 text-[10px] leading-snug ${
+                w.severity === "error"
+                  ? "border border-red-700/50 bg-red-900/20 text-red-200"
+                  : w.severity === "warn"
+                    ? "border border-amber-700/40 bg-amber-900/15 text-amber-200"
+                    : "border border-zinc-700/50 bg-zinc-900/40 text-zinc-300"
+              }`}
+              title={w.code}
+            >
+              <span className="font-mono">{w.pin_role}@{w.pin}</span> · {w.message}
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/web/src/components/BusList.tsx
+++ b/web/src/components/BusList.tsx
@@ -1,0 +1,204 @@
+/**
+ * Per-type bus editor. Renders one card per bus, with editable id and
+ * pin slots that vary by bus type. Adding a bus opens a tiny picker
+ * for the type; removing leaves any connection targeting the bus
+ * dangling (the inspector's render warnings surface that).
+ */
+import { useState } from "react";
+import {
+  type BusType,
+  addBus,
+  removeBus,
+  updateBus,
+} from "../lib/design";
+import type { Design } from "../types/api";
+
+const ALL_BUS_TYPES: BusType[] = ["i2c", "spi", "uart", "i2s", "1wire"];
+
+// Pin slots that live on the bus itself for each type. Per-component pins
+// (SPI cs, I2S DOUT/DIN) are not bus-level state and aren't shown here.
+const PIN_SLOTS_BY_TYPE: Record<BusType, string[]> = {
+  i2c:   ["sda", "scl"],
+  spi:   ["clk", "miso", "mosi"],
+  uart:  ["tx", "rx"],
+  i2s:   ["lrclk", "bclk"],
+  "1wire": [],
+};
+
+export function BusList({
+  design, gpioPins, defaultBuses, onChange,
+}: {
+  design: Design;
+  /** Pin names from the current board's gpio_capabilities, used to populate
+   *  the pin selector dropdowns. Empty when no board is loaded -- the
+   *  fields fall back to free-text input. */
+  gpioPins: string[];
+  /** board.default_buses if any -- used when adding a fresh bus so I2C
+   *  lands on the board's canonical SDA/SCL out of the box. */
+  defaultBuses: Record<string, Record<string, string>>;
+  onChange: (updater: (d: Design) => Design) => void;
+}) {
+  const buses = ((design.buses as Array<Record<string, unknown>> | undefined) ?? []).map((b) => ({
+    id: String(b.id),
+    type: String(b.type) as BusType,
+    raw: b,
+  }));
+
+  const [pickedType, setPickedType] = useState<BusType>("i2c");
+
+  return (
+    <div className="space-y-2">
+      {buses.length === 0 ? (
+        <div className="text-xs text-zinc-500">No buses.</div>
+      ) : (
+        <ul className="space-y-2">
+          {buses.map((b) => (
+            <li key={b.id}>
+              <BusCard
+                bus={b.raw}
+                type={b.type}
+                gpioPins={gpioPins}
+                onChange={(patch) => onChange((d) => updateBus(d, b.id, patch))}
+                onRemove={() => onChange((d) => removeBus(d, b.id))}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex items-center gap-2">
+        <select
+          value={pickedType}
+          onChange={(e) => setPickedType(e.target.value as BusType)}
+          className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
+        >
+          {ALL_BUS_TYPES.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+        <button
+          onClick={() => onChange((d) => addBus(d, pickedType, defaultBuses[pickedType]))}
+          className="rounded border border-zinc-800 px-2 py-0.5 text-xs text-zinc-300 hover:bg-zinc-900"
+          title={`Add a ${pickedType} bus${defaultBuses[pickedType] ? " on the board's defaults" : ""}`}
+        >
+          + add bus
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function BusCard({
+  bus, type, gpioPins, onChange, onRemove,
+}: {
+  bus: Record<string, unknown>;
+  type: BusType;
+  gpioPins: string[];
+  onChange: (patch: Partial<Record<string, unknown>>) => void;
+  onRemove: () => void;
+}) {
+  const slots = PIN_SLOTS_BY_TYPE[type];
+  const id = String(bus.id);
+  const freq = bus.frequency_hz as number | undefined;
+  const baud = bus.baud_rate as number | undefined;
+
+  return (
+    <div className="rounded border border-zinc-800 bg-zinc-900/30 p-2">
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <div className="flex items-baseline gap-2">
+          <input
+            type="text"
+            value={id}
+            onChange={(e) => onChange({ id: e.target.value })}
+            className="w-28 rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 font-mono text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
+          />
+          <span className="rounded border border-zinc-800 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-zinc-400">
+            {type}
+          </span>
+        </div>
+        <button
+          onClick={onRemove}
+          title={`Remove ${id}`}
+          className="rounded border border-zinc-800 px-1.5 py-0.5 text-xs text-zinc-500 transition-colors hover:border-red-500/40 hover:bg-red-500/10 hover:text-red-300"
+        >
+          ✕
+        </button>
+      </div>
+
+      {slots.length === 0 ? (
+        <div className="text-[11px] text-zinc-500">
+          {type === "1wire"
+            ? "1-wire pin lives on each component's connection target, not on the bus."
+            : "no bus-level pins"}
+        </div>
+      ) : (
+        <div className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-1">
+          {slots.map((slot) => (
+            <PinField
+              key={slot}
+              label={slot}
+              value={(bus[slot] as string | undefined) ?? ""}
+              gpioPins={gpioPins}
+              onChange={(v) => onChange({ [slot]: v || undefined })}
+            />
+          ))}
+        </div>
+      )}
+
+      {(type === "i2c" || type === "uart") && (
+        <div className="mt-1.5 grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-1">
+          <span className="w-16 text-[11px] text-zinc-500">
+            {type === "uart" ? "baud" : "freq Hz"}
+          </span>
+          <input
+            type="number"
+            value={type === "uart" ? (baud ?? "") : (freq ?? "")}
+            onChange={(e) => {
+              const raw = e.target.value;
+              const n = raw === "" ? undefined : parseInt(raw, 10);
+              if (n !== undefined && Number.isNaN(n)) return;
+              onChange(type === "uart" ? { baud_rate: n } : { frequency_hz: n });
+            }}
+            placeholder={type === "uart" ? "9600" : "100000"}
+            className="w-32 rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PinField({
+  label, value, gpioPins, onChange,
+}: {
+  label: string;
+  value: string;
+  gpioPins: string[];
+  onChange: (v: string) => void;
+}) {
+  const inOptions = gpioPins.includes(value);
+  return (
+    <>
+      <span className="text-[11px] uppercase tracking-wide text-zinc-500">{label}</span>
+      {gpioPins.length > 0 ? (
+        <select
+          value={inOptions ? value : ""}
+          onChange={(e) => onChange(e.target.value)}
+          className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
+        >
+          <option value="">(unset{!inOptions && value ? `: ${value}` : ""})</option>
+          {gpioPins.map((p) => (
+            <option key={p} value={p}>{p}</option>
+          ))}
+        </select>
+      ) : (
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
+        />
+      )}
+    </>
+  );
+}

--- a/web/src/components/BusList.tsx
+++ b/web/src/components/BusList.tsx
@@ -147,10 +147,14 @@ function BusCard({
             onBlur={commitRename}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
+                // commitRename runs from onBlur; this just triggers the blur.
                 e.currentTarget.blur();
               } else if (e.key === "Escape") {
+                // Reset the draft and bail out without blurring -- blurring
+                // here would race the queued state reset and the stale
+                // draftId would slip through commitRename as a real rename.
                 setDraftId(id);
-                e.currentTarget.blur();
+                e.preventDefault();
               }
             }}
             title={

--- a/web/src/components/CapabilityPickerDialog.test.tsx
+++ b/web/src/components/CapabilityPickerDialog.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * Component tests for CapabilityPickerDialog. Focused on the surface
+ * with state machinery: the alternatives disclosure (one open at a
+ * time, score delta sign + emerald tint when an alternative beats
+ * the row's score) and the bus filter's hide-then-show transition.
+ *
+ * The recommend / use_cases endpoints are mocked at the api boundary;
+ * we don't exercise the network or the recommender ranker here.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CapabilityPickerDialog } from "./CapabilityPickerDialog";
+import { api } from "../api/client";
+import type { Recommendation } from "../types/api";
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listUseCases: vi.fn(),
+      recommend: vi.fn(),
+    },
+  };
+});
+
+const mockApi = api as unknown as {
+  listUseCases: ReturnType<typeof vi.fn>;
+  recommend: ReturnType<typeof vi.fn>;
+};
+
+function recommendation(over: Partial<Recommendation>): Recommendation {
+  return {
+    library_id: over.library_id ?? "x",
+    name: over.name ?? "X",
+    category: over.category ?? "sensor",
+    use_cases: over.use_cases ?? [],
+    aliases: over.aliases ?? [],
+    required_components: over.required_components ?? [],
+    current_ma_typical: over.current_ma_typical ?? null,
+    current_ma_peak: over.current_ma_peak ?? null,
+    vcc_min: over.vcc_min ?? null,
+    vcc_max: over.vcc_max ?? null,
+    score: over.score ?? 0,
+    in_examples: over.in_examples ?? 0,
+    rationale: over.rationale ?? "",
+    notes: over.notes ?? null,
+  };
+}
+
+beforeEach(() => {
+  mockApi.listUseCases.mockReset();
+  mockApi.recommend.mockReset();
+  mockApi.listUseCases.mockResolvedValue([
+    { use_case: "temperature", count: 1, example_components: ["bme280"] },
+  ]);
+});
+
+describe("alternatives disclosure", () => {
+  it("renders an N-alternatives toggle for every match when there are multiple", async () => {
+    mockApi.recommend.mockResolvedValue({
+      query: "temperature",
+      matches: [
+        recommendation({ library_id: "bme280", name: "BME280", score: 12 }),
+        recommendation({ library_id: "dht22", name: "DHT22", score: 8 }),
+        recommendation({ library_id: "ds18b20", name: "DS18B20", score: 6 }),
+      ],
+    });
+    render(
+      <CapabilityPickerDialog
+        designReady
+        designBusTypes={[]}
+        onAdd={async () => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    // Pick the temperature capability on the left to trigger recommend.
+    await waitFor(() => screen.getByText("temperature"));
+    await userEvent.click(screen.getByText("temperature"));
+
+    // Three rows -> each one has "2 alternatives" (the other two).
+    await waitFor(() => {
+      expect(screen.getAllByText(/2 alternatives/i).length).toBe(3);
+    });
+  });
+
+  it("expands a single row at a time and shows the score delta with sign", async () => {
+    mockApi.recommend.mockResolvedValue({
+      query: "temperature",
+      matches: [
+        recommendation({ library_id: "bme280", name: "BME280", score: 12 }),
+        recommendation({ library_id: "dht22", name: "DHT22", score: 8 }),
+      ],
+    });
+    render(
+      <CapabilityPickerDialog
+        designReady
+        designBusTypes={[]}
+        onAdd={async () => {}}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("temperature"));
+    await userEvent.click(screen.getByText("temperature"));
+    await waitFor(() => screen.getByText("BME280"));
+
+    // Expand the top row (BME280, score 12). The collapsed-state toggle
+    // text is "▸ 1 alternative"; clicking it flips to "▾".
+    const toggles = screen.getAllByRole("button", { name: /1 alternative/i });
+    await userEvent.click(toggles[0]);
+
+    // The expanded panel lists the OTHER match (DHT22) with the score
+    // delta. -4 < 0 so the delta should render in the muted (zinc-600)
+    // colour, not emerald.
+    const delta = screen.getByText(/\(-4\.0\)/);
+    expect(delta).toBeInTheDocument();
+    expect(delta).toHaveClass("text-zinc-600");
+  });
+
+  it("collapses the previously expanded row when a new one is opened", async () => {
+    mockApi.recommend.mockResolvedValue({
+      query: "temperature",
+      matches: [
+        recommendation({ library_id: "bme280", name: "BME280", score: 12 }),
+        recommendation({ library_id: "dht22", name: "DHT22", score: 8 }),
+      ],
+    });
+    render(
+      <CapabilityPickerDialog
+        designReady
+        designBusTypes={[]}
+        onAdd={async () => {}}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("temperature"));
+    await userEvent.click(screen.getByText("temperature"));
+    await waitFor(() => screen.getByText("BME280"));
+
+    const toggles = screen.getAllByRole("button", { name: /1 alternative/i });
+    await userEvent.click(toggles[0]);
+    await userEvent.click(toggles[1]);
+
+    // Only one toggle reports aria-expanded=true at any time.
+    const expanded = toggles.filter(
+      (b) => b.getAttribute("aria-expanded") === "true",
+    );
+    expect(expanded).toHaveLength(1);
+    // And it's the second one (DHT22's alternatives panel).
+    expect(expanded[0]).toBe(toggles[1]);
+  });
+
+  it("uses an emerald-tinted delta when the alternative beats the row's score", async () => {
+    // This case is contrived (the recommender returns sorted-desc), but the
+    // UI doesn't *enforce* sort order, so the rendering branch is real.
+    mockApi.recommend.mockResolvedValue({
+      query: "temperature",
+      matches: [
+        recommendation({ library_id: "low", name: "Low", score: 5 }),
+        recommendation({ library_id: "high", name: "High", score: 10 }),
+      ],
+    });
+    render(
+      <CapabilityPickerDialog
+        designReady
+        designBusTypes={[]}
+        onAdd={async () => {}}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("temperature"));
+    await userEvent.click(screen.getByText("temperature"));
+    await waitFor(() => screen.getByText("Low"));
+
+    // Expand the first (Low, 5) row. Its alternative is High (10), delta +5.
+    const toggles = screen.getAllByRole("button", { name: /1 alternative/i });
+    await userEvent.click(toggles[0]);
+    const delta = screen.getByText(/\(\+5\.0\)/);
+    expect(delta).toBeInTheDocument();
+    expect(delta).toHaveClass("text-emerald-300");
+  });
+});
+
+describe("bus filter integration", () => {
+  it("hides matches that need a bus the design lacks and surfaces a counter", async () => {
+    mockApi.recommend.mockResolvedValue({
+      query: "temperature",
+      matches: [
+        recommendation({
+          library_id: "bme280", name: "BME280", score: 12,
+          required_components: ["i2c", "decoupling_caps"],
+        }),
+        recommendation({
+          library_id: "spi-temp", name: "SPI Temp", score: 9,
+          required_components: ["spi"],
+        }),
+      ],
+    });
+    render(
+      <CapabilityPickerDialog
+        designReady
+        designBusTypes={["i2c"]}
+        onAdd={async () => {}}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("temperature"));
+    await userEvent.click(screen.getByText("temperature"));
+    await waitFor(() => screen.getByText("BME280"));
+
+    // SPI part filtered out, hidden-counter shown, BME280 still listed.
+    expect(screen.queryByText("SPI Temp")).not.toBeInTheDocument();
+    expect(screen.getByText(/1 hidden by the bus filter/i)).toBeInTheDocument();
+  });
+
+  it("re-shows hidden matches when the user unchecks the filter", async () => {
+    mockApi.recommend.mockResolvedValue({
+      query: "temperature",
+      matches: [
+        recommendation({
+          library_id: "spi-temp", name: "SPI Temp", score: 9,
+          required_components: ["spi"],
+        }),
+      ],
+    });
+    render(
+      <CapabilityPickerDialog
+        designReady
+        designBusTypes={["i2c"]}
+        onAdd={async () => {}}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("temperature"));
+    await userEvent.click(screen.getByText("temperature"));
+    await waitFor(() =>
+      screen.getByText(/1 match.*hidden by the bus filter/i),
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: /match my buses/i });
+    await userEvent.click(checkbox);
+    expect(screen.getByText("SPI Temp")).toBeInTheDocument();
+  });
+});
+
+describe("Add interaction", () => {
+  it("calls onAdd with the library_id and shows the Added affirmation", async () => {
+    mockApi.recommend.mockResolvedValue({
+      query: "temperature",
+      matches: [recommendation({ library_id: "bme280", name: "BME280", score: 12 })],
+    });
+    const onAdd = vi.fn().mockResolvedValue(undefined);
+    render(
+      <CapabilityPickerDialog
+        designReady
+        designBusTypes={[]}
+        onAdd={onAdd}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("temperature"));
+    await userEvent.click(screen.getByText("temperature"));
+    await waitFor(() => screen.getByText("BME280"));
+
+    const row = screen.getByText("BME280").closest("li") as HTMLElement;
+    const addButton = within(row).getByRole("button", { name: /^Add$/ });
+    await userEvent.click(addButton);
+
+    expect(onAdd).toHaveBeenCalledWith("bme280");
+    await waitFor(() =>
+      expect(within(row).getByText(/Added/)).toBeInTheDocument(),
+    );
+  });
+});

--- a/web/src/components/CapabilityPickerDialog.tsx
+++ b/web/src/components/CapabilityPickerDialog.tsx
@@ -40,6 +40,10 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
   const [adding, setAdding] = useState<string | null>(null); // library_id mid-add
   const [added, setAdded] = useState<Set<string>>(new Set());
   const [filterByBuses, setFilterByBuses] = useState<boolean>(true);
+  /** library_id of the match whose "alternatives" disclosure is open. Only
+   *  one expansion at a time -- a single open panel keeps the list compact
+   *  and avoids the user having to scroll past several stacked panels. */
+  const [expandedAlts, setExpandedAlts] = useState<string | null>(null);
 
   const designBusSet = useMemo(() => new Set(designBusTypes), [designBusTypes]);
 
@@ -276,6 +280,8 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
                       {visible.map((m, idx) => {
                     const isAdded = added.has(m.library_id);
                     const isAdding = adding === m.library_id;
+                    const alternatives = visible.filter((alt) => alt.library_id !== m.library_id);
+                    const altsOpen = expandedAlts === m.library_id;
                     return (
                       <li
                         key={m.library_id}
@@ -312,6 +318,55 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
                                 </span>
                               )}
                             </div>
+                            {alternatives.length > 0 && (
+                              <button
+                                type="button"
+                                onClick={() => setExpandedAlts(altsOpen ? null : m.library_id)}
+                                aria-expanded={altsOpen}
+                                className="mt-1 text-[11px] text-zinc-500 hover:text-zinc-300"
+                              >
+                                {altsOpen ? "▾" : "▸"} {alternatives.length} alternative
+                                {alternatives.length === 1 ? "" : "s"}
+                              </button>
+                            )}
+                            {altsOpen && (
+                              <ul className="mt-1 space-y-0.5 border-l border-zinc-800 pl-2">
+                                {alternatives.map((alt) => (
+                                  <li
+                                    key={alt.library_id}
+                                    className="flex items-baseline justify-between gap-2 text-[11px]"
+                                  >
+                                    <span className="min-w-0 truncate">
+                                      <span className="text-zinc-300">{alt.name}</span>
+                                      <code className="ml-1 text-zinc-500">{alt.library_id}</code>
+                                      {alt.required_components.length > 0 && (
+                                        <span className="ml-1 text-zinc-500">
+                                          · {alt.required_components.join(", ")}
+                                        </span>
+                                      )}
+                                      {alt.current_ma_peak != null && (
+                                        <span className="ml-1 text-zinc-500">
+                                          · {alt.current_ma_peak}mA
+                                        </span>
+                                      )}
+                                    </span>
+                                    <span className="shrink-0 text-zinc-500">
+                                      score {alt.score}{" "}
+                                      <span
+                                        className={
+                                          alt.score < m.score
+                                            ? "text-zinc-600"
+                                            : "text-emerald-300"
+                                        }
+                                      >
+                                        ({alt.score >= m.score ? "+" : ""}
+                                        {(alt.score - m.score).toFixed(1)})
+                                      </span>
+                                    </span>
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
                           </div>
                           <div className="flex shrink-0 flex-col items-end gap-1">
                             <span className="text-[10px] text-zinc-500">score {m.score}</span>

--- a/web/src/components/CapabilityPickerDialog.tsx
+++ b/web/src/components/CapabilityPickerDialog.tsx
@@ -6,9 +6,17 @@ interface Props {
   /** True when the design has a board picked. We disable Add when there's
    *  no design yet because handleAddComponent needs board context. */
   designReady: boolean;
+  /** Bus types already present on the design (e.g., ["i2c"], ["i2c", "spi"]).
+   *  Drives the "match my buses" filter so an I2C-only design doesn't
+   *  surface an SPI-only sensor in the top-pick slot. */
+  designBusTypes: string[];
   onAdd: (libraryId: string) => Promise<void> | void;
   onClose: () => void;
 }
+
+const BUS_REQUIREMENT_KEYS: ReadonlySet<string> = new Set([
+  "i2c", "spi", "uart", "i2s", "1wire",
+]);
 
 /**
  * "Add by function" picker. Two columns:
@@ -22,7 +30,7 @@ interface Props {
  * /library/recommend for the ranking. The latter is the same endpoint
  * the agent uses; this dialog just exposes it to the human.
  */
-export function CapabilityPickerDialog({ designReady, onAdd, onClose }: Props) {
+export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onClose }: Props) {
   const [useCases, setUseCases] = useState<UseCaseEntry[] | null>(null);
   const [pickedCapability, setPickedCapability] = useState<string>("");
   const [freeText, setFreeText] = useState<string>("");
@@ -31,6 +39,24 @@ export function CapabilityPickerDialog({ designReady, onAdd, onClose }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [adding, setAdding] = useState<string | null>(null); // library_id mid-add
   const [added, setAdded] = useState<Set<string>>(new Set());
+  const [filterByBuses, setFilterByBuses] = useState<boolean>(true);
+
+  const designBusSet = useMemo(() => new Set(designBusTypes), [designBusTypes]);
+
+  /**
+   * Drop matches that require a bus the design doesn't already have. Library
+   * components advertise these via `required_components` (e.g., "i2c", "spi");
+   * non-bus tokens like "decoupling_caps" are passed through untouched.
+   */
+  function passesBusFilter(rec: Recommendation): boolean {
+    if (!filterByBuses) return true;
+    for (const req of rec.required_components) {
+      if (BUS_REQUIREMENT_KEYS.has(req) && !designBusSet.has(req)) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   // Bootstrap the use-case list.
   useEffect(() => {
@@ -179,14 +205,30 @@ export function CapabilityPickerDialog({ designReady, onAdd, onClose }: Props) {
 
           {/* Right: ranked results */}
           <div className="flex min-h-0 flex-col">
-            <div className="border-b border-zinc-800 px-4 py-2 text-xs text-zinc-400">
-              {activeQuery ? (
-                <span>
-                  matches for{" "}
-                  <code className="rounded bg-zinc-800 px-1 text-zinc-100">{activeQuery}</code>
-                </span>
-              ) : (
-                <span>pick a capability or enter free text on the left</span>
+            <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-2 text-xs text-zinc-400">
+              <span>
+                {activeQuery ? (
+                  <>
+                    matches for{" "}
+                    <code className="rounded bg-zinc-800 px-1 text-zinc-100">{activeQuery}</code>
+                  </>
+                ) : (
+                  <>pick a capability or enter free text on the left</>
+                )}
+              </span>
+              {designBusTypes.length > 0 && (
+                <label
+                  className="flex shrink-0 cursor-pointer items-center gap-1 text-[11px] text-zinc-400 hover:text-zinc-200"
+                  title={`Hide matches that need a bus your design lacks (current: ${designBusTypes.join(", ")})`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={filterByBuses}
+                    onChange={(e) => setFilterByBuses(e.target.checked)}
+                    className="h-3 w-3"
+                  />
+                  match my buses ({designBusTypes.join("/")})
+                </label>
               )}
             </div>
             <div className="flex-1 overflow-y-auto p-3">
@@ -200,16 +242,38 @@ export function CapabilityPickerDialog({ designReady, onAdd, onClose }: Props) {
                   {error}
                 </div>
               )}
-              {loadingMatches ? (
-                <div className="text-xs text-zinc-500">searching…</div>
-              ) : !activeQuery ? null : matches === null || matches.length === 0 ? (
-                <div className="text-xs text-zinc-500">
-                  no library components match{" "}
-                  <code className="rounded bg-zinc-800 px-1">{activeQuery}</code>.
-                </div>
-              ) : (
-                <ul className="space-y-2">
-                  {matches.map((m, idx) => {
+              {(() => {
+                if (loadingMatches) {
+                  return <div className="text-xs text-zinc-500">searching…</div>;
+                }
+                if (!activeQuery) return null;
+                if (!matches || matches.length === 0) {
+                  return (
+                    <div className="text-xs text-zinc-500">
+                      no library components match{" "}
+                      <code className="rounded bg-zinc-800 px-1">{activeQuery}</code>.
+                    </div>
+                  );
+                }
+                const visible = matches.filter(passesBusFilter);
+                const hiddenByFilter = matches.length - visible.length;
+                if (visible.length === 0) {
+                  return (
+                    <div className="text-xs text-zinc-500">
+                      {hiddenByFilter} match{hiddenByFilter === 1 ? "" : "es"} hidden
+                      by the bus filter. Uncheck "match my buses" to see them.
+                    </div>
+                  );
+                }
+                return (
+                  <>
+                    {hiddenByFilter > 0 && (
+                      <div className="mb-2 text-[11px] text-zinc-500">
+                        {hiddenByFilter} hidden by the bus filter.
+                      </div>
+                    )}
+                    <ul className="space-y-2">
+                      {visible.map((m, idx) => {
                     const isAdded = added.has(m.library_id);
                     const isAdding = adding === m.library_id;
                     return (
@@ -267,8 +331,10 @@ export function CapabilityPickerDialog({ designReady, onAdd, onClose }: Props) {
                       </li>
                     );
                   })}
-                </ul>
-              )}
+                    </ul>
+                  </>
+                );
+              })()}
             </div>
           </div>
         </div>

--- a/web/src/components/ConnectionForm.test.tsx
+++ b/web/src/components/ConnectionForm.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Component tests for ConnectionForm. Focused on the per-row LockToggle
+ * (3-state machine with divergence indicator), since the rest of the
+ * form is a thin shim over <select>/<input>.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ConnectionForm } from "./ConnectionForm";
+import type { ConnectionRow } from "../lib/design";
+import type { Design } from "../types/api";
+
+function makeDesign(): Design {
+  return {
+    schema_version: "0.1",
+    id: "t",
+    name: "t",
+    board: { library_id: "wemos-d1-mini", mcu: "esp8266" },
+    components: [],
+    buses: [],
+    connections: [],
+    requirements: [],
+    warnings: [],
+  } as Design;
+}
+
+const board = {
+  rails: [{ name: "5V", voltage: 5 }, { name: "GND", voltage: 0 }],
+  gpio_capabilities: { D5: ["gpio"], D6: ["gpio"], D7: ["gpio"] },
+};
+
+function gpioRow(over: Partial<ConnectionRow> = {}): ConnectionRow {
+  return {
+    index: 0,
+    component_id: "c1",
+    pin_role: "OUT",
+    target: { kind: "gpio", pin: "D5" },
+    locked_pin: null,
+    ...over,
+  };
+}
+
+describe("LockToggle", () => {
+  it("shows '🔓 lock' when no lock is set and the pin is bound", () => {
+    render(
+      <ConnectionForm
+        rows={[gpioRow()]}
+        design={makeDesign()}
+        boardData={board}
+        libraryComponents={[]}
+        onChange={() => {}}
+        onLockedPinChange={() => {}}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /lock/ });
+    expect(btn).toHaveTextContent("🔓 lock");
+    expect(btn).not.toBeDisabled();
+  });
+
+  it("disables the lock button when no pin is bound yet", () => {
+    render(
+      <ConnectionForm
+        rows={[gpioRow({ target: { kind: "gpio", pin: "" } })]}
+        design={makeDesign()}
+        boardData={board}
+        libraryComponents={[]}
+        onChange={() => {}}
+        onLockedPinChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /lock/ })).toBeDisabled();
+  });
+
+  it("calls onLockedPinChange with the bound pin when the user clicks lock", async () => {
+    const onLockedPinChange = vi.fn();
+    render(
+      <ConnectionForm
+        rows={[gpioRow()]}
+        design={makeDesign()}
+        boardData={board}
+        libraryComponents={[]}
+        onChange={() => {}}
+        onLockedPinChange={onLockedPinChange}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /lock/ }));
+    expect(onLockedPinChange).toHaveBeenCalledWith("c1", "OUT", "D5");
+  });
+
+  it("shows the locked badge in the in-sync state and clicking it clears the lock", async () => {
+    const onLockedPinChange = vi.fn();
+    render(
+      <ConnectionForm
+        rows={[gpioRow({ locked_pin: "D5" })]}
+        design={makeDesign()}
+        boardData={board}
+        libraryComponents={[]}
+        onChange={() => {}}
+        onLockedPinChange={onLockedPinChange}
+      />,
+    );
+    const badge = screen.getByRole("button", { name: /D5/i });
+    expect(badge).toHaveTextContent("🔒 D5");
+    expect(badge).toHaveClass("border-emerald-600/50");
+    expect(screen.queryByText(/will flag a mismatch/i)).not.toBeInTheDocument();
+    await userEvent.click(badge);
+    expect(onLockedPinChange).toHaveBeenCalledWith("c1", "OUT", null);
+  });
+
+  it("renders the diverged variant + inline mismatch hint when bound pin differs from lock", () => {
+    render(
+      <ConnectionForm
+        rows={[gpioRow({ target: { kind: "gpio", pin: "D7" }, locked_pin: "D5" })]}
+        design={makeDesign()}
+        boardData={board}
+        libraryComponents={[]}
+        onChange={() => {}}
+        onLockedPinChange={() => {}}
+      />,
+    );
+    const badge = screen.getByRole("button", { name: /D5/i });
+    expect(badge).toHaveTextContent("🔒 D5");
+    expect(badge).toHaveClass("border-amber-600/50");
+    // The inline warning appears below the row.
+    expect(screen.getByText(/solver will flag a mismatch/i)).toBeInTheDocument();
+    // And mentions both pins.
+    expect(screen.getByText(/locked to/i).textContent).toMatch(/D5/);
+    expect(screen.getByText(/locked to/i).textContent).toMatch(/D7/);
+  });
+});
+
+describe("ConnectionForm row routing", () => {
+  it("does not render the LockToggle for non-gpio targets", () => {
+    render(
+      <ConnectionForm
+        rows={[
+          {
+            index: 0,
+            component_id: "c1",
+            pin_role: "VCC",
+            target: { kind: "rail", rail: "5V" },
+            locked_pin: null,
+          },
+        ]}
+        design={makeDesign()}
+        boardData={board}
+        libraryComponents={[]}
+        onChange={() => {}}
+        onLockedPinChange={() => {}}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /lock/ })).not.toBeInTheDocument();
+  });
+
+  it("renders a friendly empty state when there are no connections", () => {
+    render(
+      <ConnectionForm
+        rows={[]}
+        design={makeDesign()}
+        boardData={board}
+        libraryComponents={[]}
+        onChange={() => {}}
+        onLockedPinChange={() => {}}
+      />,
+    );
+    expect(screen.getByText(/no connections/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ConnectionForm.tsx
+++ b/web/src/components/ConnectionForm.tsx
@@ -16,7 +16,7 @@ import {
 import type { Design } from "../types/api";
 
 type Kind = ConnectionTarget["kind"];
-const KINDS: Kind[] = ["rail", "gpio", "bus", "expander_pin"];
+const KINDS: Kind[] = ["rail", "gpio", "bus", "expander_pin", "component"];
 
 interface Props {
   rows: ConnectionRow[];
@@ -40,6 +40,9 @@ export function ConnectionForm({
   const gpioPins = Object.keys((board.gpio_capabilities ?? {}) as Record<string, unknown>);
   const buses = readBuses(design);
   const expanders = expandersFromDesign(design, libraryComponents);
+  const componentInstances = readComponents(design).map((c) => ({
+    id: c.id, library_id: c.library_id,
+  }));
 
   return (
     <div className="space-y-2">
@@ -51,6 +54,7 @@ export function ConnectionForm({
           gpioPins={gpioPins}
           buses={buses}
           expanders={expanders}
+          componentInstances={componentInstances}
           onChange={(t) => onChange(row.index, t)}
           onLockedPinChange={(pin) => onLockedPinChange(row.component_id, row.pin_role, pin)}
         />
@@ -60,13 +64,15 @@ export function ConnectionForm({
 }
 
 function Row({
-  row, railNames, gpioPins, buses, expanders, onChange, onLockedPinChange,
+  row, railNames, gpioPins, buses, expanders, componentInstances,
+  onChange, onLockedPinChange,
 }: {
   row: ConnectionRow;
   railNames: string[];
   gpioPins: string[];
   buses: { id: string; type: string }[];
   expanders: { id: string; library_id: string }[];
+  componentInstances: { id: string; library_id: string }[];
   onChange: (t: ConnectionTarget) => void;
   onLockedPinChange: (pin: string | null) => void;
 }) {
@@ -74,7 +80,7 @@ function Row({
 
   const onKindChange = (k: Kind) => {
     if (k === t.kind) return;
-    onChange(defaultTargetForKind(k, { railNames, gpioPins, buses, expanders }));
+    onChange(defaultTargetForKind(k, { railNames, gpioPins, buses, expanders, componentInstances }));
   };
 
   return (
@@ -145,6 +151,21 @@ function Row({
           target={t}
           expanders={expanders}
           onChange={onChange}
+        />
+      )}
+
+      {t.kind === "component" && (
+        <SelectInput
+          label="hub"
+          value={t.component_id}
+          options={componentInstances
+            .filter((c) => c.id !== row.component_id)
+            .map((c) => c.id)}
+          renderLabel={(id) => {
+            const c = componentInstances.find((x) => x.id === id);
+            return c ? `${c.id} (${c.library_id})` : id;
+          }}
+          onChange={(v) => onChange({ kind: "component", component_id: v })}
         />
       )}
     </div>
@@ -324,6 +345,7 @@ function defaultTargetForKind(
     gpioPins: string[];
     buses: { id: string; type: string }[];
     expanders: { id: string; library_id: string }[];
+    componentInstances: { id: string; library_id: string }[];
   },
 ): ConnectionTarget {
   switch (k) {
@@ -341,5 +363,7 @@ function defaultTargetForKind(
         mode: "INPUT_PULLUP",
         inverted: false,
       };
+    case "component":
+      return { kind: "component", component_id: ctx.componentInstances[0]?.id ?? "" };
   }
 }

--- a/web/src/components/ConnectionForm.tsx
+++ b/web/src/components/ConnectionForm.tsx
@@ -24,10 +24,11 @@ interface Props {
   boardData: unknown;
   libraryComponents: ComponentSummary[] | null;
   onChange: (connectionIndex: number, target: ConnectionTarget) => void;
+  onLockedPinChange: (componentId: string, pinRole: string, pin: string | null) => void;
 }
 
 export function ConnectionForm({
-  rows, design, boardData, libraryComponents, onChange,
+  rows, design, boardData, libraryComponents, onChange, onLockedPinChange,
 }: Props) {
   if (rows.length === 0) {
     return <div className="text-xs text-zinc-500">No connections.</div>;
@@ -51,6 +52,7 @@ export function ConnectionForm({
           buses={buses}
           expanders={expanders}
           onChange={(t) => onChange(row.index, t)}
+          onLockedPinChange={(pin) => onLockedPinChange(row.component_id, row.pin_role, pin)}
         />
       ))}
     </div>
@@ -58,7 +60,7 @@ export function ConnectionForm({
 }
 
 function Row({
-  row, railNames, gpioPins, buses, expanders, onChange,
+  row, railNames, gpioPins, buses, expanders, onChange, onLockedPinChange,
 }: {
   row: ConnectionRow;
   railNames: string[];
@@ -66,6 +68,7 @@ function Row({
   buses: { id: string; type: string }[];
   expanders: { id: string; library_id: string }[];
   onChange: (t: ConnectionTarget) => void;
+  onLockedPinChange: (pin: string | null) => void;
 }) {
   const t = row.target;
 
@@ -99,13 +102,29 @@ function Row({
       )}
 
       {t.kind === "gpio" && (
-        <SelectInput
-          label="pin"
-          value={t.pin}
-          options={gpioPins}
-          allowFree
-          onChange={(v) => onChange({ kind: "gpio", pin: v })}
-        />
+        <div className="flex items-center gap-1">
+          <div className="flex-1">
+            <SelectInput
+              label="pin"
+              value={t.pin}
+              options={gpioPins}
+              allowFree
+              onChange={(v) => onChange({ kind: "gpio", pin: v })}
+            />
+          </div>
+          <LockToggle
+            lockedPin={row.locked_pin}
+            currentPin={t.pin}
+            onLock={() => onLockedPinChange(t.pin || null)}
+            onUnlock={() => onLockedPinChange(null)}
+          />
+        </div>
+      )}
+      {t.kind === "gpio" && row.locked_pin && row.locked_pin !== t.pin && (
+        <div className="mt-1 rounded border border-amber-700/40 bg-amber-900/15 px-1.5 py-0.5 text-[10px] text-amber-200">
+          locked to <code>{row.locked_pin}</code> but bound to <code>{t.pin || "<unset>"}</code>;
+          solver will flag a mismatch.
+        </div>
       )}
 
       {t.kind === "bus" && (
@@ -129,6 +148,65 @@ function Row({
         />
       )}
     </div>
+  );
+}
+
+/**
+ * Per-row lock toggle. Three states:
+ *  - locked & in sync: solid badge, click to unlock.
+ *  - locked & diverged: amber-tinted badge showing the locked target;
+ *                       click to unlock. (Re-locking from here would
+ *                       overwrite the lock with whatever is currently
+ *                       bound, which is rarely what the user wants.)
+ *  - unlocked: outline button "lock"; click to write
+ *              locked_pins[role] = currently bound pin.
+ *
+ * The solver's `locked_pin_mismatch` warning surfaces the diverged case
+ * in the design pane; this control gives the user a one-click escape.
+ */
+function LockToggle({
+  lockedPin, currentPin, onLock, onUnlock,
+}: {
+  lockedPin: string | null;
+  currentPin: string;
+  onLock: () => void;
+  onUnlock: () => void;
+}) {
+  if (lockedPin === null) {
+    return (
+      <button
+        type="button"
+        onClick={onLock}
+        disabled={!currentPin}
+        title={
+          currentPin
+            ? `Lock this role to ${currentPin}; the pin solver will not move it.`
+            : "Pick a pin first, then lock it."
+        }
+        className="shrink-0 rounded border border-zinc-800 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-zinc-400 enabled:hover:border-zinc-600 enabled:hover:text-zinc-200 disabled:opacity-40"
+      >
+        🔓 lock
+      </button>
+    );
+  }
+  const diverged = lockedPin !== currentPin;
+  return (
+    <button
+      type="button"
+      onClick={onUnlock}
+      title={
+        diverged
+          ? `Locked to ${lockedPin} (bound: ${currentPin || "<unset>"}). Click to unlock.`
+          : `Locked to ${lockedPin}. Click to unlock.`
+      }
+      className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${
+        diverged
+          ? "border-amber-600/50 bg-amber-900/20 text-amber-200 hover:bg-amber-900/30"
+          : "border-emerald-600/50 bg-emerald-900/20 text-emerald-200 hover:bg-emerald-900/30"
+      }`}
+    >
+      🔒 {lockedPin}
+    </button>
   );
 }
 

--- a/web/src/components/Inspector.test.tsx
+++ b/web/src/components/Inspector.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * Component tests for the DesignInspector composition (rendered via the
+ * exported Inspector with selection={kind: "design"}). Focus is on the
+ * wiring between the inspector and its child controls -- the list rendering,
+ * the section counts, the selection callback, and the remove-component
+ * button. The deeper child components (BusList, ConnectionForm, etc.)
+ * have their own focused suites; those aren't re-tested here.
+ *
+ * api.getComponent is mocked so the component-instance branch's library
+ * fetch never hits the network. The design-pane tests don't trigger it
+ * but the mock guarantees we'd notice if the wiring shifted.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { Inspector, type Selection } from "./Inspector";
+import { api } from "../api/client";
+import type { BoardSummary, ComponentSummary, Design } from "../types/api";
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    api: { ...actual.api, getComponent: vi.fn() },
+  };
+});
+const mockApi = api as unknown as { getComponent: ReturnType<typeof vi.fn> };
+
+const boardData = {
+  rails: [{ name: "5V", voltage: 5 }, { name: "3V3", voltage: 3.3 }, { name: "GND", voltage: 0 }],
+  gpio_capabilities: { D5: ["gpio"], D6: ["gpio"], D7: ["gpio"] },
+  default_buses: { i2c: { sda: "D2", scl: "D1" } },
+};
+
+const libraryBoards: BoardSummary[] = [
+  {
+    id: "wemos-d1-mini", name: "WeMos D1 Mini",
+    mcu: "esp8266", chip_variant: "esp8266", framework: "arduino",
+    platformio_board: "d1_mini", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"],
+  },
+  {
+    id: "esp32-devkitc-v4", name: "ESP32 DevKitC",
+    mcu: "esp32", chip_variant: "esp32", framework: "arduino",
+    platformio_board: "esp32dev", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"],
+  },
+];
+
+const libraryComponents: ComponentSummary[] = [
+  {
+    id: "bme280", name: "BME280", category: "sensor",
+    use_cases: ["temperature"], aliases: [], required_components: ["i2c"],
+    current_ma_typical: 0.6, current_ma_peak: 4,
+  },
+  {
+    id: "hc-sr501", name: "PIR", category: "binary_sensor",
+    use_cases: ["motion"], aliases: [], required_components: [],
+    current_ma_typical: 50, current_ma_peak: 65,
+  },
+];
+
+function design(over: Partial<Design> = {}): Design {
+  return {
+    schema_version: "0.1",
+    id: "t",
+    name: "T",
+    board: { library_id: "wemos-d1-mini", mcu: "esp8266" },
+    components: [
+      { id: "bme1", library_id: "bme280", label: "BME", params: {} },
+      { id: "pir1", library_id: "hc-sr501", label: "Hall PIR", params: {} },
+    ],
+    buses: [{ id: "i2c0", type: "i2c", sda: "D2", scl: "D1" }],
+    connections: [
+      { component_id: "bme1", pin_role: "SDA", target: { kind: "bus", bus_id: "i2c0" } },
+      { component_id: "pir1", pin_role: "OUT", target: { kind: "gpio", pin: "D5" } },
+    ],
+    requirements: [{ id: "r1", kind: "capability", text: "detect motion" }],
+    warnings: [],
+    fleet: { device_name: "t", tags: ["indoor"] },
+    ...over,
+  } as Design;
+}
+
+function noopProps() {
+  return {
+    onSelect: vi.fn(),
+    onParamChange: vi.fn(),
+    onConnectionChange: vi.fn(),
+    onLockedPinChange: vi.fn(),
+    onDesignChange: vi.fn(),
+    onAddComponent: vi.fn(),
+    onRemoveComponent: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  mockApi.getComponent.mockReset();
+});
+
+const designSelection: Selection = { kind: "design" };
+
+describe("DesignInspector composition", () => {
+  it("renders 'No design loaded' when design is null", () => {
+    render(
+      <Inspector
+        {...noopProps()}
+        selection={designSelection}
+        design={null}
+        boardData={boardData}
+        libraryBoards={libraryBoards}
+        libraryComponents={libraryComponents}
+        compatibilityWarnings={[]}
+      />,
+    );
+    expect(screen.getByText(/No design loaded/i)).toBeInTheDocument();
+  });
+
+  it("renders one row per component with the right id + label + library_id", () => {
+    render(
+      <Inspector
+        {...noopProps()}
+        selection={designSelection}
+        design={design()}
+        boardData={boardData}
+        libraryBoards={libraryBoards}
+        libraryComponents={libraryComponents}
+        compatibilityWarnings={[]}
+      />,
+    );
+    expect(screen.getByText("bme1")).toBeInTheDocument();
+    expect(screen.getByText("pir1")).toBeInTheDocument();
+    expect(screen.getByText("BME")).toBeInTheDocument();
+    expect(screen.getByText("Hall PIR")).toBeInTheDocument();
+  });
+
+  it("section headers reflect collection counts", () => {
+    render(
+      <Inspector
+        {...noopProps()}
+        selection={designSelection}
+        design={design()}
+        boardData={boardData}
+        libraryBoards={libraryBoards}
+        libraryComponents={libraryComponents}
+        compatibilityWarnings={[]}
+      />,
+    );
+    // Components (2), Buses (1), Requirements (1), Warnings (0).
+    expect(screen.getByText(/Components \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Buses \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Requirements \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Warnings \(0\)/)).toBeInTheDocument();
+  });
+
+  it("clicking a component row fires onSelect with kind=component_instance", async () => {
+    const props = noopProps();
+    render(
+      <Inspector
+        {...props}
+        selection={designSelection}
+        design={design()}
+        boardData={boardData}
+        libraryBoards={libraryBoards}
+        libraryComponents={libraryComponents}
+        compatibilityWarnings={[]}
+      />,
+    );
+    // Two buttons match the bme1 row: the select button (whole-row) and
+    // the ✕ remove button. The select is the larger one carrying the id.
+    const bmeSelect = screen.getByText("bme1").closest("button") as HTMLElement;
+    await userEvent.click(bmeSelect);
+    expect(props.onSelect).toHaveBeenCalledWith({ kind: "component_instance", id: "bme1" });
+  });
+
+  it("clicking the ✕ on a component row fires onRemoveComponent", async () => {
+    const props = noopProps();
+    render(
+      <Inspector
+        {...props}
+        selection={designSelection}
+        design={design()}
+        boardData={boardData}
+        libraryBoards={libraryBoards}
+        libraryComponents={libraryComponents}
+        compatibilityWarnings={[]}
+      />,
+    );
+    // Find the bme1 row's container <li> and click its ✕ button. The
+    // button's accessible name is just "✕" (title is decorative); query
+    // by text content within the row to scope away from pir1's button.
+    const bmeRow = screen.getByText("bme1").closest("li") as HTMLElement;
+    const removeBtn = within(bmeRow).getByText("✕").closest("button") as HTMLElement;
+    await userEvent.click(removeBtn);
+    expect(props.onRemoveComponent).toHaveBeenCalledWith("bme1");
+  });
+
+  it("hides the Compatibility section when there are no warnings", () => {
+    render(
+      <Inspector
+        {...noopProps()}
+        selection={designSelection}
+        design={design()}
+        boardData={boardData}
+        libraryBoards={libraryBoards}
+        libraryComponents={libraryComponents}
+        compatibilityWarnings={[]}
+      />,
+    );
+    expect(screen.queryByText(/Compatibility \(\d+\)/)).not.toBeInTheDocument();
+  });
+
+  it("shows the Compatibility section with the count when warnings are present", () => {
+    render(
+      <Inspector
+        {...noopProps()}
+        selection={designSelection}
+        design={design()}
+        boardData={boardData}
+        libraryBoards={libraryBoards}
+        libraryComponents={libraryComponents}
+        compatibilityWarnings={[
+          { severity: "warn", code: "x", pin: "D5", component_id: "pir1", pin_role: "OUT", message: "test" },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/Compatibility \(1\)/)).toBeInTheDocument();
+  });
+
+  it("shows the Fleet section only when the design has a fleet block", () => {
+    // With fleet -> visible.
+    const { rerender } = render(
+      <Inspector
+        {...noopProps()}
+        selection={designSelection}
+        design={design()}
+        boardData={boardData}
+        libraryBoards={libraryBoards}
+        libraryComponents={libraryComponents}
+        compatibilityWarnings={[]}
+      />,
+    );
+    expect(screen.getByText("Fleet")).toBeInTheDocument();
+
+    // Strip fleet -> hidden.
+    const noFleet = { ...design() };
+    delete (noFleet as Record<string, unknown>).fleet;
+    rerender(
+      <Inspector
+        {...noopProps()}
+        selection={designSelection}
+        design={noFleet}
+        boardData={boardData}
+        libraryBoards={libraryBoards}
+        libraryComponents={libraryComponents}
+        compatibilityWarnings={[]}
+      />,
+    );
+    expect(screen.queryByText("Fleet")).not.toBeInTheDocument();
+  });
+
+  it("renders an empty-components affordance when the design has no components", () => {
+    render(
+      <Inspector
+        {...noopProps()}
+        selection={designSelection}
+        design={design({ components: [] })}
+        boardData={boardData}
+        libraryBoards={libraryBoards}
+        libraryComponents={libraryComponents}
+        compatibilityWarnings={[]}
+      />,
+    );
+    expect(screen.getByText(/Components \(0\)/)).toBeInTheDocument();
+    expect(screen.getByText(/no components/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Inspector.tsx
+++ b/web/src/components/Inspector.tsx
@@ -180,6 +180,7 @@ function DesignInspector({
           design={design}
           gpioPins={gpioPins}
           defaultBuses={defaultBuses}
+          compatibilityWarnings={compatibilityWarnings}
           onChange={onDesignChange}
         />
       </Section>

--- a/web/src/components/Inspector.tsx
+++ b/web/src/components/Inspector.tsx
@@ -7,6 +7,7 @@ import {
   readRequirements,
   readWarnings,
   type ComponentInstance,
+  type ConnectionRow,
   type ConnectionTarget,
   type DesignWarning,
   type Requirement,
@@ -21,6 +22,7 @@ import {
 } from "../lib/design";
 import { ParamForm } from "./ParamForm";
 import { ConnectionForm } from "./ConnectionForm";
+import { PinoutView } from "./PinoutView";
 import { BusList } from "./BusList";
 
 export type Selection =
@@ -550,12 +552,13 @@ function ComponentInstanceInspector({
 
       <Section title="Connections">
         {design ? (
-          <ConnectionForm
+          <ConnectionsPane
             rows={connectionRows}
             design={design}
             boardData={boardData}
+            instance={inst}
             libraryComponents={libraryComponents}
-            onChange={onConnectionChange}
+            onConnectionChange={onConnectionChange}
             onLockedPinChange={onLockedPinChange}
           />
         ) : null}
@@ -576,6 +579,70 @@ function ComponentInstanceInspector({
     </div>
   );
 }
+
+/**
+ * View toggle wrapping the Form-based ConnectionForm and the drag-and-
+ * drop PinoutView. Form is the default since it covers every target
+ * kind (rail/gpio/bus/expander_pin/component); Pinout is a faster
+ * gpio-only surface for board-pin-heavy designs.
+ */
+function ConnectionsPane({
+  rows, design, boardData, instance, libraryComponents,
+  onConnectionChange, onLockedPinChange,
+}: {
+  rows: ConnectionRow[];
+  design: Design;
+  boardData: unknown;
+  instance: ComponentInstance;
+  libraryComponents: ComponentSummary[] | null;
+  onConnectionChange: (connectionIndex: number, target: ConnectionTarget) => void;
+  onLockedPinChange: (componentId: string, pinRole: string, pin: string | null) => void;
+}) {
+  const [view, setView] = useState<"form" | "pinout">("form");
+  const board = (boardData ?? {}) as Record<string, unknown>;
+  const gpioCapabilities = (board.gpio_capabilities ?? {}) as Record<string, string[]>;
+  const allConnections = readConnections(design);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1 text-[11px]">
+        {(["form", "pinout"] as const).map((v) => (
+          <button
+            key={v}
+            type="button"
+            onClick={() => setView(v)}
+            className={`rounded px-1.5 py-0.5 transition-colors ${
+              view === v
+                ? "bg-zinc-800 text-zinc-100"
+                : "text-zinc-500 hover:text-zinc-200"
+            }`}
+          >
+            {v === "form" ? "Form" : "Pinout"}
+          </button>
+        ))}
+      </div>
+      {view === "form" ? (
+        <ConnectionForm
+          rows={rows}
+          design={design}
+          boardData={boardData}
+          libraryComponents={libraryComponents}
+          onChange={onConnectionChange}
+          onLockedPinChange={onLockedPinChange}
+        />
+      ) : (
+        <PinoutView
+          rows={rows}
+          allConnections={allConnections}
+          instance={instance}
+          gpioCapabilities={gpioCapabilities}
+          onChange={onConnectionChange}
+        />
+      )}
+    </div>
+  );
+}
+
 
 function FullComponentView({ comp, compact = false }: { comp: unknown; compact?: boolean }) {
   const c = comp as Record<string, unknown>;

--- a/web/src/components/Inspector.tsx
+++ b/web/src/components/Inspector.tsx
@@ -21,6 +21,7 @@ import {
 } from "../lib/design";
 import { ParamForm } from "./ParamForm";
 import { ConnectionForm } from "./ConnectionForm";
+import { BusList } from "./BusList";
 
 export type Selection =
   | { kind: "design" }
@@ -38,6 +39,7 @@ interface Props {
   onSelect: (s: Selection) => void;
   onParamChange: (componentInstanceId: string, paramKey: string, value: unknown) => void;
   onConnectionChange: (connectionIndex: number, target: ConnectionTarget) => void;
+  onLockedPinChange: (componentId: string, pinRole: string, pin: string | null) => void;
   onDesignChange: (updater: (d: Design) => Design) => void;
   onAddComponent: (libraryId: string) => void;
   onRemoveComponent: (instanceId: string) => void;
@@ -46,7 +48,7 @@ interface Props {
 export function Inspector({
   selection, design, boardData, libraryBoards, libraryComponents,
   compatibilityWarnings,
-  onSelect, onParamChange, onConnectionChange, onDesignChange,
+  onSelect, onParamChange, onConnectionChange, onLockedPinChange, onDesignChange,
   onAddComponent, onRemoveComponent,
 }: Props) {
   return (
@@ -75,6 +77,7 @@ export function Inspector({
         {selection.kind === "design" && (
           <DesignInspector
             design={design}
+            boardData={boardData}
             libraryBoards={libraryBoards}
             libraryComponents={libraryComponents}
             compatibilityWarnings={compatibilityWarnings}
@@ -95,6 +98,7 @@ export function Inspector({
             compatibilityWarnings={compatibilityWarnings}
             onParamChange={onParamChange}
             onConnectionChange={onConnectionChange}
+            onLockedPinChange={onLockedPinChange}
           />
         )}
       </div>
@@ -103,10 +107,11 @@ export function Inspector({
 }
 
 function DesignInspector({
-  design, libraryBoards, libraryComponents, compatibilityWarnings,
+  design, boardData, libraryBoards, libraryComponents, compatibilityWarnings,
   onSelect, onDesignChange, onAddComponent, onRemoveComponent,
 }: {
   design: Design | null;
+  boardData: unknown;
   libraryBoards: BoardSummary[] | null;
   libraryComponents: ComponentSummary[] | null;
   compatibilityWarnings: CompatibilityWarning[];
@@ -121,6 +126,10 @@ function DesignInspector({
   const warnings = readWarnings(design);
   const board = (design.board as Record<string, unknown> | undefined) ?? {};
   const fleet = (design.fleet ?? null) as Record<string, unknown> | null;
+  const boardRecord = (boardData ?? {}) as Record<string, unknown>;
+  const gpioPins = Object.keys((boardRecord.gpio_capabilities ?? {}) as Record<string, unknown>);
+  const defaultBuses = (boardRecord.default_buses ?? {}) as Record<string, Record<string, string>>;
+  const buses = (design.buses as unknown[] | undefined) ?? [];
 
   return (
     <div className="space-y-5 text-sm text-zinc-300">
@@ -163,6 +172,15 @@ function DesignInspector({
         <AddComponentControl
           libraryComponents={libraryComponents}
           onAdd={onAddComponent}
+        />
+      </Section>
+
+      <Section title={`Buses (${buses.length})`}>
+        <BusList
+          design={design}
+          gpioPins={gpioPins}
+          defaultBuses={defaultBuses}
+          onChange={onDesignChange}
         />
       </Section>
 
@@ -486,7 +504,7 @@ function LibraryComponentInspector({ id }: { id: string }) {
 
 function ComponentInstanceInspector({
   instanceId, design, boardData, libraryComponents, compatibilityWarnings,
-  onParamChange, onConnectionChange,
+  onParamChange, onConnectionChange, onLockedPinChange,
 }: {
   instanceId: string;
   design: Design | null;
@@ -495,6 +513,7 @@ function ComponentInstanceInspector({
   compatibilityWarnings: CompatibilityWarning[];
   onParamChange: (componentInstanceId: string, paramKey: string, value: unknown) => void;
   onConnectionChange: (connectionIndex: number, target: ConnectionTarget) => void;
+  onLockedPinChange: (componentId: string, pinRole: string, pin: string | null) => void;
 }) {
   const components = readComponents(design);
   const inst = components.find((c) => c.id === instanceId) as ComponentInstance | undefined;
@@ -536,6 +555,7 @@ function ComponentInstanceInspector({
             boardData={boardData}
             libraryComponents={libraryComponents}
             onChange={onConnectionChange}
+            onLockedPinChange={onLockedPinChange}
           />
         ) : null}
       </Section>

--- a/web/src/components/PinoutView.test.tsx
+++ b/web/src/components/PinoutView.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * Component tests for PinoutView. Focused on the drag-and-drop wiring:
+ * dropping a connection chip onto a board pin fires onChange with the
+ * right { kind: "gpio", pin } payload, conflict detection paints the
+ * occupied pins in the rose tone, and the empty states render the
+ * informational fallbacks.
+ *
+ * jsdom's HTML5 drag-and-drop is minimal but sufficient: we synthesize
+ * the dragstart -> drop sequence with userEvent and a hand-built
+ * DataTransfer stub.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { PinoutView } from "./PinoutView";
+import type { ComponentInstance, ConnectionRow } from "../lib/design";
+
+const board = {
+  GPIO0:  ["boot", "strap", "boot_high"],
+  GPIO5:  ["gpio", "spi_cs", "boot_high"],
+  GPIO13: ["gpio", "adc", "adc2", "pwm"],
+  GPIO34: ["gpio", "adc", "adc1", "input_only"],
+};
+
+const instance: ComponentInstance = { id: "pir1", library_id: "hc-sr501", label: "PIR" };
+
+function gpioRow(pinRole: string, pin: string, index = 0): ConnectionRow {
+  return {
+    index, component_id: "pir1", pin_role: pinRole,
+    target: { kind: "gpio", pin }, locked_pin: null,
+  };
+}
+
+function railRow(): ConnectionRow {
+  return {
+    index: 99, component_id: "pir1", pin_role: "VCC",
+    target: { kind: "rail", rail: "5V" }, locked_pin: null,
+  };
+}
+
+/** Build a DataTransfer-shaped stub that records set/getData. jsdom's
+ *  DataTransfer is incomplete; this is enough for the drag-drop path. */
+function makeDataTransfer() {
+  const store = new Map<string, string>();
+  return {
+    setData: (mime: string, value: string) => store.set(mime, value),
+    getData: (mime: string) => store.get(mime) ?? "",
+    effectAllowed: "uninitialized",
+  } as unknown as DataTransfer;
+}
+
+describe("PinoutView empty states", () => {
+  it("warns when the board has no gpio_capabilities", () => {
+    render(
+      <PinoutView
+        rows={[gpioRow("OUT", "")]}
+        allConnections={[gpioRow("OUT", "")]}
+        instance={instance}
+        gpioCapabilities={{}}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText(/No board pinout available/i)).toBeInTheDocument();
+  });
+
+  it("warns when the component has no gpio connections to drag", () => {
+    render(
+      <PinoutView
+        rows={[railRow()]}
+        allConnections={[railRow()]}
+        instance={instance}
+        gpioCapabilities={board}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText(/no gpio connections to drag/i)).toBeInTheDocument();
+  });
+});
+
+describe("PinoutView rendering", () => {
+  it("lists every board pin with its capability badges", () => {
+    render(
+      <PinoutView
+        rows={[gpioRow("OUT", "")]}
+        allConnections={[gpioRow("OUT", "")]}
+        instance={instance}
+        gpioCapabilities={board}
+        onChange={() => {}}
+      />,
+    );
+    // Every board pin renders.
+    for (const pin of Object.keys(board)) {
+      expect(screen.getByTestId(`pin-${pin}`)).toBeInTheDocument();
+    }
+    // The ADC2 badge appears on GPIO13.
+    const gpio13 = screen.getByTestId("pin-GPIO13");
+    expect(within(gpio13).getByText("ADC2")).toBeInTheDocument();
+    // input-only flag on GPIO34.
+    expect(within(screen.getByTestId("pin-GPIO34")).getByText(/input only/i))
+      .toBeInTheDocument();
+  });
+
+  it("annotates the pin currently bound to a connection on this instance", () => {
+    render(
+      <PinoutView
+        rows={[gpioRow("OUT", "GPIO13")]}
+        allConnections={[gpioRow("OUT", "GPIO13")]}
+        instance={instance}
+        gpioCapabilities={board}
+        onChange={() => {}}
+      />,
+    );
+    const gpio13 = screen.getByTestId("pin-GPIO13");
+    expect(within(gpio13).getByText(/← OUT/)).toBeInTheDocument();
+  });
+
+  it("flags pins occupied by a different component as 'used by'", () => {
+    const other: ConnectionRow = {
+      index: 5, component_id: "led1", pin_role: "DATA",
+      target: { kind: "gpio", pin: "GPIO5" }, locked_pin: null,
+    };
+    render(
+      <PinoutView
+        rows={[gpioRow("OUT", "")]}
+        allConnections={[gpioRow("OUT", ""), other]}
+        instance={instance}
+        gpioCapabilities={board}
+        onChange={() => {}}
+      />,
+    );
+    const gpio5 = screen.getByTestId("pin-GPIO5");
+    expect(within(gpio5).getByText(/used by led1\.DATA/i)).toBeInTheDocument();
+  });
+});
+
+describe("PinoutView drag-and-drop", () => {
+  it("dropping a draggable onto a board pin fires onChange with the gpio target", () => {
+    const onChange = vi.fn();
+    const row = gpioRow("OUT", "");
+    render(
+      <PinoutView
+        rows={[row]}
+        allConnections={[row]}
+        instance={instance}
+        gpioCapabilities={board}
+        onChange={onChange}
+      />,
+    );
+    const dt = makeDataTransfer();
+    const drag = screen.getByTestId("drag-OUT");
+    fireEvent.dragStart(drag, { dataTransfer: dt });
+    expect(dt.getData("application/x-esphome-studio-connection-index")).toBe(String(row.index));
+
+    const target = screen.getByTestId("pin-GPIO13");
+    fireEvent.dragOver(target, { dataTransfer: dt });
+    fireEvent.drop(target, { dataTransfer: dt });
+
+    expect(onChange).toHaveBeenCalledWith(row.index, { kind: "gpio", pin: "GPIO13" });
+  });
+
+  it("dropping with an empty payload is a no-op (defensive)", () => {
+    const onChange = vi.fn();
+    render(
+      <PinoutView
+        rows={[gpioRow("OUT", "")]}
+        allConnections={[gpioRow("OUT", "")]}
+        instance={instance}
+        gpioCapabilities={board}
+        onChange={onChange}
+      />,
+    );
+    const target = screen.getByTestId("pin-GPIO13");
+    fireEvent.drop(target, { dataTransfer: makeDataTransfer() });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/PinoutView.tsx
+++ b/web/src/components/PinoutView.tsx
@@ -1,0 +1,179 @@
+/**
+ * Drag-and-drop pinout view for the component-instance inspector.
+ *
+ * Renders two columns side by side:
+ *
+ *   - Left: every GPIO pin on the current board, with capability badges
+ *           (boot strap, ADC unit, input-only, serial console).
+ *   - Right: every kind=gpio connection on the selected component
+ *           instance, draggable.
+ *
+ * Drop a connection onto a board pin to rewrite the connection's
+ * target to {kind: "gpio", pin: <pin>}. Conflicts (the destination
+ * pin already used by a *different* component's connection) render
+ * red but the drop is still allowed -- the user can then resolve via
+ * the existing CSP solver or by hand. The form-based ConnectionForm
+ * stays available alongside this view; the inspector toggles between
+ * the two.
+ */
+import type { ComponentInstance, ConnectionRow, ConnectionTarget } from "../lib/design";
+
+interface Props {
+  rows: ConnectionRow[];                    // connections of the selected instance
+  allConnections: ConnectionRow[];          // every connection in the design (for conflict detection)
+  instance: ComponentInstance;
+  gpioCapabilities: Record<string, string[]>;
+  onChange: (connectionIndex: number, target: ConnectionTarget) => void;
+}
+
+const SPECIAL_BADGES: { tag: string; label: string; tone: string }[] = [
+  { tag: "boot_high", label: "boot HIGH", tone: "border-amber-700/40 bg-amber-900/15 text-amber-200" },
+  { tag: "boot_low",  label: "boot LOW",  tone: "border-amber-700/40 bg-amber-900/15 text-amber-200" },
+  { tag: "input_only", label: "input only", tone: "border-rose-700/40 bg-rose-900/15 text-rose-200" },
+  { tag: "serial_tx", label: "TX",        tone: "border-rose-700/40 bg-rose-900/15 text-rose-200" },
+  { tag: "serial_rx", label: "RX",        tone: "border-rose-700/40 bg-rose-900/15 text-rose-200" },
+  { tag: "adc1",      label: "ADC1",      tone: "border-emerald-700/40 bg-emerald-900/15 text-emerald-200" },
+  { tag: "adc2",      label: "ADC2",      tone: "border-amber-700/40 bg-amber-900/15 text-amber-200" },
+  { tag: "i2c_sda",   label: "SDA",       tone: "border-blue-700/40 bg-blue-900/15 text-blue-200" },
+  { tag: "i2c_scl",   label: "SCL",       tone: "border-blue-700/40 bg-blue-900/15 text-blue-200" },
+];
+
+const DRAG_MIME = "application/x-esphome-studio-connection-index";
+
+export function PinoutView({
+  rows, allConnections, instance, gpioCapabilities, onChange,
+}: Props) {
+  const gpioConnections = rows.filter((r) => r.target.kind === "gpio");
+  const otherUses: Map<string, string> = new Map();
+  for (const c of allConnections) {
+    if (c.component_id === instance.id) continue;
+    if (c.target.kind === "gpio" && c.target.pin) {
+      otherUses.set(c.target.pin, `${c.component_id}.${c.pin_role}`);
+    }
+  }
+  // Pin -> the connection on THIS instance that targets it (for the
+  // "currently here" annotation on each board row).
+  const myUses: Map<string, string> = new Map();
+  for (const c of gpioConnections) {
+    if (c.target.kind === "gpio" && c.target.pin) {
+      myUses.set(c.target.pin, c.pin_role);
+    }
+  }
+
+  const pinNames = Object.keys(gpioCapabilities);
+
+  function handleDrop(pin: string, e: React.DragEvent) {
+    e.preventDefault();
+    const raw = e.dataTransfer.getData(DRAG_MIME);
+    if (!raw) return;
+    const idx = parseInt(raw, 10);
+    if (Number.isNaN(idx)) return;
+    onChange(idx, { kind: "gpio", pin });
+  }
+
+  if (pinNames.length === 0) {
+    return (
+      <div className="text-xs text-zinc-500">
+        No board pinout available -- pick a board first.
+      </div>
+    );
+  }
+  if (gpioConnections.length === 0) {
+    return (
+      <div className="text-xs text-zinc-500">
+        This component has no gpio connections to drag. Use the Form view
+        to set rail / bus / expander_pin / component targets.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {/* Left: board pins (drop targets). */}
+      <div className="space-y-1">
+        <div className="text-[11px] uppercase tracking-wide text-zinc-500">
+          Board pins
+        </div>
+        <ul className="space-y-1">
+          {pinNames.map((pin) => {
+            const caps = gpioCapabilities[pin] ?? [];
+            const occupiedBy = otherUses.get(pin);
+            const heldHere = myUses.get(pin);
+            return (
+              <li key={pin}>
+                <div
+                  data-testid={`pin-${pin}`}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => handleDrop(pin, e)}
+                  className={`flex items-center gap-2 rounded border px-2 py-1 text-xs transition-colors ${
+                    occupiedBy
+                      ? "border-rose-700/40 bg-rose-900/10 text-zinc-200"
+                      : heldHere
+                        ? "border-emerald-700/40 bg-emerald-900/15 text-zinc-100"
+                        : "border-zinc-800 bg-zinc-900/30 text-zinc-200 hover:border-zinc-600"
+                  }`}
+                >
+                  <span className="w-14 shrink-0 font-mono">{pin}</span>
+                  <div className="flex flex-1 flex-wrap items-center gap-1">
+                    {SPECIAL_BADGES.filter((b) => caps.includes(b.tag)).map((b) => (
+                      <span
+                        key={b.tag}
+                        className={`rounded border px-1 text-[10px] uppercase tracking-wide ${b.tone}`}
+                      >
+                        {b.label}
+                      </span>
+                    ))}
+                    {heldHere && (
+                      <span className="ml-auto text-[10px] text-emerald-300">
+                        ← {heldHere}
+                      </span>
+                    )}
+                    {occupiedBy && !heldHere && (
+                      <span className="ml-auto text-[10px] text-rose-300">
+                        used by {occupiedBy}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      {/* Right: this component's gpio connections (draggable). */}
+      <div className="space-y-1">
+        <div className="text-[11px] uppercase tracking-wide text-zinc-500">
+          {instance.id} pins
+        </div>
+        <ul className="space-y-1">
+          {gpioConnections.map((row) => {
+            const t = row.target as { kind: "gpio"; pin: string };
+            return (
+              <li key={row.index}>
+                <div
+                  draggable
+                  onDragStart={(e) => {
+                    e.dataTransfer.setData(DRAG_MIME, String(row.index));
+                    e.dataTransfer.effectAllowed = "move";
+                  }}
+                  data-testid={`drag-${row.pin_role}`}
+                  className="flex cursor-grab items-center justify-between gap-2 rounded border border-zinc-800 bg-zinc-900/40 px-2 py-1 text-xs hover:border-zinc-600 active:cursor-grabbing"
+                >
+                  <span className="font-mono">{row.pin_role}</span>
+                  <span className={`font-mono ${t.pin ? "text-zinc-100" : "text-zinc-500"}`}>
+                    {t.pin || "(unbound)"}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+        <p className="pt-1 text-[11px] text-zinc-500">
+          Drag a row onto a board pin on the left to bind it. Red rows
+          are already used by another component's connection.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/PushToFleetDialog.test.tsx
+++ b/web/src/components/PushToFleetDialog.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Component tests for PushToFleetDialog. Two surfaces:
+ *
+ *   1. Status fetch on mount + the canPush gating that follows from it.
+ *   2. The build-log polling loop. The single-shot "first chunk finishes
+ *      the job" path is covered without timers; the multi-chunk path uses
+ *      vi.useFakeTimers to step over the 1.5s between polls deterministically.
+ *
+ * The api/client surface is mocked at the import boundary; we never make a
+ * real network call.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { PushToFleetDialog } from "./PushToFleetDialog";
+import { api } from "../api/client";
+import type { Design } from "../types/api";
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      fleetStatus: vi.fn(),
+      fleetPush: vi.fn(),
+      fleetJobLog: vi.fn(),
+    },
+  };
+});
+
+const mockApi = api as unknown as {
+  fleetStatus: ReturnType<typeof vi.fn>;
+  fleetPush: ReturnType<typeof vi.fn>;
+  fleetJobLog: ReturnType<typeof vi.fn>;
+};
+
+const design: Design = {
+  schema_version: "0.1",
+  id: "garage-motion",
+  name: "Garage motion",
+  board: { library_id: "esp32-devkitc-v4", mcu: "esp32" },
+  components: [],
+  buses: [],
+  connections: [],
+  requirements: [],
+  warnings: [],
+  fleet: { device_name: "garage-motion", tags: [] },
+} as Design;
+
+beforeEach(() => {
+  mockApi.fleetStatus.mockReset();
+  mockApi.fleetPush.mockReset();
+  mockApi.fleetJobLog.mockReset();
+});
+
+describe("status + push gating", () => {
+  it("disables Push when the fleet is unconfigured", async () => {
+    mockApi.fleetStatus.mockResolvedValue({
+      available: false,
+      reason: "FLEET_URL not set",
+      url: null,
+    });
+    render(<PushToFleetDialog design={design} onClose={() => {}} />);
+    const pushButton = await screen.findByRole("button", { name: /^Push/i });
+    expect(pushButton).toBeDisabled();
+    expect(screen.getByText(/FLEET_URL not set/i)).toBeInTheDocument();
+  });
+
+  it("enables Push when configured + fires fleetPush with the device name", async () => {
+    mockApi.fleetStatus.mockResolvedValue({ available: true, reason: null, url: "http://addon" });
+    mockApi.fleetPush.mockResolvedValue({
+      filename: "garage-motion.yaml",
+      created: true,
+      run_id: null,
+      enqueued: 0,
+    });
+    render(<PushToFleetDialog design={design} onClose={() => {}} />);
+    const pushButton = await screen.findByRole("button", { name: /^Push/i });
+    await waitFor(() => expect(pushButton).not.toBeDisabled());
+    await userEvent.click(pushButton);
+    await waitFor(() =>
+      expect(screen.getByText(/Created/i)).toBeInTheDocument(),
+    );
+    expect(mockApi.fleetPush).toHaveBeenCalledWith(
+      expect.objectContaining({ design, compile: false, device_name: "garage-motion" }),
+    );
+  });
+});
+
+describe("build-log polling", () => {
+  it("does not render the log viewer when the push response has no run_id", async () => {
+    mockApi.fleetStatus.mockResolvedValue({ available: true, reason: null, url: "http://addon" });
+    mockApi.fleetPush.mockResolvedValue({
+      filename: "garage-motion.yaml",
+      created: true,
+      run_id: null,
+      enqueued: 0,
+    });
+    render(<PushToFleetDialog design={design} onClose={() => {}} />);
+    const btn = await screen.findByRole("button", { name: /^Push/i });
+    await waitFor(() => expect(btn).not.toBeDisabled());
+    await userEvent.click(btn);
+    await screen.findByText(/Created/i);
+    expect(screen.queryByText(/build log/i)).not.toBeInTheDocument();
+    expect(mockApi.fleetJobLog).not.toHaveBeenCalled();
+  });
+
+  it("tails a single-shot finished log without needing the timer", async () => {
+    mockApi.fleetStatus.mockResolvedValue({ available: true, reason: null, url: "http://addon" });
+    mockApi.fleetPush.mockResolvedValue({
+      filename: "garage-motion.yaml",
+      created: false,
+      run_id: "run-42",
+      enqueued: 1,
+    });
+    mockApi.fleetJobLog.mockResolvedValueOnce({
+      log: "build ok\n",
+      offset: 9,
+      finished: true,
+    });
+    render(<PushToFleetDialog design={design} onClose={() => {}} />);
+    const pushBtn = await screen.findByRole("button", { name: /^Push/i });
+    await waitFor(() => expect(pushBtn).not.toBeDisabled());
+
+    // Tick the compile checkbox so the user-visible state matches the
+    // run_id-bearing response we mocked.
+    await userEvent.click(screen.getByRole("checkbox", { name: /compile after upload/i }));
+    await userEvent.click(pushBtn);
+
+    await waitFor(() => screen.getByText(/Compile enqueued/i));
+    await waitFor(() => screen.getByText(/build ok/));
+    expect(screen.getByText(/finished/i)).toBeInTheDocument();
+    expect(mockApi.fleetJobLog).toHaveBeenCalledWith("run-42", 0);
+    // Polling stops once finished; only one call.
+    expect(mockApi.fleetJobLog).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("build-log multi-chunk polling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("appends chunks and stops when finished=true", async () => {
+    mockApi.fleetStatus.mockResolvedValue({ available: true, reason: null, url: "http://addon" });
+    mockApi.fleetPush.mockResolvedValue({
+      filename: "garage-motion.yaml",
+      created: false,
+      run_id: "run-99",
+      enqueued: 1,
+    });
+    mockApi.fleetJobLog
+      .mockResolvedValueOnce({ log: "compiling...\n", offset: 13, finished: false })
+      .mockResolvedValueOnce({ log: "linking...\n", offset: 24, finished: true });
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTimeAsync });
+    render(<PushToFleetDialog design={design} onClose={() => {}} />);
+    const pushBtn = await screen.findByRole("button", { name: /^Push/i });
+    await waitFor(() => expect(pushBtn).not.toBeDisabled());
+    await user.click(screen.getByRole("checkbox", { name: /compile after upload/i }));
+    await user.click(pushBtn);
+
+    // First chunk lands without needing the timer (it resolves before the
+    // setTimeout(1500) gate).
+    await waitFor(() => screen.getByText(/compiling\.\.\./));
+    expect(mockApi.fleetJobLog).toHaveBeenNthCalledWith(1, "run-99", 0);
+    expect(screen.getByText(/tailing…/)).toBeInTheDocument();
+
+    // Cross the 1.5s poll gap; the second chunk fetches at offset=13.
+    await vi.advanceTimersByTimeAsync(1500);
+    await waitFor(() => screen.getByText(/linking\.\.\./));
+    expect(mockApi.fleetJobLog).toHaveBeenNthCalledWith(2, "run-99", 13);
+    await waitFor(() => screen.getByText(/finished/i));
+    expect(mockApi.fleetJobLog).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces a log error and stops polling when fleetJobLog throws", async () => {
+    mockApi.fleetStatus.mockResolvedValue({ available: true, reason: null, url: "http://addon" });
+    mockApi.fleetPush.mockResolvedValue({
+      filename: "garage-motion.yaml",
+      created: false,
+      run_id: "run-7",
+      enqueued: 1,
+    });
+    mockApi.fleetJobLog.mockRejectedValueOnce(new Error("addon disconnected"));
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTimeAsync });
+    render(<PushToFleetDialog design={design} onClose={() => {}} />);
+    const pushBtn = await screen.findByRole("button", { name: /^Push/i });
+    await waitFor(() => expect(pushBtn).not.toBeDisabled());
+    await user.click(screen.getByRole("checkbox", { name: /compile after upload/i }));
+    await user.click(pushBtn);
+
+    await waitFor(() => screen.getByText(/log error: addon disconnected/i));
+    expect(screen.getByText(/stopped/i)).toBeInTheDocument();
+    expect(mockApi.fleetJobLog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/PushToFleetDialog.test.tsx
+++ b/web/src/components/PushToFleetDialog.test.tsx
@@ -138,6 +138,127 @@ describe("build-log polling", () => {
   });
 });
 
+describe("build-log SSE transport", () => {
+  // A minimal EventSource stub: tests reach in and call the captured
+  // onmessage / addEventListener handlers to drive the dialog through
+  // the streaming path without a real network connection.
+  type Listener = (ev: MessageEvent) => void;
+  class FakeEventSource {
+    static instances: FakeEventSource[] = [];
+    static OPEN = 1;
+    static CLOSED = 2;
+    url: string;
+    readyState = FakeEventSource.OPEN;
+    onmessage: ((ev: MessageEvent) => void) | null = null;
+    onerror: (() => void) | null = null;
+    listeners: Record<string, Listener[]> = {};
+    constructor(url: string) {
+      this.url = url;
+      FakeEventSource.instances.push(this);
+    }
+    addEventListener(name: string, cb: Listener) {
+      (this.listeners[name] ??= []).push(cb);
+    }
+    close() { this.readyState = FakeEventSource.CLOSED; }
+    emitMessage(payload: object) {
+      this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent);
+    }
+    emitNamed(name: string, data: object) {
+      const ev = { data: JSON.stringify(data) } as MessageEvent;
+      (this.listeners[name] ?? []).forEach((cb) => cb(ev));
+    }
+  }
+
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    (globalThis as unknown as { EventSource: typeof FakeEventSource }).EventSource =
+      FakeEventSource;
+  });
+  afterEach(() => {
+    delete (globalThis as { EventSource?: unknown }).EventSource;
+  });
+
+  it("streams chunks via EventSource and stops on the done event", async () => {
+    mockApi.fleetStatus.mockResolvedValue({ available: true, reason: null, url: "http://addon" });
+    mockApi.fleetPush.mockResolvedValue({
+      filename: "garage-motion.yaml",
+      created: false,
+      run_id: "run-77",
+      enqueued: 1,
+    });
+    render(<PushToFleetDialog design={design} onClose={() => {}} />);
+    const pushBtn = await screen.findByRole("button", { name: /^Push/i });
+    await waitFor(() => expect(pushBtn).not.toBeDisabled());
+    await userEvent.click(screen.getByRole("checkbox", { name: /compile after upload/i }));
+    await userEvent.click(pushBtn);
+
+    await waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    const es = FakeEventSource.instances[0];
+    expect(es.url).toMatch(/\/api\/fleet\/jobs\/run-77\/log\/stream/);
+
+    es.emitMessage({ log: "compiling...\n", offset: 13, finished: false });
+    await waitFor(() => screen.getByText(/compiling\.\.\./));
+    expect(screen.getByText(/tailing.*\(stream\)/i)).toBeInTheDocument();
+
+    es.emitMessage({ log: "build ok\n", offset: 22, finished: true });
+    await waitFor(() => screen.getByText(/build ok/));
+    await waitFor(() => screen.getByText(/finished/i));
+    // The polling endpoint stays untouched -- SSE handled the run.
+    expect(mockApi.fleetJobLog).not.toHaveBeenCalled();
+  });
+
+  it("falls back to HTTP polling on a transport error", async () => {
+    mockApi.fleetStatus.mockResolvedValue({ available: true, reason: null, url: "http://addon" });
+    mockApi.fleetPush.mockResolvedValue({
+      filename: "garage-motion.yaml",
+      created: false,
+      run_id: "run-88",
+      enqueued: 1,
+    });
+    mockApi.fleetJobLog.mockResolvedValueOnce({
+      log: "fallback ok\n", offset: 12, finished: true,
+    });
+    render(<PushToFleetDialog design={design} onClose={() => {}} />);
+    const pushBtn = await screen.findByRole("button", { name: /^Push/i });
+    await waitFor(() => expect(pushBtn).not.toBeDisabled());
+    await userEvent.click(screen.getByRole("checkbox", { name: /compile after upload/i }));
+    await userEvent.click(pushBtn);
+
+    await waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    const es = FakeEventSource.instances[0];
+    // Simulate a transport hiccup: onerror fires while readyState is OPEN.
+    es.onerror?.();
+
+    await waitFor(() => expect(mockApi.fleetJobLog).toHaveBeenCalledTimes(1));
+    await waitFor(() => screen.getByText(/fallback ok/));
+    await waitFor(() => screen.getByText(/finished/i));
+    expect(screen.queryByText(/\(stream\)/i)).not.toBeInTheDocument();
+  });
+
+  it("surfaces a server-emitted error event without falling back", async () => {
+    mockApi.fleetStatus.mockResolvedValue({ available: true, reason: null, url: "http://addon" });
+    mockApi.fleetPush.mockResolvedValue({
+      filename: "garage-motion.yaml",
+      created: false,
+      run_id: "run-bad",
+      enqueued: 1,
+    });
+    render(<PushToFleetDialog design={design} onClose={() => {}} />);
+    const pushBtn = await screen.findByRole("button", { name: /^Push/i });
+    await waitFor(() => expect(pushBtn).not.toBeDisabled());
+    await userEvent.click(screen.getByRole("checkbox", { name: /compile after upload/i }));
+    await userEvent.click(pushBtn);
+
+    await waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    const es = FakeEventSource.instances[0];
+    es.emitNamed("error", { message: "unknown run_id 'run-bad'" });
+
+    await waitFor(() => screen.getByText(/log error: unknown run_id/i));
+    // Server-side logical error does NOT trigger the polling fallback.
+    expect(mockApi.fleetJobLog).not.toHaveBeenCalled();
+  });
+});
+
 describe("build-log multi-chunk polling", () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });

--- a/web/src/components/PushToFleetDialog.tsx
+++ b/web/src/components/PushToFleetDialog.tsx
@@ -6,6 +6,10 @@ const LOG_POLL_INTERVAL_MS = 1500;
 
 interface Props {
   design: Design;
+  /** When true, ask the server to refuse the push if the design has any
+   *  warn/error compatibility entries. Defaults to false; the App's
+   *  header strict-mode toggle drives this. */
+  strict?: boolean;
   onClose: () => void;
 }
 
@@ -18,7 +22,7 @@ interface Props {
  * Status is fetched on open so we can disable the button + show why the
  * fleet isn't reachable when it isn't.
  */
-export function PushToFleetDialog({ design, onClose }: Props) {
+export function PushToFleetDialog({ design, strict = false, onClose }: Props) {
   const [status, setStatus] = useState<FleetStatus | null>(null);
   const [statusError, setStatusError] = useState<string | null>(null);
   const fleet = (design.fleet as Record<string, unknown> | undefined) ?? undefined;
@@ -98,6 +102,7 @@ export function PushToFleetDialog({ design, onClose }: Props) {
         design,
         compile,
         device_name: deviceName.trim() || undefined,
+        strict,
       });
       setResult(r);
       if (r.run_id) {
@@ -105,10 +110,27 @@ export function PushToFleetDialog({ design, onClose }: Props) {
         void pollJobLog(r.run_id);
       }
     } catch (e) {
-      const msg = e instanceof ApiError
-        ? `${e.status}: ${typeof e.body === "object" && e.body && "detail" in e.body
-            ? String((e.body as { detail: unknown }).detail) : e.message}`
-        : e instanceof Error ? e.message : String(e);
+      let msg: string;
+      if (e instanceof ApiError) {
+        const body = e.body as
+          | { detail?: unknown }
+          | undefined;
+        const detail = body?.detail;
+        if (
+          typeof detail === "object" && detail !== null &&
+          (detail as { error?: string }).error === "strict_mode_blocked"
+        ) {
+          // Surface the strict envelope's friendly message; the warnings
+          // themselves already render in the design pane via the regular
+          // compatibility flow.
+          const d = detail as { message?: string; warnings?: unknown[] };
+          msg = `${e.status}: ${d.message ?? "strict mode refused the push"}`;
+        } else {
+          msg = `${e.status}: ${typeof detail === "string" ? detail : e.message}`;
+        }
+      } else {
+        msg = e instanceof Error ? e.message : String(e);
+      }
       setPushError(msg);
     } finally {
       setPushing(false);
@@ -183,6 +205,14 @@ export function PushToFleetDialog({ design, onClose }: Props) {
               Lowercase letters, digits, and hyphens only (max 64).
             </p>
           </div>
+
+          {strict && (
+            <div className="rounded border border-amber-700/40 bg-amber-900/15 px-3 py-2 text-[11px] text-amber-200">
+              Strict mode is on. The push will be refused if the design has any
+              warn/error compatibility entries; resolve them or toggle strict
+              off in the header to ship anyway.
+            </div>
+          )}
 
           <label className="flex cursor-pointer items-start gap-2 rounded border border-zinc-800 bg-zinc-900/40 px-3 py-2">
             <input

--- a/web/src/components/PushToFleetDialog.tsx
+++ b/web/src/components/PushToFleetDialog.tsx
@@ -37,8 +37,10 @@ export function PushToFleetDialog({ design, strict = false, onClose }: Props) {
   const [logText, setLogText] = useState<string>("");
   const [logFinished, setLogFinished] = useState<boolean>(false);
   const [logError, setLogError] = useState<string | null>(null);
+  const [logTransport, setLogTransport] = useState<"sse" | "poll" | null>(null);
   const logScrollRef = useRef<HTMLPreElement | null>(null);
   const pollAbortRef = useRef<{ stop: boolean }>({ stop: false });
+  const eventSourceRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -56,6 +58,8 @@ export function PushToFleetDialog({ design, strict = false, onClose }: Props) {
     return () => {
       cancelled = true;
       pollAbortRef.current.stop = true;
+      eventSourceRef.current?.close();
+      eventSourceRef.current = null;
     };
   }, []);
 
@@ -66,13 +70,87 @@ export function PushToFleetDialog({ design, strict = false, onClose }: Props) {
     }
   }, [logText]);
 
-  async function pollJobLog(runId: string) {
-    const abort = pollAbortRef.current;
-    abort.stop = false;
-    let offset = 0;
+  /**
+   * Open an EventSource against `/api/fleet/jobs/<runId>/log/stream` and
+   * append each chunk to the log viewer. Returns true on success (the
+   * EventSource opened); returns false if the browser doesn't have
+   * EventSource at all so the caller can fall back to polling.
+   *
+   * The server emits `data:` frames (chunks), an `event: done` frame at
+   * the end of a successful run, and an `event: error` frame when the
+   * addon rejects the stream (e.g., unknown run_id). A transport-level
+   * onerror flips us back to polling so a flaky proxy never strands the
+   * UI in "tailing…" forever.
+   */
+  function streamJobLog(runId: string): boolean {
+    if (typeof EventSource === "undefined") return false;
     setLogText("");
     setLogFinished(false);
     setLogError(null);
+    setLogTransport("sse");
+    const es = new EventSource(`/api/fleet/jobs/${encodeURIComponent(runId)}/log/stream`);
+    eventSourceRef.current = es;
+    let lastOffset = 0;
+
+    es.onmessage = (ev) => {
+      try {
+        const chunk = JSON.parse(ev.data) as {
+          log: string; offset: number; finished: boolean;
+        };
+        if (chunk.log) setLogText((prev) => prev + chunk.log);
+        lastOffset = chunk.offset;
+        if (chunk.finished) {
+          setLogFinished(true);
+          es.close();
+          eventSourceRef.current = null;
+        }
+      } catch {
+        // Ignore malformed frames; the next valid one will land.
+      }
+    };
+    es.addEventListener("done", () => {
+      setLogFinished(true);
+      es.close();
+      eventSourceRef.current = null;
+    });
+    es.addEventListener("error", (ev) => {
+      // Server-emitted error frame (named `error`). The data carries a
+      // {message} envelope; surface it and stop -- no fallback poll
+      // because this is a logical failure, not a transport hiccup.
+      const me = ev as MessageEvent;
+      try {
+        const data = JSON.parse(me.data ?? "{}") as { message?: string };
+        if (data.message) setLogError(data.message);
+      } catch {
+        // Server-emitted error without a parseable body.
+      }
+      es.close();
+      eventSourceRef.current = null;
+    });
+    es.onerror = () => {
+      // Transport-level failure (network, proxy buffering, server died).
+      // Fall back to polling from the offset we last accepted.
+      if (es.readyState === EventSource.CLOSED) return;
+      es.close();
+      eventSourceRef.current = null;
+      setLogTransport("poll");
+      void pollJobLog(runId, lastOffset);
+    };
+    return true;
+  }
+
+  /** HTTP polling fallback. Used directly when EventSource isn't
+   *  available, or as a fallback when the SSE transport errors. */
+  async function pollJobLog(runId: string, startOffset = 0) {
+    const abort = pollAbortRef.current;
+    abort.stop = false;
+    let offset = startOffset;
+    if (startOffset === 0) {
+      setLogText("");
+      setLogFinished(false);
+      setLogError(null);
+    }
+    setLogTransport("poll");
     while (!abort.stop) {
       try {
         const chunk = await api.fleetJobLog(runId, offset);
@@ -93,6 +171,15 @@ export function PushToFleetDialog({ design, strict = false, onClose }: Props) {
     }
   }
 
+  /** Pick the best transport for tailing this run's log. Tries SSE
+   *  first; the polling path is the fallback the SSE handler installs
+   *  on transport error. */
+  function tailJobLog(runId: string) {
+    if (!streamJobLog(runId)) {
+      void pollJobLog(runId);
+    }
+  }
+
   async function handlePush() {
     setPushing(true);
     setPushError(null);
@@ -106,8 +193,9 @@ export function PushToFleetDialog({ design, strict = false, onClose }: Props) {
       });
       setResult(r);
       if (r.run_id) {
-        // Fire-and-forget: the polling loop respects pollAbortRef.
-        void pollJobLog(r.run_id);
+        // Fire-and-forget: SSE first, polling as a fallback. Both paths
+        // respect the abort/event-source refs cleaned up on unmount.
+        tailJobLog(r.run_id);
       }
     } catch (e) {
       let msg: string;
@@ -257,7 +345,11 @@ export function PushToFleetDialog({ design, strict = false, onClose }: Props) {
                   build log
                 </label>
                 <span className="text-[11px] text-zinc-500">
-                  {logFinished ? "finished" : logError ? "stopped" : "tailing…"}
+                  {logFinished
+                    ? "finished"
+                    : logError
+                      ? "stopped"
+                      : `tailing… ${logTransport === "sse" ? "(stream)" : logTransport === "poll" ? "(poll)" : ""}`}
                 </span>
               </div>
               <pre

--- a/web/src/lib/design.test.ts
+++ b/web/src/lib/design.test.ts
@@ -14,6 +14,7 @@ import {
   readRequirements,
   readWarnings,
   removeBus,
+  renameBus,
   removeComponent,
   removeRequirement,
   removeWarning,
@@ -490,5 +491,45 @@ describe("buses", () => {
   it("removeBus on unknown id is a no-op", () => {
     const next = removeBus(baseDesign, "ghost");
     expect(next.buses).toEqual(baseDesign.buses);
+  });
+
+  it("updateBus silently strips an `id` patch (use renameBus instead)", () => {
+    const next = updateBus(baseDesign, "i2c0", { id: "evil", sda: "D7" });
+    const buses = next.buses as Array<Record<string, unknown>>;
+    expect(buses[0]).toMatchObject({ id: "i2c0", sda: "D7" });
+  });
+
+  it("renameBus rewrites every connection that targeted the old id", () => {
+    const next = renameBus(baseDesign, "i2c0", "shared_i2c");
+    const buses = next.buses as Array<Record<string, unknown>>;
+    expect(buses[0].id).toBe("shared_i2c");
+    const conns = next.connections as Array<{ target: { kind: string; bus_id?: string } }>;
+    expect(conns[1].target).toEqual({ kind: "bus", bus_id: "shared_i2c" });
+    // Non-bus connections are untouched.
+    expect(conns[0].target).toEqual({ kind: "gpio", pin: "D2" });
+  });
+
+  it("renameBus is a no-op when oldId === newId", () => {
+    const next = renameBus(baseDesign, "i2c0", "i2c0");
+    expect(next).toBe(baseDesign);
+  });
+
+  it("renameBus is a no-op when the new id collides with another bus", () => {
+    const seeded = addBus(baseDesign, "spi");
+    const next = renameBus(seeded, "i2c0", "spi0");
+    const buses = next.buses as Array<Record<string, unknown>>;
+    // No rename happened; the SPI bus is still present and the I2C still i2c0.
+    expect(buses.map((b) => b.id)).toEqual(["i2c0", "spi0"]);
+  });
+
+  it("renameBus is a no-op when the source id doesn't exist", () => {
+    const next = renameBus(baseDesign, "ghost", "renamed");
+    expect(next).toBe(baseDesign);
+  });
+
+  it("renameBus does not mutate the input", () => {
+    const before = clone(baseDesign);
+    renameBus(baseDesign, "i2c0", "shared_i2c");
+    expect(baseDesign).toEqual(before);
   });
 });

--- a/web/src/lib/design.test.ts
+++ b/web/src/lib/design.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  addBus,
   addComponent,
   addRequirement,
   addWarning,
@@ -12,11 +13,14 @@ import {
   readConnections,
   readRequirements,
   readWarnings,
+  removeBus,
   removeComponent,
   removeRequirement,
   removeWarning,
   setBoardLibraryId,
   setFleetField,
+  setLockedPin,
+  updateBus,
   updateComponentParam,
   updateConnectionTarget,
   updateRequirement,
@@ -395,5 +399,96 @@ describe("isDirty", () => {
   it("returns true after a mutating helper runs", () => {
     const next = updateComponentParam(baseDesign, "bme1", "address", "0x77");
     expect(isDirty(baseDesign, next)).toBe(true);
+  });
+});
+
+
+describe("locked_pins", () => {
+  it("readConnections lifts locked_pin from the matching component", () => {
+    const d = clone(baseDesign);
+    (d.components as Array<Record<string, unknown>>)[0].locked_pins = { OUT: "D5" };
+    const rows = readConnections(d, "pir1");
+    expect(rows[0].locked_pin).toBe("D5");
+  });
+
+  it("readConnections leaves locked_pin null when no lock exists", () => {
+    const rows = readConnections(baseDesign, "pir1");
+    expect(rows[0].locked_pin).toBeNull();
+  });
+
+  it("setLockedPin writes a new entry", () => {
+    const next = setLockedPin(baseDesign, "pir1", "OUT", "D6");
+    const c = (next.components as Array<Record<string, unknown>>)[0];
+    expect(c.locked_pins).toEqual({ OUT: "D6" });
+    // input unchanged
+    expect((baseDesign.components as Array<Record<string, unknown>>)[0].locked_pins).toBeUndefined();
+  });
+
+  it("setLockedPin removes the field entirely when the map empties", () => {
+    const seeded = setLockedPin(baseDesign, "pir1", "OUT", "D6");
+    const cleared = setLockedPin(seeded, "pir1", "OUT", null);
+    const c = (cleared.components as Array<Record<string, unknown>>)[0];
+    expect(c.locked_pins).toBeUndefined();
+  });
+
+  it("setLockedPin treats empty string the same as null", () => {
+    const seeded = setLockedPin(baseDesign, "pir1", "OUT", "D6");
+    const cleared = setLockedPin(seeded, "pir1", "OUT", "");
+    const c = (cleared.components as Array<Record<string, unknown>>)[0];
+    expect(c.locked_pins).toBeUndefined();
+  });
+
+  it("setLockedPin preserves locks for sibling roles", () => {
+    const seeded = setLockedPin(baseDesign, "pir1", "OUT", "D6");
+    const next = setLockedPin(seeded, "pir1", "VCC", "5V");
+    const c = (next.components as Array<Record<string, unknown>>)[0];
+    expect(c.locked_pins).toEqual({ OUT: "D6", VCC: "5V" });
+  });
+
+  it("setLockedPin is a no-op for unknown component ids", () => {
+    const next = setLockedPin(baseDesign, "ghost", "OUT", "D6");
+    expect(next.components).toEqual(baseDesign.components);
+  });
+});
+
+describe("buses", () => {
+  it("addBus appends a fresh bus with auto-id", () => {
+    const next = addBus(baseDesign, "spi");
+    const buses = next.buses as Array<Record<string, unknown>>;
+    expect(buses.length).toBe(2);
+    expect(buses[1]).toMatchObject({ id: "spi0", type: "spi" });
+  });
+
+  it("addBus skips ids already used", () => {
+    const seeded = addBus(baseDesign, "i2c");
+    const buses = seeded.buses as Array<Record<string, unknown>>;
+    // baseDesign has i2c0; addBus must pick i2c1.
+    expect(buses[1]).toMatchObject({ id: "i2c1", type: "i2c" });
+  });
+
+  it("addBus seeds from defaults when provided", () => {
+    const next = addBus(baseDesign, "uart", { tx: "D1", rx: "D2", baud_rate: "9600" });
+    const buses = next.buses as Array<Record<string, unknown>>;
+    expect(buses[1]).toMatchObject({ id: "uart0", type: "uart", tx: "D1", rx: "D2" });
+  });
+
+  it("updateBus patches a single bus immutably", () => {
+    const next = updateBus(baseDesign, "i2c0", { sda: "D6", frequency_hz: 400000 });
+    const b = (next.buses as Array<Record<string, unknown>>)[0];
+    expect(b).toMatchObject({ id: "i2c0", sda: "D6", scl: "D1", frequency_hz: 400000 });
+    // input untouched
+    expect((baseDesign.buses as Array<Record<string, unknown>>)[0]).not.toMatchObject({ sda: "D6" });
+  });
+
+  it("removeBus drops the matching bus and leaves others alone", () => {
+    const seeded = addBus(baseDesign, "spi");
+    const next = removeBus(seeded, "i2c0");
+    const buses = next.buses as Array<Record<string, unknown>>;
+    expect(buses.map((b) => b.id)).toEqual(["spi0"]);
+  });
+
+  it("removeBus on unknown id is a no-op", () => {
+    const next = removeBus(baseDesign, "ghost");
+    expect(next.buses).toEqual(baseDesign.buses);
   });
 });

--- a/web/src/lib/design.ts
+++ b/web/src/lib/design.ts
@@ -18,7 +18,8 @@ export type ConnectionTarget =
       number: number;
       mode?: string;
       inverted?: boolean;
-    };
+    }
+  | { kind: "component"; component_id: string };
 
 export interface ConnectionRow {
   index: number;       // index into design.connections, for stable identity

--- a/web/src/lib/design.ts
+++ b/web/src/lib/design.ts
@@ -408,16 +408,52 @@ export function addBus(
   return { ...d, buses: [...buses, newBus] };
 }
 
-/** Patch a single bus by id. Pure: returns a new design. */
+/** Patch a single bus by id. Pure: returns a new design.
+ *
+ *  NOTE: do NOT pass `id` in the patch -- a bus rename is more than a
+ *  field write because every `connection.target.bus_id` referencing the
+ *  old id has to follow. Use `renameBus` for that path; this helper
+ *  silently strips an `id` key to keep the connection table from
+ *  drifting out of sync. */
 export function updateBus(
   d: Design,
   busId: string,
   patch: Partial<Record<string, unknown>>,
 ): Design {
   const buses = (d.buses as Array<Record<string, unknown>> | undefined) ?? [];
+  const { id: _ignoredId, ...safePatch } = patch;
   return {
     ...d,
-    buses: buses.map((b) => (b.id === busId ? { ...b, ...patch } : b)),
+    buses: buses.map((b) => (b.id === busId ? { ...b, ...safePatch } : b)),
+  };
+}
+
+/**
+ * Rename a bus and rewrite every connection that targets it. Atomic:
+ * the bus list and the connection table never diverge. No-op when
+ * `oldId === newId`. If a bus with `newId` already exists we do
+ * nothing -- the caller (a UI input on blur) is expected to validate
+ * before calling, but the guard here keeps us out of the merge case
+ * where two buses claim the same id.
+ *
+ * Pure: returns a new design.
+ */
+export function renameBus(d: Design, oldId: string, newId: string): Design {
+  if (oldId === newId) return d;
+  const buses = (d.buses as Array<Record<string, unknown>> | undefined) ?? [];
+  if (!buses.some((b) => b.id === oldId)) return d;
+  if (buses.some((b) => b.id === newId)) return d;
+  const connections = (d.connections as Array<Record<string, unknown>> | undefined) ?? [];
+  return {
+    ...d,
+    buses: buses.map((b) => (b.id === oldId ? { ...b, id: newId } : b)),
+    connections: connections.map((c) => {
+      const t = c.target as Record<string, unknown> | undefined;
+      if (t && t.kind === "bus" && t.bus_id === oldId) {
+        return { ...c, target: { ...t, bus_id: newId } };
+      }
+      return c;
+    }),
   };
 }
 

--- a/web/src/lib/design.ts
+++ b/web/src/lib/design.ts
@@ -319,6 +319,7 @@ function defaultTargetForPin(
     spi_clk: "spi", spi_miso: "spi", spi_mosi: "spi",
     i2s_lrclk: "i2s", i2s_bclk: "i2s",
     uart_rx: "uart", uart_tx: "uart",
+    onewire_data: "1wire",
   };
   const wantBus = busKindToType[k];
   if (wantBus) {
@@ -342,6 +343,7 @@ export function neededBusTypes(lib: LibraryComponentDetail): Set<string> {
     else if (p.kind === "spi_clk" || p.kind === "spi_miso" || p.kind === "spi_mosi") need.add("spi");
     else if (p.kind === "i2s_lrclk" || p.kind === "i2s_bclk") need.add("i2s");
     else if (p.kind === "uart_rx" || p.kind === "uart_tx") need.add("uart");
+    else if (p.kind === "onewire_data") need.add("1wire");
   }
   return need;
 }

--- a/web/src/lib/design.ts
+++ b/web/src/lib/design.ts
@@ -25,6 +25,10 @@ export interface ConnectionRow {
   component_id: string;
   pin_role: string;
   target: ConnectionTarget;
+  /** The pin name from `components[i].locked_pins[role]` if the user has
+   *  locked this role; null otherwise. Read-only -- the inspector mutates
+   *  the lock via setLockedPin, not by editing this field. */
+  locked_pin: string | null;
 }
 
 export function readComponents(d: Design | null): ComponentInstance[] {
@@ -70,14 +74,60 @@ export function isDirty(original: Design | null, current: Design | null): boolea
 
 export function readConnections(d: Design | null, componentId?: string): ConnectionRow[] {
   if (!d || !Array.isArray(d.connections)) return [];
+  const components = (d.components as Array<Record<string, unknown>> | undefined) ?? [];
+  const locksByCid = new Map<string, Record<string, string>>();
+  for (const c of components) {
+    const lp = c.locked_pins as Record<string, string> | undefined;
+    if (lp && typeof lp === "object") {
+      locksByCid.set(String(c.id), lp);
+    }
+  }
   return (d.connections as Array<Record<string, unknown>>)
-    .map((c, index) => ({
-      index,
-      component_id: String(c.component_id),
-      pin_role: String(c.pin_role),
-      target: c.target as ConnectionTarget,
-    }))
+    .map((c, index) => {
+      const cid = String(c.component_id);
+      const role = String(c.pin_role);
+      const locks = locksByCid.get(cid);
+      return {
+        index,
+        component_id: cid,
+        pin_role: role,
+        target: c.target as ConnectionTarget,
+        locked_pin: locks && typeof locks[role] === "string" ? locks[role] : null,
+      };
+    })
     .filter((c) => !componentId || c.component_id === componentId);
+}
+
+/**
+ * Set or clear a single (componentId, pinRole) entry in a component's
+ * `locked_pins` map. Passing `null` removes the entry; if the resulting
+ * map is empty the field itself is dropped to keep the JSON tidy.
+ * Pure: never mutates `d`.
+ */
+export function setLockedPin(
+  d: Design,
+  componentId: string,
+  pinRole: string,
+  pin: string | null,
+): Design {
+  const components = (d.components as Array<Record<string, unknown>> | undefined) ?? [];
+  return {
+    ...d,
+    components: components.map((c) => {
+      if (c.id !== componentId) return c;
+      const existing = (c.locked_pins as Record<string, string> | undefined) ?? {};
+      const next: Record<string, string> = { ...existing };
+      if (pin === null || pin === "") {
+        delete next[pinRole];
+      } else {
+        next[pinRole] = pin;
+      }
+      const { locked_pins: _drop, ...rest } = c;
+      return Object.keys(next).length > 0
+        ? { ...rest, locked_pins: next }
+        : rest;
+    }),
+  };
 }
 
 /**
@@ -340,6 +390,42 @@ function nextBusId(
     if (!used.has(id)) return id;
   }
   return `${type}_${Date.now()}`;
+}
+
+export type BusType = "i2c" | "spi" | "uart" | "i2s" | "1wire";
+
+/** Add a bus of the given type; the new bus inherits the board's default
+ * pinout when one is present, otherwise lands with empty pin slots and
+ * relies on the user (or the pin solver) to fill them in. Pure. */
+export function addBus(
+  d: Design,
+  type: BusType,
+  defaults?: Record<string, string>,
+): Design {
+  const buses = (d.buses as Array<Record<string, unknown>> | undefined) ?? [];
+  const id = nextBusId(d, [], type);
+  const newBus: Record<string, unknown> = { id, type, ...(defaults ?? {}) };
+  return { ...d, buses: [...buses, newBus] };
+}
+
+/** Patch a single bus by id. Pure: returns a new design. */
+export function updateBus(
+  d: Design,
+  busId: string,
+  patch: Partial<Record<string, unknown>>,
+): Design {
+  const buses = (d.buses as Array<Record<string, unknown>> | undefined) ?? [];
+  return {
+    ...d,
+    buses: buses.map((b) => (b.id === busId ? { ...b, ...patch } : b)),
+  };
+}
+
+/** Remove a bus. Connections that target it are left in place; the
+ *  inspector's bus-mismatch warning handles the dangling references. */
+export function removeBus(d: Design, busId: string): Design {
+  const buses = (d.buses as Array<Record<string, unknown>> | undefined) ?? [];
+  return { ...d, buses: buses.filter((b) => b.id !== busId) };
 }
 
 /**

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,16 @@
+/**
+ * Vitest global setup. Imported once per test file via vitest.config.ts.
+ *
+ * Brings in @testing-library/jest-dom matchers (toBeInTheDocument,
+ * toHaveClass, etc.) and a jsdom shim for the few browser APIs the
+ * components touch but jsdom doesn't ship.
+ */
+import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+// Unmount any rendered tree between tests so DOM queries from one
+// test never leak into the next.
+afterEach(() => {
+  cleanup();
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "./vite.config";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+      setupFiles: ["./src/test/setup.ts"],
+      globals: false,
+      // Existing pure-logic tests under src/lib don't need jsdom but the
+      // overhead is negligible at this scale, so we keep one config.
+      include: ["src/**/*.test.{ts,tsx}"],
+    },
+  }),
+);


### PR DESCRIPTION
Folds 16 commits worth of 0.7 ship + 0.7+ iterations + pre-0.8 cleanup into main. Started with the bare-bones distributed-esphome handoff and ended with a feature-complete UI ready for the 0.8 / 0.9 milestones to start.

## Themes

### 0.7 fleet handoff
- **f48daca** initial `studio/fleet/client.py` + `/fleet/{status,push}` endpoints, header **Push to fleet** modal, addon's `/ui/api/*` over Bearer token. `FLEET_URL` + `FLEET_TOKEN` env vars on the API server.
- **b0663de** build-log polling: `GET /fleet/jobs/{run_id}/log` relays the addon's HTTP fallback, dialog tails it at 1.5s and renders a scrolling `<pre>` viewer once a compile is enqueued.
- **15c8eb2** SSE log relay: `/fleet/jobs/{run_id}/log/stream` polls the addon at ~300ms server-side and streams Server-Sent Events. Dialog tries `EventSource` first, falls back to the polling loop on transport error at the last accepted offset so no log bytes are lost. Status pill shows `(stream)` vs `(poll)`.
- **9917c26** strict-only push gate: `POST /fleet/push` accepts `strict: bool` and refuses with the same `strict_mode_blocked` envelope `/design/render?strict=true` uses when warn/error compat entries remain.

### 0.7+ feature surface
- **59ac595** capability-driven **Add by function** picker. New `GET /library/use_cases` aggregates the canonical capability vocabulary; two-pane dialog ranks library components for the picked use case (or free text) using the existing `/library/recommend`.
- **53e77bb** picker alternatives disclosure + RTL/jsdom scaffold. Each match expands an inline list of OTHER matches with score deltas (emerald when the alternative beats, muted when worse). New `vitest.config.ts` with `environment: "jsdom"` + `@testing-library/jest-dom` matchers.
- **811c8ad** ConnectionForm + PushToFleetDialog tests + strict-mode toggle. `POST /design/render?strict=true` rejects renders with warn/error compat entries; header gains an amber-tinted "strict" checkbox.
- **a297f60 / 4c41595** pin locks (solver + compat + UI). New `locked_pins[role] -> pin` map per component; solver applies locks, surfaces mismatches; compatibility checker validates the locked pin satisfies the role's required capability. Inspector gains a 🔓/🔒 toggle next to each gpio pin selector.
- **4c41595** bus editor in the design inspector (rename id, edit pin slots per type, add/remove buses).
- **1c1a382** bus rename propagation + inline bus warnings. `renameBus` rewrites every connection's `bus_id` atomically; bus card filters whole-design compat warnings down to its own.

### Library expansion (10 new components)
- **9917c26** RCWL-0516 (microwave motion, low-power PIR alternative) + DS18B20 (1-wire temp).
- **8daf012** 1-wire bus type promotion. `Bus.pin` field; multiple DS18B20s on a shared physical wire emit ONE `one_wire:` block + N `dallas_temp` sensors. New `examples/multi-temp.json` + golden artifacts pin the round-trip.
- **9fff499** ADS1115 + MPU6050 + Inspector composition tests.
- **381a83b** v3 batch: BMP180, HTU21D, MAX31855 (SPI thermocouple), HX711 (load-cell ADC), TSL2561 (lux).
- **b3b6803** ADS1115 hub-only split: new `kind: "component"` connection target lets `ads1115_channel` reference its `ads1115` hub by id. Channels become first-class components with their own params row instead of being buried inside an array. Generic — future hub patterns (RGB controllers, mux chips) reuse it.

### UX cleanup (pre-0.8)
- **94ee2a7** drag-and-drop pinout view. Native HTML5 DnD; two-column visual layout (board GPIOs with capability badges on the left, draggable connection chips on the right). Conflict detection paints rose on pins another component uses; pins held by this instance glow emerald. Form/Pinout toggle in the inspector — Form remains default since it covers every target kind.
- **b0663de** ADC2/WiFi conflict detection on classic ESP32. ADC2 pins (GPIO0,2,4,12-15,25-27) tagged; analog_in landing on one warns. Pin solver prefers ADC1 (GPIO32-39) for unbound analog_in.
- **9fff499** Inspector composition tests + RTL coverage of the design pane (9 cases).

### Roadmap
- **3b5ee61** 0.9 KiCad schematic export scope expanded with the architectural rationale for keeping our library canonical for ESPHome semantics while leaning on `kicad-symbols` for the schematic-rendering layer (concrete `kicad:` block shape with `pin_map`, SKiDL-driven generator, `studio/kicad/scaffold.py` helper, PCB layout deferred to 1.0+).

## Test counts

| | Before (origin/main tip) | After |
|---|---|---|
| pytest | 213 | **242** (+29) |
| vitest | 96 | **115** (+19) |
| Library components | 14 | **22** (+8) |
| Boards | 6 | 6 |
| Examples + goldens | 12 | **13** (+ multi-temp) |

Ruff + tsc + vite build clean across the whole arc.

## Test plan

- [ ] `python -m pytest` (242 tests in ~6s)
- [ ] `python -m ruff check .` (clean)
- [ ] `cd web && npm run build && npx vitest run` (115 tests in ~5s, build clean)
- [ ] Smoke: `python -m studio.api` + `cd web && npm run dev`, open inspector, confirm Form/Pinout toggle, capability picker, bus editor, strict-mode toggle, push-to-fleet (against a real or mocked addon)

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_