### PR TITLE
0.8 v2: enclosure search relay (Thingiverse) + tabbed dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Useful endpoints:
 | `POST` | `/design/validate` | parse a `design.json`, return summary or 422 |
 | `POST` | `/design/render` | parse + render a `design.json` to `{yaml, ascii}` |
 | `POST` | `/design/enclosure/openscad` | generate a parametric `.scad` shell for the design's board |
+| `GET`  | `/enclosure/search?library_id=...&query=...` | search community-uploaded enclosure models (Thingiverse) |
+| `GET`  | `/enclosure/search/status` | per-source availability + configure hints |
 | `GET`  | `/examples` | list bundled examples |
 | `GET`  | `/examples/{id}` | fetch an example as raw `design.json` |
 | `GET`  | `/fleet/status` | check whether `FLEET_URL` + `FLEET_TOKEN` reach a distributed-esphome ha-addon |

--- a/START.md
+++ b/START.md
@@ -27,17 +27,62 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 + build clean.
 
 **Next up candidates:**
-- 0.8 v2 — Thingiverse / Printables search relay. Pulls
-  community-uploaded models that already fit the chosen board, ranks
-  them, and surfaces the top hits in the same dialog as the
-  generator. Thingiverse has a documented API (key + rate limits);
-  Printables needs scraping or unofficial endpoints. `httpx.MockTransport`
-  for tests, same pattern as the fleet client.
 - 0.9 — KiCad schematic export. Full scope in the Roadmap section
   below; key points: SKiDL-driven, `kicad:` reference block per
   component/board (we stay canonical for ESPHome semantics, KiCad
   for schematic rendering), `studio/kicad/scaffold.py` helper for
   cheap library expansion, PCB deferred to 1.0+.
+- Printables search source. Currently deferred -- Printables
+  doesn't expose a public REST/GraphQL API and scraping their
+  internals is fragile (the page-level GraphQL endpoint changes
+  without notice + their CDN aggressively rate-limits unauthenticated
+  reads). Revisit when they ship a documented API or a community
+  proxy stabilises. The studio surfaces the gap honestly via the
+  search-status endpoint (`available: false, reason: "Printables
+  search deferred -- no public API yet"`) so users see why it's
+  empty rather than wondering if something broke.
+- 0.9 — KiCad schematic export. Full scope in the Roadmap section
+  below; key points: SKiDL-driven, `kicad:` reference block per
+  component/board (we stay canonical for ESPHome semantics, KiCad
+  for schematic rendering), `studio/kicad/scaffold.py` helper for
+  cheap library expansion, PCB deferred to 1.0+.
+
+**0.8 v2 -- enclosure search relay shipped (Thingiverse).**
+`studio/enclosure/search.py` adds a pluggable per-source search client.
+v2 ships the Thingiverse implementation (documented API, free
+`THINGIVERSE_API_KEY` token from https://www.thingiverse.com/developers,
+~300 req/hour rate limit). The Printables source is included in the
+catalogue but always reports `available: false, reason: "Printables
+search deferred -- no public API yet"`; deferred deliberately because
+their public API is undocumented, their internal GraphQL endpoint
+changes without notice, and their CDN rate-limits unauthenticated
+reads. Revisit when a documented API or stable community proxy
+appears.
+
+`GET /enclosure/search?library_id=<board>&query=<refinement>` runs the
+constructed query (`<board.name> enclosure [<refinement>]`) against
+every configured source and returns the merged ranked results
+alongside per-source statuses so the UI can render configuration
+hints when a source is unconfigured. `GET /enclosure/search/status`
+surfaces the same status list ahead of any actual search.
+
+The header **Generate enclosure** button is replaced by a single
+**Enclosure** button that opens a tabbed dialog: Generate (the
+original parametric `.scad` download path) and Search (the new
+relay). The Search tab fires an initial query on first open with
+no refinement, renders per-source status banners (emerald for
+available, amber for unavailable + the configure hint), and shows
+results as cards with thumbnail + creator + likes that link out to
+the source. A free-text refinement field re-fires the search; a
+cancellation guard via a ticket ref prevents stale responses from
+overwriting newer ones.
+
+20 new pytest cases (17 search-client unit tests + 3 endpoint
+contract tests using the existing `httpx.MockTransport` pattern from
+the fleet client). 5 new vitest cases for the dialog (Generate
+success + 422 banner; Search initial fetch + result rendering;
+refinement round-trip; configuration-hint surface when no source
+is available).
 
 **0.8 v1 -- parametric OpenSCAD enclosure generator shipped.** Each
 of the 5 dev-board YAMLs (`wemos-d1-mini`, `esp32-devkitc-v4`,
@@ -572,10 +617,17 @@ immediate way in and the agent (when it arrives) lands in a working surface.
     so the user dials in fit without re-rendering. Endpoint
     `POST /design/enclosure/openscad`; header **Generate enclosure**
     button triggers a browser download.
-  - **v2 — Thingiverse / Printables search relay.** Pull
-    community-uploaded models that fit the chosen board + components,
-    rank them, and surface the top hits alongside the generator.
-    Same `enclosure:` metadata feeds the search query.
+  - **v2 ✅ Shipped (Thingiverse search relay).** Pluggable
+    per-source search at `studio/enclosure/search.py`. Thingiverse
+    implementation gated on `THINGIVERSE_API_KEY`. Printables
+    deliberately deferred (no public API yet; their internal GraphQL
+    endpoint changes without notice and the CDN rate-limits
+    unauthenticated reads -- the source stays in the catalogue but
+    always reports `available: false` with a "deferred" reason so
+    the UI surfaces the gap honestly). `GET /enclosure/search`
+    + `GET /enclosure/search/status` endpoints. The header
+    **Generate enclosure** button is now a single **Enclosure**
+    button opening a tabbed dialog (Generate / Search).
   - **Stretch — component dimensions on breakouts** (BME280 module,
     OLED module, etc.) so the generator can place display windows
     and stack-mount cutouts, not just the headline USB port.

--- a/studio/api/app.py
+++ b/studio/api/app.py
@@ -45,7 +45,13 @@ from studio.api.schemas import (
 from studio.fleet.client import FleetClient, FleetUnavailable
 from studio.csp.compatibility import check_pin_compatibility
 from studio.csp.pin_solver import solve_pins as run_solve_pins
-from studio.enclosure import EnclosureUnavailable, generate_scad
+from studio.enclosure import (
+    EnclosureUnavailable,
+    default_sources,
+    generate_scad,
+    query_for_board,
+    search_enclosures,
+)
 from studio.recommend.recommender import Constraints, recommend_components
 from studio.generate.ascii_gen import render_ascii
 from studio.generate.yaml_gen import render_yaml
@@ -310,6 +316,67 @@ def create_app(
                 "Content-Disposition": f'attachment; filename="{filename}"',
             },
         )
+
+    @app.get("/enclosure/search/status", tags=["enclosure"])
+    def enclosure_search_status() -> dict:
+        """Per-source availability for the enclosure-search relay.
+        Used by the UI to gate the Search tab and surface configuration
+        hints when a source is unconfigured."""
+        return {
+            "sources": [
+                {
+                    "source": s.source,
+                    "available": s.available,
+                    "reason": s.reason,
+                    "configure_hint": s.configure_hint,
+                }
+                for s in (src.status() for src in default_sources())
+            ],
+        }
+
+    @app.get("/enclosure/search", tags=["enclosure"])
+    def enclosure_search(
+        library_id: str,
+        query: Optional[str] = None,
+        limit: int = 20,
+    ) -> dict:
+        """Search community-uploaded 3D enclosure models for the named
+        board. Query construction: `<board_name> enclosure [<query>]`.
+        Results merge across every configured source (Thingiverse only
+        in v2; Printables stays deferred). 404 when library_id is
+        unknown."""
+        try:
+            board = lib.board(library_id)
+        except FileNotFoundError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
+        full_query = query_for_board(board.name, query)
+        capped = max(1, min(limit, 50))
+        out = search_enclosures(full_query, limit=capped)
+        return {
+            "query": out.query,
+            "sources": [
+                {
+                    "source": s.source,
+                    "available": s.available,
+                    "reason": s.reason,
+                    "configure_hint": s.configure_hint,
+                }
+                for s in out.sources
+            ],
+            "results": [
+                {
+                    "source": h.source,
+                    "id": h.id,
+                    "title": h.title,
+                    "creator": h.creator,
+                    "thumbnail_url": h.thumbnail_url,
+                    "model_url": h.model_url,
+                    "likes": h.likes,
+                    "summary": h.summary,
+                }
+                for h in out.results
+            ],
+        }
 
     @app.get("/examples", response_model=list[ExampleSummary], tags=["examples"])
     def list_examples() -> list[ExampleSummary]:

--- a/studio/enclosure/__init__.py
+++ b/studio/enclosure/__init__.py
@@ -1,5 +1,30 @@
-"""Enclosure helpers (0.8). v1 ships the parametric OpenSCAD generator;
-v2 will add the Thingiverse / Printables search relay."""
-from studio.enclosure.openscad import EnclosureUnavailable, generate_scad
+"""Enclosure helpers (0.8).
 
-__all__ = ["EnclosureUnavailable", "generate_scad"]
+v1 ships the parametric OpenSCAD generator; v2 adds the
+Thingiverse / Printables search relay. The two surfaces share the
+board's `enclosure:` metadata as input.
+"""
+from studio.enclosure.openscad import EnclosureUnavailable, generate_scad
+from studio.enclosure.search import (
+    EnclosureHit,
+    PrintablesSource,
+    SearchResponse,
+    SourceStatus,
+    ThingiverseSource,
+    default_sources,
+    query_for_board,
+    search_enclosures,
+)
+
+__all__ = [
+    "EnclosureUnavailable",
+    "generate_scad",
+    "EnclosureHit",
+    "SearchResponse",
+    "SourceStatus",
+    "ThingiverseSource",
+    "PrintablesSource",
+    "default_sources",
+    "query_for_board",
+    "search_enclosures",
+]

--- a/studio/enclosure/search.py
+++ b/studio/enclosure/search.py
@@ -1,0 +1,217 @@
+"""Search clients for community-uploaded 3D enclosure models.
+
+0.8 v2 ships a single source -- Thingiverse (documented API, reachable
+with a free key). Printables doesn't expose a public API yet; we leave
+a stub source whose `is_configured()` always returns False with a
+"deferred" reason, surfaced by the status endpoint so users see the
+gap rather than being silently down a hit.
+
+Each source returns a list of `EnclosureHit` records the API can
+serialise verbatim. The query is built from the board's display name
+plus an optional user-supplied refinement -- e.g., "ESP32 DevKitC
+enclosure" -> ranked Thingiverse results.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional, Protocol
+
+import httpx
+
+
+@dataclass
+class EnclosureHit:
+    """One row in a search result list."""
+    source: str            # thingiverse | printables | ...
+    id: str                # source-native id (string for portability)
+    title: str
+    creator: Optional[str]
+    thumbnail_url: Optional[str]
+    model_url: str
+    likes: Optional[int] = None
+    summary: Optional[str] = None
+
+
+@dataclass
+class SourceStatus:
+    """Per-source configuration / availability surface."""
+    source: str
+    available: bool
+    reason: Optional[str] = None
+    # Free-text note carrying the configuration handle (env var name,
+    # etc.) so the UI can guide the user to enable a missing source.
+    configure_hint: Optional[str] = None
+
+
+@dataclass
+class SearchResponse:
+    query: str
+    sources: list[SourceStatus] = field(default_factory=list)
+    results: list[EnclosureHit] = field(default_factory=list)
+
+
+class _Source(Protocol):
+    """Each search source implements this minimal surface so the
+    aggregator can fan out without caring about per-vendor specifics."""
+
+    name: str
+
+    def status(self) -> SourceStatus: ...
+    def search(self, query: str, *, limit: int) -> list[EnclosureHit]: ...
+
+
+# ---------------------------------------------------------------------------
+# Thingiverse
+# ---------------------------------------------------------------------------
+
+class ThingiverseSource:
+    """Talks to api.thingiverse.com using a Bearer app token.
+
+    Auth: register an app at https://www.thingiverse.com/developers and
+    set the resulting token as `THINGIVERSE_API_KEY`. Rate limit is
+    ~300 requests/hour for the public tier; we don't cache today,
+    on the assumption that searches are infrequent and bursty.
+    """
+
+    name = "thingiverse"
+    base_url = "https://api.thingiverse.com"
+
+    def __init__(
+        self,
+        token: Optional[str] = None,
+        *,
+        timeout: float = 15.0,
+        transport: Optional[httpx.BaseTransport] = None,
+    ) -> None:
+        self.token = token if token is not None else os.environ.get("THINGIVERSE_API_KEY", "")
+        self.timeout = timeout
+        self._transport = transport
+
+    def status(self) -> SourceStatus:
+        if not self.token:
+            return SourceStatus(
+                source=self.name,
+                available=False,
+                reason="THINGIVERSE_API_KEY not set",
+                configure_hint="Register an app at https://www.thingiverse.com/developers and export THINGIVERSE_API_KEY=<token>",
+            )
+        return SourceStatus(source=self.name, available=True)
+
+    def _client(self) -> httpx.Client:
+        return httpx.Client(
+            base_url=self.base_url,
+            timeout=self.timeout,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/json",
+            },
+            transport=self._transport,
+        )
+
+    def search(self, query: str, *, limit: int = 20) -> list[EnclosureHit]:
+        if not self.token:
+            return []
+        with self._client() as c:
+            resp = c.get(
+                "/search",
+                params={"q": query, "type": "things", "per_page": str(limit)},
+            )
+        if resp.status_code != 200:
+            return []
+        body = resp.json()
+        # Thingiverse wraps results in `hits` (newer API) or returns the
+        # raw list (older API); accept both shapes.
+        items = body.get("hits") if isinstance(body, dict) else body
+        if not isinstance(items, list):
+            return []
+        return [_thingiverse_to_hit(it) for it in items[:limit] if isinstance(it, dict)]
+
+
+def _thingiverse_to_hit(it: dict) -> EnclosureHit:
+    creator = it.get("creator") or {}
+    if isinstance(creator, dict):
+        creator_name = creator.get("name") or creator.get("first_name")
+    else:
+        creator_name = None
+    return EnclosureHit(
+        source="thingiverse",
+        id=str(it.get("id") or it.get("public_url") or ""),
+        title=str(it.get("name") or "untitled"),
+        creator=creator_name,
+        thumbnail_url=it.get("thumbnail") or it.get("preview_image"),
+        model_url=str(it.get("public_url") or it.get("url") or ""),
+        likes=it.get("like_count"),
+        summary=it.get("description_html") or it.get("description"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Printables (deferred)
+# ---------------------------------------------------------------------------
+
+class PrintablesSource:
+    """Stub source: Printables doesn't expose a public REST/GraphQL API
+    today, and scraping their internals is fragile. Status is always
+    `available=False` with a 'deferred' reason; search returns empty.
+    Kept in the source list so the UI surfaces the gap honestly."""
+
+    name = "printables"
+
+    def status(self) -> SourceStatus:
+        return SourceStatus(
+            source=self.name,
+            available=False,
+            reason="Printables search deferred -- no public API yet",
+            configure_hint=None,
+        )
+
+    def search(self, query: str, *, limit: int = 20) -> list[EnclosureHit]:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+def default_sources() -> list[_Source]:
+    return [ThingiverseSource(), PrintablesSource()]
+
+
+def search_enclosures(
+    query: str,
+    *,
+    sources: Optional[list[_Source]] = None,
+    limit: int = 20,
+) -> SearchResponse:
+    """Run `query` against every configured source and merge the hits.
+
+    Returns the per-source status alongside the merged result list so
+    the UI can surface "thingiverse: 12 hits / printables: deferred"
+    without a separate round-trip. Per-source failures are absorbed
+    silently; the source's status entry already explains why it's not
+    contributing hits.
+    """
+    sources = sources if sources is not None else default_sources()
+    statuses: list[SourceStatus] = []
+    hits: list[EnclosureHit] = []
+    for s in sources:
+        statuses.append(s.status())
+        try:
+            hits.extend(s.search(query, limit=limit))
+        except (httpx.HTTPError, ValueError):
+            # Failures degrade to "no hits from this source" -- the
+            # status entry already carries the user-visible reason
+            # for any auth/configuration gap.
+            pass
+    return SearchResponse(query=query, sources=statuses, results=hits[:limit])
+
+
+def query_for_board(board_name: str, refinement: Optional[str] = None) -> str:
+    """Construct the search string we send to each source. Just `<board>
+    enclosure` plus the user's optional extra terms, with whitespace
+    collapsed so empty refinements don't tear the query."""
+    parts = [board_name.strip(), "enclosure"]
+    if refinement and refinement.strip():
+        parts.append(refinement.strip())
+    return " ".join(p for p in parts if p)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -210,6 +210,40 @@ def test_enclosure_openscad_unknown_board_returns_422(client):
     assert "no enclosure metadata" in detail
 
 
+def test_enclosure_search_status_lists_sources(client, monkeypatch):
+    """The status endpoint surfaces every source even when unconfigured,
+    so the UI can render configuration hints."""
+    monkeypatch.delenv("THINGIVERSE_API_KEY", raising=False)
+    r = client.get("/enclosure/search/status")
+    assert r.status_code == 200
+    sources = r.json()["sources"]
+    by_name = {s["source"]: s for s in sources}
+    assert by_name["thingiverse"]["available"] is False
+    assert "THINGIVERSE_API_KEY" in by_name["thingiverse"]["reason"]
+    assert "thingiverse.com/developers" in by_name["thingiverse"]["configure_hint"]
+    # Printables is always deferred.
+    assert by_name["printables"]["available"] is False
+    assert "deferred" in by_name["printables"]["reason"].lower()
+
+
+def test_enclosure_search_unknown_board_returns_404(client):
+    r = client.get("/enclosure/search?library_id=not-a-board")
+    assert r.status_code == 404
+
+
+def test_enclosure_search_returns_empty_when_no_source_configured(client, monkeypatch):
+    """Without THINGIVERSE_API_KEY the search produces an empty result
+    list but still surfaces both source statuses + the constructed
+    query so the UI can guide the user."""
+    monkeypatch.delenv("THINGIVERSE_API_KEY", raising=False)
+    r = client.get("/enclosure/search?library_id=esp32-devkitc-v4")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["query"] == "ESP32-DevKitC-V4 enclosure"
+    assert body["results"] == []
+    assert {s["source"] for s in body["sources"]} == {"thingiverse", "printables"}
+
+
 def test_render_missing_bus_returns_422_with_message(client):
     """A design that validates but references a non-existent bus
     (e.g. a freshly-added I2C component before the user adds an i2c bus)

--- a/tests/test_enclosure_search.py
+++ b/tests/test_enclosure_search.py
@@ -1,0 +1,211 @@
+"""Tests for the enclosure search relay (0.8 v2).
+
+Uses httpx.MockTransport to stand in for Thingiverse's HTTP API, the
+same pattern test_fleet.py uses for the addon. Three concerns:
+
+  1. The status surface (configured vs missing key vs deferred source).
+  2. The Thingiverse client maps the upstream `hits` into our
+     EnclosureHit shape, with creator + thumbnail + likes preserved.
+  3. The aggregator absorbs per-source failures and still returns the
+     statuses so the UI can show partial degradation.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from studio.enclosure.search import (
+    PrintablesSource,
+    SearchResponse,
+    ThingiverseSource,
+    _thingiverse_to_hit,
+    query_for_board,
+    search_enclosures,
+)
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+def test_thingiverse_status_unconfigured(monkeypatch):
+    monkeypatch.delenv("THINGIVERSE_API_KEY", raising=False)
+    s = ThingiverseSource().status()
+    assert s.available is False
+    assert "THINGIVERSE_API_KEY" in (s.reason or "")
+    assert "thingiverse.com/developers" in (s.configure_hint or "")
+
+
+def test_thingiverse_status_configured():
+    s = ThingiverseSource(token="tk-1").status()
+    assert s.available is True
+    assert s.reason is None
+
+
+def test_printables_is_always_deferred():
+    s = PrintablesSource().status()
+    assert s.available is False
+    assert "deferred" in (s.reason or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Thingiverse client
+# ---------------------------------------------------------------------------
+
+def _thingiverse_transport(*, status: int = 200, body: dict | list | None = None,
+                            expected_query: str | None = None) -> httpx.MockTransport:
+    """Build a MockTransport that asserts the request shape and returns
+    `body` (defaults to a single-hit response)."""
+    payload = body if body is not None else {
+        "hits": [{
+            "id": 12345,
+            "name": "ESP32 DevKitC enclosure",
+            "creator": {"name": "joedirt", "first_name": "Joe"},
+            "thumbnail": "https://example.com/thumb.jpg",
+            "public_url": "https://www.thingiverse.com/thing:12345",
+            "like_count": 42,
+            "description": "A snug enclosure for the DevKitC.",
+        }],
+    }
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert req.url.path == "/search", req.url.path
+        assert req.headers.get("authorization") == "Bearer tk-1"
+        if expected_query is not None:
+            assert req.url.params.get("q") == expected_query, req.url.params
+        return httpx.Response(status, json=payload)
+
+    return httpx.MockTransport(handler)
+
+
+def test_thingiverse_search_returns_empty_when_unconfigured(monkeypatch):
+    monkeypatch.delenv("THINGIVERSE_API_KEY", raising=False)
+    s = ThingiverseSource()
+    assert s.search("anything", limit=5) == []
+
+
+def test_thingiverse_search_maps_hits_to_enclosure_hits():
+    s = ThingiverseSource(token="tk-1", transport=_thingiverse_transport())
+    hits = s.search("ESP32 DevKitC enclosure", limit=5)
+    assert len(hits) == 1
+    h = hits[0]
+    assert h.source == "thingiverse"
+    assert h.id == "12345"
+    assert h.title == "ESP32 DevKitC enclosure"
+    assert h.creator == "joedirt"
+    assert h.thumbnail_url == "https://example.com/thumb.jpg"
+    assert h.model_url == "https://www.thingiverse.com/thing:12345"
+    assert h.likes == 42
+
+
+def test_thingiverse_search_passes_the_query_through():
+    s = ThingiverseSource(
+        token="tk-1",
+        transport=_thingiverse_transport(expected_query="WeMos D1 Mini enclosure case"),
+    )
+    s.search("WeMos D1 Mini enclosure case", limit=5)
+
+
+def test_thingiverse_search_handles_legacy_list_response():
+    """Older Thingiverse API revisions return the array directly
+    rather than wrapping in `{hits: [...]}`. The client should accept
+    both."""
+    body = [{
+        "id": 7,
+        "name": "Legacy",
+        "public_url": "https://www.thingiverse.com/thing:7",
+    }]
+    s = ThingiverseSource(token="tk-1", transport=_thingiverse_transport(body=body))
+    hits = s.search("anything", limit=5)
+    assert len(hits) == 1
+    assert hits[0].id == "7"
+    assert hits[0].title == "Legacy"
+
+
+def test_thingiverse_search_returns_empty_on_http_error():
+    """Auth failures, server errors, etc. degrade to no hits rather
+    than crashing the dialog."""
+    s = ThingiverseSource(
+        token="tk-1",
+        transport=_thingiverse_transport(status=401, body={"error": "bad token"}),
+    )
+    assert s.search("anything", limit=5) == []
+
+
+def test_thingiverse_to_hit_handles_string_creator():
+    """If the upstream returns a bare string for creator (some endpoints
+    do), we fall through gracefully without raising."""
+    h = _thingiverse_to_hit({"id": 1, "name": "x", "creator": "joedirt", "public_url": "u"})
+    # Bare-string creator falls into the not-a-dict branch; we end up
+    # with creator=None rather than crashing on .get().
+    assert h.creator is None
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+class _StubSource:
+    def __init__(self, name, hits=None, status_kwargs=None, raises=None):
+        self.name = name
+        self._hits = hits or []
+        self._status_kwargs = status_kwargs or {"available": True}
+        self._raises = raises
+
+    def status(self):
+        from studio.enclosure.search import SourceStatus
+        return SourceStatus(source=self.name, **self._status_kwargs)
+
+    def search(self, query, *, limit):
+        if self._raises:
+            raise self._raises
+        return self._hits[:limit]
+
+
+def test_aggregator_merges_hits_from_multiple_sources():
+    from studio.enclosure.search import EnclosureHit
+    a = _StubSource("a", hits=[EnclosureHit("a", "1", "A1", None, None, "u1")])
+    b = _StubSource("b", hits=[EnclosureHit("b", "2", "B1", None, None, "u2")])
+    out = search_enclosures("q", sources=[a, b], limit=10)
+    assert isinstance(out, SearchResponse)
+    assert out.query == "q"
+    assert {s.source for s in out.sources} == {"a", "b"}
+    assert {h.id for h in out.results} == {"1", "2"}
+
+
+def test_aggregator_caps_at_limit():
+    from studio.enclosure.search import EnclosureHit
+    a = _StubSource("a", hits=[EnclosureHit("a", str(i), f"A{i}", None, None, "u") for i in range(5)])
+    out = search_enclosures("q", sources=[a], limit=3)
+    assert len(out.results) == 3
+
+
+def test_aggregator_swallows_per_source_failures():
+    from studio.enclosure.search import EnclosureHit
+    bad = _StubSource("bad", raises=httpx.ConnectError("boom"))
+    good = _StubSource("good", hits=[EnclosureHit("good", "1", "G1", None, None, "u")])
+    out = search_enclosures("q", sources=[bad, good], limit=10)
+    # The bad source still appears in statuses; the good one's hit is preserved.
+    assert {s.source for s in out.sources} == {"bad", "good"}
+    assert [h.id for h in out.results] == ["1"]
+
+
+# ---------------------------------------------------------------------------
+# Query construction
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name,refinement,expected", [
+    ("WeMos D1 Mini", None, "WeMos D1 Mini enclosure"),
+    ("ESP32-DevKitC-V4", "battery", "ESP32-DevKitC-V4 enclosure battery"),
+    ("Foo", "   ", "Foo enclosure"),  # whitespace-only refinement is stripped
+    ("  Foo  ", None, "Foo enclosure"),
+])
+def test_query_for_board(name, refinement, expected):
+    assert query_for_board(name, refinement) == expected
+
+
+# Unused import guard so test failures point at the right place.
+def test_smoke_imports():
+    assert json is not None  # quiet the linter

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import { SolveResultBanner } from "./components/SolveResultBanner";
 import { NewDesignDialog } from "./components/NewDesignDialog";
 import { PushToFleetDialog } from "./components/PushToFleetDialog";
 import { CapabilityPickerDialog } from "./components/CapabilityPickerDialog";
+import { EnclosureDialog } from "./components/EnclosureDialog";
 import { useDebouncedValue } from "./lib/debounce";
 import {
   addComponent,
@@ -70,6 +71,7 @@ export default function App() {
   const [selectedSaved, setSelectedSaved] = useState<string | null>(null);
   const [showNewDialog, setShowNewDialog] = useState(false);
   const [showFleetDialog, setShowFleetDialog] = useState(false);
+  const [showEnclosureDialog, setShowEnclosureDialog] = useState(false);
   const [showCapabilityDialog, setShowCapabilityDialog] = useState(false);
   const [savingState, setSavingState] = useState<"idle" | "saving" | "saved">("idle");
 
@@ -341,36 +343,6 @@ export default function App() {
     }
   }
 
-  async function handleGenerateEnclosure() {
-    if (!design) return;
-    setRenderError(null);
-    try {
-      const scad = await api.enclosureScad(design);
-      // Trigger a browser download. We synthesize an <a download> click
-      // rather than navigating to the endpoint URL so the request body
-      // (the live design) carries the un-saved edits.
-      const blob = new Blob([scad], { type: "text/plain" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `${design.id ?? "design"}.scad`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    } catch (e) {
-      let msg: string;
-      if (e instanceof ApiError) {
-        const body = e.body as { detail?: unknown } | undefined;
-        const detail = body?.detail;
-        msg = `${e.status}: ${typeof detail === "string" ? detail : e.message}`;
-      } else {
-        msg = e instanceof Error ? e.message : String(e);
-      }
-      setRenderError(msg);
-    }
-  }
-
   if (bootError) {
     return (
       <div className="flex h-full items-center justify-center p-6 text-sm">
@@ -466,11 +438,11 @@ export default function App() {
           </button>
           <button
             disabled={!design}
-            onClick={handleGenerateEnclosure}
+            onClick={() => setShowEnclosureDialog(true)}
             className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 enabled:hover:bg-zinc-900 disabled:opacity-40"
-            title="Download a parametric OpenSCAD shell for the current board"
+            title="Generate a parametric .scad shell or search community-uploaded models"
           >
-            Generate enclosure
+            Enclosure
           </button>
           <button
             disabled={!design}
@@ -560,6 +532,18 @@ export default function App() {
           design={design}
           strict={strictMode}
           onClose={() => setShowFleetDialog(false)}
+        />
+      )}
+      {showEnclosureDialog && design && (
+        <EnclosureDialog
+          design={design}
+          boardLibraryId={String((design.board as Record<string, unknown> | undefined)?.library_id ?? "")}
+          boardName={String(
+            (boards ?? []).find(
+              (b) => b.id === String((design.board as Record<string, unknown> | undefined)?.library_id ?? ""),
+            )?.name ?? (design.board as Record<string, unknown> | undefined)?.library_id ?? "Board",
+          )}
+          onClose={() => setShowEnclosureDialog(false)}
         />
       )}
       {showCapabilityDialog && (

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -5,6 +5,8 @@ import type {
   AgentTurnResponse,
   BoardSummary,
   ComponentSummary,
+  EnclosureSearchResponse,
+  EnclosureSearchStatus,
   ExampleSummary,
   FleetJobLogResponse,
   FleetPushResponse,
@@ -94,6 +96,14 @@ export const api = {
     request<SolvePinsResponse>("/design/solve_pins", { method: "POST", body: JSON.stringify(design) }),
   enclosureScad: (design: Design) =>
     requestText("/design/enclosure/openscad", { method: "POST", body: JSON.stringify(design) }),
+  enclosureSearchStatus: () =>
+    request<EnclosureSearchStatus>("/enclosure/search/status"),
+  enclosureSearch: (params: { library_id: string; query?: string; limit?: number }) => {
+    const qs = new URLSearchParams({ library_id: params.library_id });
+    if (params.query) qs.set("query", params.query);
+    if (params.limit != null) qs.set("limit", String(params.limit));
+    return request<EnclosureSearchResponse>(`/enclosure/search?${qs.toString()}`);
+  },
 
   agentStatus: () => request<AgentStatus>("/agent/status"),
   agentTurn: (body: { session_id?: string | null; design: Design; message: string }) =>

--- a/web/src/components/EnclosureDialog.test.tsx
+++ b/web/src/components/EnclosureDialog.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * Component tests for EnclosureDialog (0.8 v2). Two surfaces:
+ *
+ *   Generate tab — clicks the action and confirms api.enclosureScad
+ *                  was called with the live design; surface state
+ *                  flips to "Downloaded ✓" on success and to a
+ *                  rose error banner on a 422.
+ *   Search tab   — first-open kicks off api.enclosureSearch with
+ *                  library_id from props and no refinement; per-source
+ *                  status banners render with reasons + configure
+ *                  hints; results list renders title + creator + likes
+ *                  with a link to the source.
+ *
+ * api/client mocked at the import boundary. URL.createObjectURL is
+ * stubbed so the Generate tab's <a download> click doesn't crash
+ * jsdom (which lacks the API).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { EnclosureDialog } from "./EnclosureDialog";
+import { api } from "../api/client";
+import type { Design, EnclosureSearchResponse } from "../types/api";
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      enclosureScad: vi.fn(),
+      enclosureSearch: vi.fn(),
+      enclosureSearchStatus: vi.fn(),
+    },
+  };
+});
+
+const mockApi = api as unknown as {
+  enclosureScad: ReturnType<typeof vi.fn>;
+  enclosureSearch: ReturnType<typeof vi.fn>;
+  enclosureSearchStatus: ReturnType<typeof vi.fn>;
+};
+
+const design: Design = {
+  schema_version: "0.1",
+  id: "garage-motion",
+  name: "Garage motion",
+  board: { library_id: "esp32-devkitc-v4", mcu: "esp32" },
+  components: [],
+  buses: [],
+  connections: [],
+  requirements: [],
+  warnings: [],
+} as Design;
+
+beforeEach(() => {
+  mockApi.enclosureScad.mockReset();
+  mockApi.enclosureSearch.mockReset();
+  mockApi.enclosureSearchStatus.mockReset();
+
+  // jsdom lacks URL.createObjectURL/revokeObjectURL; stub them so the
+  // Generate tab's <a download> click doesn't throw.
+  (URL as unknown as { createObjectURL: () => string }).createObjectURL = vi.fn(() => "blob:fake");
+  (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  delete (URL as unknown as Record<string, unknown>).createObjectURL;
+  delete (URL as unknown as Record<string, unknown>).revokeObjectURL;
+});
+
+
+describe("Generate tab", () => {
+  it("clicks generate -> calls enclosureScad with the design and shows the success state", async () => {
+    mockApi.enclosureScad.mockResolvedValue("// .scad text\nmodule shell() {}\n");
+    mockApi.enclosureSearch.mockResolvedValue({
+      query: "x", sources: [], results: [],
+    } as EnclosureSearchResponse);
+    render(
+      <EnclosureDialog
+        design={design}
+        boardLibraryId="esp32-devkitc-v4"
+        boardName="ESP32-DevKitC-V4"
+        onClose={() => {}}
+      />,
+    );
+    const btn = await screen.findByRole("button", { name: /Generate enclosure/ });
+    await userEvent.click(btn);
+    await waitFor(() => expect(mockApi.enclosureScad).toHaveBeenCalledWith(design));
+    await waitFor(() => screen.getByText(/Downloaded ✓/));
+  });
+
+  it("surfaces a 422 from the server in a rose-toned banner", async () => {
+    const { ApiError } = await vi.importActual<typeof import("../api/client")>(
+      "../api/client",
+    );
+    mockApi.enclosureScad.mockRejectedValue(
+      new ApiError(422, "POST /design/enclosure/openscad -> 422", {
+        detail: "board 'esp01_1m' has no enclosure metadata",
+      }),
+    );
+    mockApi.enclosureSearch.mockResolvedValue({
+      query: "x", sources: [], results: [],
+    } as EnclosureSearchResponse);
+    render(
+      <EnclosureDialog
+        design={design}
+        boardLibraryId="esp01_1m"
+        boardName="ESP-01S"
+        onClose={() => {}}
+      />,
+    );
+    const btn = await screen.findByRole("button", { name: /Generate enclosure/ });
+    await userEvent.click(btn);
+    await waitFor(() => screen.getByText(/no enclosure metadata/));
+  });
+});
+
+
+describe("Search tab", () => {
+  it("kicks off a search with library_id on first open + renders results", async () => {
+    mockApi.enclosureSearch.mockResolvedValue({
+      query: "ESP32-DevKitC-V4 enclosure",
+      sources: [
+        { source: "thingiverse", available: true, reason: null, configure_hint: null },
+        {
+          source: "printables",
+          available: false,
+          reason: "Printables search deferred -- no public API yet",
+          configure_hint: null,
+        },
+      ],
+      results: [
+        {
+          source: "thingiverse",
+          id: "12345",
+          title: "DevKitC enclosure",
+          creator: "joedirt",
+          thumbnail_url: "https://example.com/t.jpg",
+          model_url: "https://www.thingiverse.com/thing:12345",
+          likes: 42,
+          summary: null,
+        },
+      ],
+    } as EnclosureSearchResponse);
+
+    render(
+      <EnclosureDialog
+        design={design}
+        boardLibraryId="esp32-devkitc-v4"
+        boardName="ESP32-DevKitC-V4"
+        onClose={() => {}}
+      />,
+    );
+
+    // Switch to Search tab.
+    await userEvent.click(screen.getByRole("button", { name: /Search community/ }));
+
+    await waitFor(() => expect(mockApi.enclosureSearch).toHaveBeenCalledWith({
+      library_id: "esp32-devkitc-v4",
+      query: undefined,
+    }));
+
+    // Source statuses render. "thingiverse" appears twice (status banner +
+    // result row tag), so accept any match.
+    await waitFor(() => expect(screen.getAllByText(/thingiverse/).length).toBeGreaterThan(0));
+    expect(screen.getByText(/· available/)).toBeInTheDocument();
+    expect(screen.getByText(/Printables search deferred/)).toBeInTheDocument();
+
+    // Result row renders with creator + likes + link.
+    const link = screen.getByRole("link", { name: "DevKitC enclosure" });
+    expect(link).toHaveAttribute("href", "https://www.thingiverse.com/thing:12345");
+    expect(screen.getByText(/by joedirt/)).toBeInTheDocument();
+    expect(screen.getByText(/♥ 42/)).toBeInTheDocument();
+  });
+
+  it("submits a refinement back to enclosureSearch when the user types + clicks Search", async () => {
+    mockApi.enclosureSearch.mockResolvedValue({
+      query: "ESP32-DevKitC-V4 enclosure",
+      sources: [
+        { source: "thingiverse", available: true, reason: null, configure_hint: null },
+      ],
+      results: [],
+    } as EnclosureSearchResponse);
+
+    render(
+      <EnclosureDialog
+        design={design}
+        boardLibraryId="esp32-devkitc-v4"
+        boardName="ESP32-DevKitC-V4"
+        onClose={() => {}}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Search community/ }));
+    await waitFor(() => expect(mockApi.enclosureSearch).toHaveBeenCalledTimes(1));
+
+    const refinement = screen.getByPlaceholderText(/battery, screw mount, slim/);
+    await userEvent.type(refinement, "battery");
+    await userEvent.click(screen.getByRole("button", { name: /^Search$/ }));
+
+    await waitFor(() => expect(mockApi.enclosureSearch).toHaveBeenLastCalledWith({
+      library_id: "esp32-devkitc-v4",
+      query: "battery",
+    }));
+  });
+
+  it("renders the configuration hint when no source is available", async () => {
+    mockApi.enclosureSearch.mockResolvedValue({
+      query: "ESP32-DevKitC-V4 enclosure",
+      sources: [
+        {
+          source: "thingiverse",
+          available: false,
+          reason: "THINGIVERSE_API_KEY not set",
+          configure_hint:
+            "Register an app at https://www.thingiverse.com/developers and export THINGIVERSE_API_KEY=<token>",
+        },
+        {
+          source: "printables",
+          available: false,
+          reason: "Printables search deferred -- no public API yet",
+          configure_hint: null,
+        },
+      ],
+      results: [],
+    } as EnclosureSearchResponse);
+
+    render(
+      <EnclosureDialog
+        design={design}
+        boardLibraryId="esp32-devkitc-v4"
+        boardName="ESP32-DevKitC-V4"
+        onClose={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Search community/ }));
+    // THINGIVERSE_API_KEY appears twice: in the reason banner and in the
+    // configure_hint subline. Either is fine.
+    await waitFor(() => expect(screen.getAllByText(/THINGIVERSE_API_KEY/).length).toBeGreaterThan(0));
+    expect(screen.getByText(/thingiverse.com\/developers/)).toBeInTheDocument();
+    expect(screen.getByText(/No search source is configured/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/EnclosureDialog.tsx
+++ b/web/src/components/EnclosureDialog.tsx
@@ -1,0 +1,322 @@
+/**
+ * Enclosure dialog (0.8). Two tabs:
+ *
+ *   Generate — downloads a parametric `.scad` shell built from the
+ *              board's enclosure metadata. Same path as the prior
+ *              header-button download; just framed in a dialog so it
+ *              shares the modal furniture with the search tab.
+ *   Search   — relays to /enclosure/search and renders ranked
+ *              community-uploaded models. The Search tab is gated on
+ *              at least one source being available; when none are
+ *              configured, surfaces the per-source configure_hint.
+ *
+ * The /enclosure/search/status fetch happens lazily on first open of
+ * the Search tab so the dialog opens fast.
+ */
+import { useEffect, useRef, useState } from "react";
+import { api, ApiError } from "../api/client";
+import type {
+  Design,
+  EnclosureHit,
+  EnclosureSearchResponse,
+  EnclosureSourceStatus,
+} from "../types/api";
+
+type Tab = "generate" | "search";
+
+interface Props {
+  design: Design;
+  /** library_id of the design's board, pulled out at call site so the
+   *  dialog doesn't have to walk the design dict itself. */
+  boardLibraryId: string;
+  /** Display name for the search query construction copy. */
+  boardName: string;
+  onClose: () => void;
+}
+
+export function EnclosureDialog({ design, boardLibraryId, boardName, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>("generate");
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="m-4 flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-lg border border-zinc-800 bg-zinc-950 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
+          <div>
+            <div className="text-sm font-semibold text-zinc-100">Enclosure</div>
+            <div className="text-xs text-zinc-500">
+              {boardName} ({boardLibraryId})
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-900"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="flex border-b border-zinc-800 text-xs">
+          {(["generate", "search"] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-3 py-2 transition-colors ${
+                tab === t
+                  ? "border-b-2 border-blue-400 text-zinc-100"
+                  : "text-zinc-400 hover:text-zinc-200"
+              }`}
+            >
+              {t === "generate" ? "Generate (OpenSCAD)" : "Search community models"}
+            </button>
+          ))}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto p-4 text-sm">
+          {tab === "generate" ? (
+            <GenerateTab design={design} />
+          ) : (
+            <SearchTab boardLibraryId={boardLibraryId} boardName={boardName} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Generate tab
+// ---------------------------------------------------------------------------
+
+function GenerateTab({ design }: { design: Design }) {
+  const [downloading, setDownloading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [downloaded, setDownloaded] = useState(false);
+
+  async function handleGenerate() {
+    setDownloading(true);
+    setError(null);
+    setDownloaded(false);
+    try {
+      const scad = await api.enclosureScad(design);
+      const blob = new Blob([scad], { type: "text/plain" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${design.id ?? "design"}.scad`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setDownloaded(true);
+    } catch (e) {
+      let msg: string;
+      if (e instanceof ApiError) {
+        const body = e.body as { detail?: unknown } | undefined;
+        const detail = body?.detail;
+        msg = `${e.status}: ${typeof detail === "string" ? detail : e.message}`;
+      } else {
+        msg = e instanceof Error ? e.message : String(e);
+      }
+      setError(msg);
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3 text-zinc-300">
+      <p className="text-xs leading-relaxed text-zinc-400">
+        Downloads a self-contained <code className="text-zinc-200">.scad</code> file
+        with a tunables block at the top (wall thickness, clearance, standoff
+        geometry). Open in OpenSCAD; press <kbd>F5</kbd> to preview, then export STL
+        for printing. Bottom shell only -- the lid is up to you, for now.
+      </p>
+      <button
+        onClick={handleGenerate}
+        disabled={downloading}
+        className="rounded bg-blue-500/20 px-3 py-1.5 text-sm text-blue-100 ring-1 ring-blue-400/40 enabled:hover:bg-blue-500/30 disabled:opacity-40"
+      >
+        {downloading ? "Generating…" : downloaded ? "Downloaded ✓ — generate again" : "Generate enclosure →"}
+      </button>
+      {error && (
+        <div className="rounded border border-rose-700/40 bg-rose-900/15 px-2 py-1.5 text-xs text-rose-200">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Search tab
+// ---------------------------------------------------------------------------
+
+function SearchTab({ boardLibraryId, boardName }: { boardLibraryId: string; boardName: string }) {
+  const [refinement, setRefinement] = useState("");
+  const [response, setResponse] = useState<EnclosureSearchResponse | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inflightRef = useRef<{ cancelled: boolean } | null>(null);
+
+  // Fire one initial search on mount so the user sees results immediately.
+  useEffect(() => {
+    void runSearch("");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function runSearch(extra: string) {
+    // Cancel any in-flight previous search so a stale response can't
+    // overwrite a newer one when the user clicks Search rapidly.
+    if (inflightRef.current) inflightRef.current.cancelled = true;
+    const ticket = { cancelled: false };
+    inflightRef.current = ticket;
+    setSearching(true);
+    setError(null);
+    try {
+      const r = await api.enclosureSearch({
+        library_id: boardLibraryId,
+        query: extra.trim() || undefined,
+      });
+      if (ticket.cancelled) return;
+      setResponse(r);
+    } catch (e) {
+      if (ticket.cancelled) return;
+      const msg = e instanceof ApiError ? `${e.status}: ${e.message}` :
+        e instanceof Error ? e.message : String(e);
+      setError(msg);
+    } finally {
+      if (!ticket.cancelled) setSearching(false);
+    }
+  }
+
+  // Cleanup on unmount: cancel any in-flight search so a late response
+  // doesn't write into an unmounted component.
+  useEffect(() => () => {
+    if (inflightRef.current) inflightRef.current.cancelled = true;
+  }, []);
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    void runSearch(refinement);
+  }
+
+  const sources: EnclosureSourceStatus[] = response?.sources ?? [];
+  const anyAvailable = sources.some((s) => s.available);
+  const results: EnclosureHit[] = response?.results ?? [];
+
+  return (
+    <div className="space-y-3">
+      <form onSubmit={onSubmit} className="space-y-1">
+        <label className="block text-[11px] uppercase tracking-wide text-zinc-500">refinement</label>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={refinement}
+            onChange={(e) => setRefinement(e.target.value)}
+            placeholder={`e.g. battery, screw mount, slim`}
+            className="flex-1 rounded border border-zinc-800 bg-zinc-900 px-2 py-1 text-xs text-zinc-100 focus:border-zinc-600 focus:outline-none"
+          />
+          <button
+            type="submit"
+            disabled={searching}
+            className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 enabled:hover:bg-zinc-900 disabled:opacity-40"
+          >
+            {searching ? "Searching…" : "Search"}
+          </button>
+        </div>
+        <p className="text-[11px] text-zinc-500">
+          Query: <code className="text-zinc-300">
+            {response?.query || `${boardName} enclosure${refinement.trim() ? ` ${refinement.trim()}` : ""}`}
+          </code>
+        </p>
+      </form>
+
+      {sources.length > 0 && (
+        <div className="space-y-1">
+          {sources.map((s) => (
+            <div
+              key={s.source}
+              className={`rounded border px-2 py-1 text-[11px] ${
+                s.available
+                  ? "border-emerald-700/40 bg-emerald-900/15 text-emerald-200"
+                  : "border-amber-700/40 bg-amber-900/15 text-amber-200"
+              }`}
+            >
+              <span className="font-mono">{s.source}</span>
+              {s.available ? " · available" : ` · unavailable: ${s.reason ?? "unknown"}`}
+              {s.configure_hint && !s.available && (
+                <div className="mt-0.5 text-[10px] text-amber-200/80">{s.configure_hint}</div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded border border-rose-700/40 bg-rose-900/15 px-2 py-1.5 text-xs text-rose-200">
+          {error}
+        </div>
+      )}
+
+      {!anyAvailable && response && (
+        <div className="rounded border border-zinc-800 bg-zinc-900/30 px-3 py-2 text-xs text-zinc-400">
+          No search source is configured. Set the env var listed in the source
+          status above and restart the studio API to enable search.
+        </div>
+      )}
+
+      {results.length > 0 && (
+        <ul className="space-y-2">
+          {results.map((r) => (
+            <li
+              key={`${r.source}:${r.id}`}
+              className="rounded border border-zinc-800 bg-zinc-900/40 p-2"
+            >
+              <div className="flex items-start gap-3">
+                {r.thumbnail_url && (
+                  <a href={r.model_url} target="_blank" rel="noreferrer noopener">
+                    <img
+                      src={r.thumbnail_url}
+                      alt=""
+                      className="h-20 w-20 shrink-0 rounded object-cover"
+                      loading="lazy"
+                    />
+                  </a>
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline gap-2">
+                    <a
+                      href={r.model_url}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="text-sm text-zinc-100 hover:underline"
+                    >
+                      {r.title}
+                    </a>
+                    <span className="text-[11px] text-zinc-500">{r.source}</span>
+                  </div>
+                  <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-zinc-500">
+                    {r.creator && <span>by {r.creator}</span>}
+                    {r.likes != null && <span>♥ {r.likes}</span>}
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!searching && response && results.length === 0 && anyAvailable && (
+        <div className="text-xs text-zinc-500">
+          No matches for <code className="rounded bg-zinc-800 px-1">{response.query}</code>.
+          Try a different refinement.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -204,3 +204,35 @@ export type AgentStreamEvent =
       usage: Record<string, number>;
     }
   | { type: "error"; message: string };
+
+// ---------------------------------------------------------------------------
+// Enclosure search (0.8 v2)
+// ---------------------------------------------------------------------------
+
+export interface EnclosureSourceStatus {
+  source: string;
+  available: boolean;
+  reason: string | null;
+  configure_hint: string | null;
+}
+
+export interface EnclosureSearchStatus {
+  sources: EnclosureSourceStatus[];
+}
+
+export interface EnclosureHit {
+  source: string;
+  id: string;
+  title: string;
+  creator: string | null;
+  thumbnail_url: string | null;
+  model_url: string;
+  likes: number | null;
+  summary: string | null;
+}
+
+export interface EnclosureSearchResponse {
+  query: string;
+  sources: EnclosureSourceStatus[];
+  results: EnclosureHit[];
+}


### PR DESCRIPTION
Second half of 0.8 (Enclosure suggestions). Search community-uploaded enclosure models alongside the parametric generator that landed in v1.

## Why Printables is deferred

Printables is part of the queue but **not** part of v2. The reasons, captured both in the source code (`PrintablesSource.status()` always reports the deferral) and surfaced in the UI as an amber status banner:

- **No documented public API.** They have an internal GraphQL endpoint that the page UI consumes, but it isn't versioned, isn't public, and changes without notice.
- **CDN aggressively rate-limits unauthenticated reads.** A scraping integration would be both fragile (subject to the GraphQL schema shifting) and noisy (running into 429s on bursty searches).
- **No stable community proxy** that I'd trust as a dependency.

The studio surfaces the gap honestly — the source stays in the catalogue, the search-status endpoint always reports `{available: false, reason: "Printables search deferred -- no public API yet"}`, and the dialog renders it as an amber banner with explanation. Users see the deferral rather than wondering if something broke. **Revisit when Printables ships a documented API or a stable community proxy emerges.**

Thingiverse, by contrast, has a documented API + free token registration at https://www.thingiverse.com/developers + a clear ~300 req/hr rate limit. Set `THINGIVERSE_API_KEY` and search just works.

## Backend

- `studio/enclosure/search.py` — pluggable per-source client. `EnclosureHit`, `SourceStatus`, `SearchResponse` dataclasses. `ThingiverseSource` (Bearer token, `httpx.MockTransport`-friendly), `PrintablesSource` (always-deferred stub). `search_enclosures(query, sources=...)` fans out, merges hits, absorbs per-source failures while preserving statuses. `query_for_board(board_name, refinement)` builds `<board> enclosure [<refinement>]`.
- `GET /enclosure/search/status` — per-source availability + configure hints (e.g., "Register an app at https://www.thingiverse.com/developers and export THINGIVERSE_API_KEY=<token>").
- `GET /enclosure/search?library_id=<id>&query=<refinement>` — runs the constructed query, returns merged ranked results + statuses. 404 for unknown library_id.

## Web

- `EnclosureDialog` replaces the v1 download button with a tabbed dialog: **Generate** (the parametric `.scad` download path) and **Search** (the new relay).
- Search tab fires an initial query on first open, renders per-source status banners (emerald available, amber unavailable + configure hint), shows result cards with thumbnail / creator / likes linking out to the source. Free-text refinement re-fires the search; cancellation guard via a ticket ref prevents stale responses from overwriting newer ones.

## Tests

| Layer | Count | Highlights |
|---|---|---|
| `test_enclosure_search.py` | 17 | Status surfaces, Thingiverse client maps hits + passes query through + accepts both `{hits: [...]}` and legacy bare-array responses + returns empty on HTTP error; aggregator merges + caps + swallows failures; `query_for_board` parametrised over 4 input shapes |
| `test_api.py` (+3) | 3 | `/enclosure/search/status` renders both sources with reasons + hints, 404 on unknown board, empty results with statuses preserved when unconfigured |
| `EnclosureDialog.test.tsx` | 5 | Generate success + 422 banner; Search initial fetch + result rendering; refinement round-trip; configuration-hint surface |

275 pytest (+20), 120 vitest (+5), ruff + tsc + vite build clean.

## Test plan

- [ ] `python -m pytest`
- [ ] `python -m ruff check .`
- [ ] `cd web && npm run build && npx vitest run`
- [ ] Smoke: with `THINGIVERSE_API_KEY` set, click **Enclosure** in the header, switch to **Search community models**, confirm thingiverse status badge is emerald and DevKitC/D1 Mini queries return real-looking results that link to thingiverse.com.

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_