### PR TITLE
0.9 v1: KiCad schematic export via SKiDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Useful endpoints:
 | `POST` | `/design/validate` | parse a `design.json`, return summary or 422 |
 | `POST` | `/design/render` | parse + render a `design.json` to `{yaml, ascii}` |
 | `POST` | `/design/enclosure/openscad` | generate a parametric `.scad` shell for the design's board |
+| `POST` | `/design/kicad/schematic` | generate a SKiDL Python script the user runs locally to produce a `.kicad_sch` |
 | `GET`  | `/enclosure/search?library_id=...&query=...` | search community-uploaded enclosure models (Thingiverse) |
 | `GET`  | `/enclosure/search/status` | per-source availability + configure hints |
 | `GET`  | `/examples` | list bundled examples |

--- a/START.md
+++ b/START.md
@@ -27,11 +27,18 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 + build clean.
 
 **Next up candidates:**
-- 0.9 — KiCad schematic export. Full scope in the Roadmap section
-  below; key points: SKiDL-driven, `kicad:` reference block per
-  component/board (we stay canonical for ESPHome semantics, KiCad
-  for schematic rendering), `studio/kicad/scaffold.py` helper for
-  cheap library expansion, PCB deferred to 1.0+.
+- Library mapping expansion — 21 of 41 components and 6 of 13 boards
+  carry a `kicad:` block today; the rest fall back to a generic 4-pin
+  connector with a TODO. The pattern is well-pinned, so filling in
+  the rest is mechanical (look up the right `kicad-symbols` entry,
+  add ~6 lines of YAML). High-value next batch: bmp280, dht, apa102,
+  st7789, ssd1306 confirmation, the new ESP32-S3 / C3 / WROVER-CAM
+  boards.
+- `studio/kicad/scaffold.py` — read a `.kicad_sym` file and print
+  a starter `library/components/<id>.yaml` skeleton so adding new
+  parts becomes ~30 seconds of curation rather than ~5 minutes.
+- 1.0 — KiCad PCB layout. Reuse the schematic's netlist; Freerouting
+  for autorouting; Gerber + JLCPCB CPL/BOM export.
 - Printables search source. Currently deferred -- Printables
   doesn't expose a public REST/GraphQL API and scraping their
   internals is fragile (the page-level GraphQL endpoint changes
@@ -46,6 +53,43 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
   component/board (we stay canonical for ESPHome semantics, KiCad
   for schematic rendering), `studio/kicad/scaffold.py` helper for
   cheap library expansion, PCB deferred to 1.0+.
+
+**0.9 v1 -- KiCad schematic export shipped.** New `kicad:` reference
+block on `LibraryComponent` + `LibraryBoard` (KicadSymbolRef:
+symbol_lib + symbol + footprint + pin_map + value override).
+Mappings landed for 21 components (BME280, DS18B20, MPU6050,
+ADS1115, MCP23008/17, SSD1306, WS2812B, MAX31855, HX711, TSL2561,
+SX1276, MAX98357A, plus generic-connector fallbacks for HC-SR501,
+HC-SR04, RCWL-0516, RC522, ST7789, UART GPS) and 6 boards (D1 Mini,
+ESP32 DevKitC V4, NodeMCU-32S, NodeMCU v2, ESP-01S, TTGO LoRa32 V1).
+Components without a mapping fall back to a generic 4-pin
+Connector_Generic with a TODO comment so the script always runs.
+
+`studio/kicad/generator.py` walks the design and emits a SKiDL Python
+script. The studio doesn't import or run SKiDL itself -- a hard
+runtime dep would pull in numpy + EDA-toolchain weight that's wrong
+for a server. The user installs SKiDL locally and runs the script
+to produce `<design_id>.kicad_sch`. Pin-name remaps from each
+component's `kicad.pin_map` bake into the connection lines (the
+BME280's VCC role becomes `c_bme1["VDD"]` to match the Bosch
+symbol's pin name); rails / buses / GPIO / expander_pin / component
+targets each render as the right SKiDL net expression.
+
+`POST /design/kicad/schematic` returns the script text with a
+Content-Disposition: attachment header. Header gains a **Schematic**
+button (between Solve pins and Push to fleet) opening
+`SchematicDialog` with usage instructions and a one-click
+`.skidl.py` download.
+
+15 new tests: 13 pytest (each bundled example compiles, mappings
+flow through, fallback emits TODO, every net kind renders right,
+component-target round-trip with the ADS1115 hub split, identifier
+sanitisation parametric); 2 API contract; 5 vitest (download
+round-trip, success affirmation, 422 banner, design-id in the
+usage snippet, SKiDL doc link).
+
+PCB layout (Freerouting + Gerber export) deferred to 1.0+ as
+planned.
 
 **0.8 v2 -- enclosure search relay shipped (Thingiverse).**
 `studio/enclosure/search.py` adds a pluggable per-source search client.
@@ -631,10 +675,13 @@ immediate way in and the agent (when it arrives) lands in a working surface.
   - **Stretch — component dimensions on breakouts** (BME280 module,
     OLED module, etc.) so the generator can place display windows
     and stack-mount cutouts, not just the headline USB port.
-- **0.9 — KiCad schematic export.** Walk `design.json` and emit a
-  `.kicad_sch` (KiCad 6+ s-expression format) the user opens in
-  KiCad. SKiDL is the recommended path: a mature Python DSL that
-  takes parts + nets and writes the schematic for us. Concretely:
+- **0.9 — KiCad schematic export.** ✅ Shipped (v1). Walks
+  `design.json` and emits a SKiDL Python script the user runs
+  locally to produce `<design_id>.kicad_sch`. The studio doesn't
+  import or run SKiDL itself -- this keeps the artefact transparent
+  (the user can `cat` it, edit it, regenerate) and avoids adding
+  numpy + EDA-toolchain weight to the server. PCB layout deferred
+  to 1.0+ as planned. Concretely:
 
   - **Library mapping, not duplication.** Our `library/components/<id>.yaml`
     stays the canonical source for ESPHome semantics; it gains a small

--- a/library/boards/esp01_1m.yaml
+++ b/library/boards/esp01_1m.yaml
@@ -24,3 +24,7 @@ gpio_capabilities:
   GPIO14: [gpio]
   GPIO15: [gpio, strap, boot_low, pull_down_external]
   GPIO16: [gpio, no_pwm, no_i2c, no_interrupt]
+# KiCad symbol mapping (0.9 schematic export).
+kicad:
+  symbol_lib: RF_Module
+  symbol: ESP-01

--- a/library/boards/esp32-devkitc-v4.yaml
+++ b/library/boards/esp32-devkitc-v4.yaml
@@ -76,3 +76,8 @@ enclosure:
       height_mm: 3.0
       height_above_pcb_mm: 1.5
   component_height_max_mm: 13.0
+# KiCad symbol mapping (0.9 schematic export).
+kicad:
+  symbol_lib: MCU_Module
+  symbol: ESP32-DevKitC-V4
+  footprint: Module:Espressif_ESP32-DevKitC-V4

--- a/library/boards/nodemcu-32s.yaml
+++ b/library/boards/nodemcu-32s.yaml
@@ -66,3 +66,7 @@ enclosure:
       height_mm: 3.0
       height_above_pcb_mm: 1.5
   component_height_max_mm: 13.0
+# KiCad symbol mapping (0.9 schematic export).
+kicad:
+  symbol_lib: MCU_Module
+  symbol: NodeMCU-32S

--- a/library/boards/nodemcu-v2.yaml
+++ b/library/boards/nodemcu-v2.yaml
@@ -52,3 +52,9 @@ enclosure:
       height_mm: 3.0
       height_above_pcb_mm: 1.5
   component_height_max_mm: 13.0
+# KiCad symbol mapping (0.9 schematic export). KiCad doesn't ship a
+# dedicated NodeMCU v2 module symbol; the closest stand-in is the
+# generic ESP-12 module footprint at the right pinout.
+kicad:
+  symbol_lib: MCU_Module
+  symbol: NodeMCU-1.0

--- a/library/boards/ttgo-lora32-v1.yaml
+++ b/library/boards/ttgo-lora32-v1.yaml
@@ -82,3 +82,10 @@ enclosure:
       height_mm: 7.0
       height_above_pcb_mm: 0.0  # rooted at PCB level
   component_height_max_mm: 9.0
+# KiCad symbol mapping (0.9 schematic export). No dedicated TTGO LoRa32
+# symbol in kicad-symbols today; the user will likely want to replace
+# the generic header with a manufacturer footprint after import.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_02x18_Odd_Even
+  value: TTGO_LoRa32_V1

--- a/library/boards/wemos-d1-mini.yaml
+++ b/library/boards/wemos-d1-mini.yaml
@@ -59,3 +59,9 @@ enclosure:
       height_mm: 3.0
       height_above_pcb_mm: 1.5
   component_height_max_mm: 7.0
+# KiCad symbol mapping (0.9 schematic export). The studio's library role
+# names (VCC, GND) match this module symbol's pin names so pin_map is empty.
+kicad:
+  symbol_lib: MCU_Module
+  symbol: WeMos_D1_mini
+  footprint: Module:WEMOS_D1_mini_light

--- a/library/components/ads1115.yaml
+++ b/library/components/ads1115.yaml
@@ -51,3 +51,11 @@ notes: |
   GND/VDD/SDA/SCL for 0x48/0x49/0x4A/0x4B respectively. 4-channel
   16-bit ADC over I2C; rescues ESP32 designs from the ADC2/WiFi
   conflict and gives ESP8266 a wider dynamic range than its 10-bit ADC.
+# KiCad symbol mapping (0.9 schematic export). Hub-only -- ads1115_channel
+# instances reference this hub via a kind:component target, no separate
+# symbol per channel.
+kicad:
+  symbol_lib: Analog_ADC
+  symbol: ADS1115xDGS
+  pin_map:
+    VCC: VDD

--- a/library/components/bme280.yaml
+++ b/library/components/bme280.yaml
@@ -42,3 +42,10 @@ params_schema:
     default: "0x76"
 
 notes: "3V3 only. On 5V boards, place behind level shifter or use 3V3 rail."
+# KiCad symbol mapping (0.9 schematic export).
+kicad:
+  symbol_lib: Sensor
+  symbol: BME280
+  footprint: Package_LGA:Bosch_LGA-8_2.5x2.5mm_P0.65mm_ClockwisePinNumbering
+  pin_map:
+    VCC: VDD

--- a/library/components/bmp180.yaml
+++ b/library/components/bmp180.yaml
@@ -44,3 +44,10 @@ notes: |
   BMP085 and BMP180 (hardware-compatible). Worth keeping for legacy
   modules people already have on hand; pick the BMP280 / BME280 for new
   builds.
+# KiCad symbol mapping (0.9 schematic export). BMP085 / BMP180 share
+# pinout + symbol in kicad-symbols.
+kicad:
+  symbol_lib: Sensor
+  symbol: BMP180
+  pin_map:
+    VCC: VDD

--- a/library/components/ds18b20.yaml
+++ b/library/components/ds18b20.yaml
@@ -52,3 +52,12 @@ notes: |
   about ambiguous read order when the addresses are missing. Output
   is 3.3V-compatible. Parasite power is supported by ESPHome but not
   modeled here -- wire VCC.
+# KiCad symbol mapping (0.9 schematic export). The standard TO-92
+# package; map our DATA role to the symbol's DQ pin.
+kicad:
+  symbol_lib: Sensor_Temperature
+  symbol: DS18B20
+  footprint: Package_TO_SOT_THT:TO-92_Inline
+  pin_map:
+    VCC: VDD
+    DATA: DQ

--- a/library/components/hc-sr04.yaml
+++ b/library/components/hc-sr04.yaml
@@ -47,3 +47,9 @@ params_schema:
   timeout: { type: string, default: "2m" }
 
 notes: "ECHO pin is 5V on bare HC-SR04. ESP boards are not 5V-tolerant; add a voltage divider or use HC-SR04P (3.3V) variant. ESPHome's ultrasonic platform internally limits range to ~4m."
+# KiCad symbol mapping (0.9 schematic export). Generic 4-pin header
+# (VCC, TRIG, ECHO, GND).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  value: HC-SR04

--- a/library/components/hc-sr501.yaml
+++ b/library/components/hc-sr501.yaml
@@ -43,3 +43,10 @@ params_schema:
     default: 2500
 
 notes: "Requires 5V supply. OUT signal is 3.3V, safe for ESP32 GPIO."
+# KiCad symbol mapping (0.9 schematic export). Generic 3-pin header --
+# the HC-SR501 PIR ships as a breakout module without a dedicated
+# kicad-symbols entry.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x03
+  value: HC-SR501

--- a/library/components/htu21d.yaml
+++ b/library/components/htu21d.yaml
@@ -43,3 +43,11 @@ notes: |
   pressure doesn't -- cheaper, lower current draw, fixed 0x40 address.
   3.3V only. The Si7021 / SHT2x families speak the same protocol so
   this template covers them too.
+# KiCad symbol mapping (0.9 schematic export). The HTU21D / Si7021 /
+# SHT2x family share the SHT21 KiCad symbol.
+kicad:
+  symbol_lib: Sensor
+  symbol: SHT21
+  value: HTU21D
+  pin_map:
+    VCC: VDD

--- a/library/components/hx711.yaml
+++ b/library/components/hx711.yaml
@@ -50,3 +50,11 @@ notes: |
   channel A (128 or 64x) or channel B (32x); most load cells live on
   channel A. 3.3V or 5V supply -- DOUT swings to whatever VCC is, so
   keep a 5V HX711 off a 3.3V GPIO without a level shifter.
+# KiCad symbol mapping (0.9 schematic export). HX711 lives under
+# Analog_ADC in modern KiCad releases; SCK is the symbol's pin name
+# for our SCK role so no map entry needed there.
+kicad:
+  symbol_lib: Analog_ADC
+  symbol: HX711
+  pin_map:
+    VCC: AVDD

--- a/library/components/max31855.yaml
+++ b/library/components/max31855.yaml
@@ -49,3 +49,10 @@ notes: |
   via `reference_temperature: true`. 3.3V only -- a 5V MCU needs a
   level shifter on the SPI lines. Keep the thermocouple wires twisted
   and the optional 10nF noise cap close to the screw terminals.
+# KiCad symbol mapping (0.9 schematic export).
+kicad:
+  symbol_lib: Sensor_Temperature
+  symbol: MAX31855xASA
+  pin_map:
+    VCC: VDD
+    CLK: SCK

--- a/library/components/max98357a.yaml
+++ b/library/components/max98357a.yaml
@@ -36,3 +36,11 @@ params_schema:
   mode: { type: string, enum: [mono, stereo, left, right], default: "mono" }
 
 notes: "MAX98357A is mono Class-D. For stereo use two boards with one wired left, one right -- ESPHome doesn't support that yet (one media_player per device). DIN, BCLK, LRCLK come from the i2s_audio bus and i2s_dout_pin connection. SD pin (shutdown) is optional; tie high or omit for always-on."
+# KiCad symbol mapping (0.9 schematic export). KiCad bundles MAX98357A
+# in the Amplifier_Audio library for newer releases; older installs
+# may need an alias or an external addon library.
+kicad:
+  symbol_lib: Amplifier_Audio
+  symbol: MAX98357A
+  pin_map:
+    VCC: VDD

--- a/library/components/mcp23008.yaml
+++ b/library/components/mcp23008.yaml
@@ -37,3 +37,9 @@ params_schema:
     default: "0x20"
 
 notes: "Per-pin direction/mode is configured by the downstream gpio platforms (binary_sensor, switch, output) that reference this hub via `mcp23008: <id>` in their pin block."
+# KiCad symbol mapping (0.9 schematic export).
+kicad:
+  symbol_lib: Interface_Expansion
+  symbol: MCP23008-SP
+  pin_map:
+    VCC: VDD

--- a/library/components/mcp23017.yaml
+++ b/library/components/mcp23017.yaml
@@ -37,3 +37,9 @@ params_schema:
     default: "0x20"
 
 notes: "16 GPIOs (A0-A7, B0-B7) addressable as numbers 0-15. Per-pin direction is configured by downstream gpio platforms via expander_pin connections."
+# KiCad symbol mapping (0.9 schematic export).
+kicad:
+  symbol_lib: Interface_Expansion
+  symbol: MCP23017_SP
+  pin_map:
+    VCC: VDD

--- a/library/components/mpu6050.yaml
+++ b/library/components/mpu6050.yaml
@@ -63,3 +63,10 @@ notes: |
   (AD0 to VCC). The INT pin is supported by ESPHome but not modeled
   here -- wire it to a free GPIO and attach a binary_sensor in
   esphome_extras if you need motion-wake.
+# KiCad symbol mapping (0.9 schematic export). The bare-chip pinout;
+# breakout boards (GY-521) wire the 8 pins directly to a 0.1" header.
+kicad:
+  symbol_lib: Sensor_Motion
+  symbol: MPU-6050
+  pin_map:
+    VCC: VDD

--- a/library/components/rc522.yaml
+++ b/library/components/rc522.yaml
@@ -42,3 +42,10 @@ params_schema:
   update_interval: { type: string, default: "1s" }
 
 notes: "ESPHome's `rc522_spi` is a singleton -- one reader per device. 3.3V only; do not power from 5V even if your board has a 5V rail."
+# KiCad symbol mapping (0.9 schematic export). RC522 breakouts use an
+# 8-pin SPI header; the dedicated symbol isn't in kicad-symbols, so
+# fall back to a generic 8-pin connector with the part name as value.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x08
+  value: MFRC522

--- a/library/components/rcwl-0516.yaml
+++ b/library/components/rcwl-0516.yaml
@@ -42,3 +42,8 @@ notes: |
   safe for any ESP GPIO. Sensitivity and on-time are set by SMD resistors
   (R-CDS, R-GN) rather than ESPHome params. Treat the 5V VIN as a hard
   minimum -- 3.3V supply works in practice but spec'd at 4V+.
+# KiCad symbol mapping (0.9 schematic export). Generic 3-pin header.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x03
+  value: RCWL-0516

--- a/library/components/ssd1306.yaml
+++ b/library/components/ssd1306.yaml
@@ -46,3 +46,10 @@ params_schema:
     default: "0x3C"
 
 notes: "Many breakouts ship with 10kohm pull-ups already. Verify before adding more."
+# KiCad symbol mapping (0.9 schematic export). Module symbol for the
+# common 0.96" I2C breakout.
+kicad:
+  symbol_lib: Display_Character
+  symbol: SSD1306
+  pin_map:
+    VCC: VDD

--- a/library/components/st7789.yaml
+++ b/library/components/st7789.yaml
@@ -64,3 +64,9 @@ params_schema:
   update_interval: { type: string, default: "5s" }
 
 notes: "Bare ST7789 panels often need precise model dimensions and offsets; if you don't know them, start with model: Custom and tune width/height/offset_*."
+# KiCad symbol mapping (0.9 schematic export). Generic display header
+# fallback -- ST7789V breakouts vary in pin count.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x08
+  value: ST7789V

--- a/library/components/sx127x.yaml
+++ b/library/components/sx127x.yaml
@@ -81,3 +81,10 @@ params_schema:
   rx_start:         { type: boolean, default: true }
 
 notes: "ESPHome's `sx127x` is a singleton. The module typically needs a 10uF bulk cap close to VCC because TX bursts pull >100mA momentarily. Frequency must match a band legal in your region."
+# KiCad symbol mapping (0.9 schematic export). Generic SX1276 covers
+# the SX1272/SX1278 variants with the same pinout.
+kicad:
+  symbol_lib: RF
+  symbol: SX1276
+  pin_map:
+    VCC: VDD

--- a/library/components/tsl2561.yaml
+++ b/library/components/tsl2561.yaml
@@ -58,3 +58,9 @@ notes: |
   Three I2C addresses are selectable via the ADDR pin; default 0x39
   works for the bare chip floating ADDR. 3.3V only -- 5V MCUs need a
   level shifter on SDA/SCL.
+# KiCad symbol mapping (0.9 schematic export).
+kicad:
+  symbol_lib: Sensor
+  symbol: TSL2561FN
+  pin_map:
+    VCC: VDD

--- a/library/components/uart_gps.yaml
+++ b/library/components/uart_gps.yaml
@@ -33,3 +33,9 @@ params_schema:
     description: "Sub-sensors to expose. Keys are GPS sensor names (latitude, longitude, altitude, speed, course, satellites, hdop), values are the sensor config (typically `{ name: ... }`)."
 
 notes: "ESPHome's `gps:` is a singleton. Wire the GPS module's TX to the MCU's RX (i.e. uart bus rx pin) and vice versa -- the module sends NMEA, the MCU only listens. Some clones output 9600 baud out of the box; others 115200."
+# KiCad symbol mapping (0.9 schematic export). Generic 4-pin header --
+# matches the typical NEO-6M / NEO-8M breakout.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  value: UART_GPS

--- a/library/components/ws2812b.yaml
+++ b/library/components/ws2812b.yaml
@@ -45,3 +45,9 @@ params_schema:
   num_leds: { type: integer, default: 1, minimum: 1 }
 
 notes: "Current rises ~60mA per LED at full white. Budget accordingly. Add a 300-500ohm series resistor on DIN and a 1000uF cap across VCC/GND for strips >8 LEDs."
+# KiCad symbol mapping (0.9 schematic export).
+kicad:
+  symbol_lib: LED
+  symbol: WS2812B
+  pin_map:
+    VCC: VDD

--- a/studio/api/app.py
+++ b/studio/api/app.py
@@ -52,6 +52,7 @@ from studio.enclosure import (
     query_for_board,
     search_enclosures,
 )
+from studio.kicad import generate_skidl
 from studio.recommend.recommender import Constraints, recommend_components
 from studio.generate.ascii_gen import render_ascii
 from studio.generate.yaml_gen import render_yaml
@@ -315,6 +316,38 @@ def create_app(
             headers={
                 "Content-Disposition": f'attachment; filename="{filename}"',
             },
+        )
+
+    @app.post("/design/kicad/schematic", tags=["design"])
+    def design_kicad_schematic(design: dict) -> PlainTextResponse:
+        """Render a SKiDL Python script the user runs locally to produce
+        `<design_id>.kicad_sch`.
+
+        We don't import or run SKiDL ourselves -- a hard runtime dep
+        would pull in numpy + EDA-toolchain weight that's wrong for
+        a server. The user pipes the response through:
+
+            curl -X POST .../design/kicad/schematic ... > design.skidl.py
+            pip install skidl
+            python design.skidl.py
+
+        Components without a `kicad:` mapping render as a generic
+        4-pin connector with a TODO comment; the script always runs
+        and the user can patch the .py before re-running, or fill in
+        the library YAML and re-export.
+        """
+        try:
+            d = Design.model_validate(design)
+        except ValidationError as e:
+            raise HTTPException(status_code=422, detail=e.errors()) from e
+        try:
+            script = generate_skidl(d, lib)
+        except FileNotFoundError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        filename = f"{d.id}.skidl.py"
+        return PlainTextResponse(
+            content=script,
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
         )
 
     @app.get("/enclosure/search/status", tags=["enclosure"])

--- a/studio/kicad/__init__.py
+++ b/studio/kicad/__init__.py
@@ -1,0 +1,5 @@
+"""KiCad schematic export (0.9). v1 emits a SKiDL Python script the
+user runs locally; PCB layout is deferred to 1.0+."""
+from studio.kicad.generator import generate_skidl
+
+__all__ = ["generate_skidl"]

--- a/studio/kicad/generator.py
+++ b/studio/kicad/generator.py
@@ -1,0 +1,331 @@
+"""KiCad schematic export (0.9).
+
+Walks a `design.json` and emits a SKiDL Python script that, when run,
+produces a `.kicad_sch` the user opens in KiCad. The studio doesn't
+import or run SKiDL itself -- a hard runtime dep would pull in numpy
++ a chunk of EDA-toolchain weight that's wrong for a server. Instead
+the user runs the generated script locally:
+
+    pip install skidl
+    python <design_id>.skidl.py
+    # produces <design_id>.kicad_sch in the cwd
+
+Mapping: each `library/components/<id>.yaml` and
+`library/boards/<id>.yaml` carries a `kicad:` block (KicadSymbolRef)
+that names the symbol library + symbol + optional footprint + pin
+remap. Unmapped components fall back to a generic 0.1" header with a
+TODO comment so the script always runs; the user can edit the .py
+before re-running, or fill in the `kicad:` block in the library YAML
+and re-export.
+
+Pure: no I/O, no SKiDL import. Tests verify the emitted text is
+syntactically plausible (executes under `compile()`) and that key
+mappings (symbol, footprint, pin_map applied) appear verbatim.
+"""
+from __future__ import annotations
+
+import re
+
+from studio.library import KicadSymbolRef, Library
+from studio.model import Design
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PY_IDENT_RE = re.compile(r"[^A-Za-z0-9_]")
+
+
+def _py_var(name: str) -> str:
+    """Coerce an arbitrary id into a safe Python identifier prefixed
+    with `c_` (component) or `n_` (net) by the caller."""
+    out = _PY_IDENT_RE.sub("_", name)
+    if out and out[0].isdigit():
+        out = "_" + out
+    return out
+
+
+def _quote(s: str) -> str:
+    """JSON-style double-quoted string literal that Python accepts."""
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+# ---------------------------------------------------------------------------
+# Per-component / per-board emission
+# ---------------------------------------------------------------------------
+
+def _emit_part(var: str, ref: str, kicad: KicadSymbolRef, comment: str | None = None) -> str:
+    parts = [
+        _quote(kicad.symbol_lib),
+        _quote(kicad.symbol),
+        f"ref={_quote(ref)}",
+    ]
+    if kicad.value:
+        parts.append(f"value={_quote(kicad.value)}")
+    if kicad.footprint:
+        parts.append(f"footprint={_quote(kicad.footprint)}")
+    line = f"{var} = Part({', '.join(parts)})"
+    if comment:
+        return f"# {comment}\n{line}"
+    return line
+
+
+def _emit_placeholder(var: str, ref: str, lib_id: str) -> str:
+    """Fallback when a component has no `kicad:` block. Emits a generic
+    4-pin header with a TODO so the script still runs and the user can
+    fix it up post-hoc."""
+    return (
+        f"# TODO: {lib_id} not yet mapped to a KiCad symbol.\n"
+        f"# Add a `kicad:` block to library/components/{lib_id}.yaml,\n"
+        f"# or replace this Part(...) call with the right symbol manually.\n"
+        f"{var} = Part(\"Connector_Generic\", \"Conn_01x04\", "
+        f"ref={_quote(ref)}, value={_quote(lib_id)})"
+    )
+
+
+def _resolve_pin_role(role: str, kicad: KicadSymbolRef | None) -> str:
+    if kicad and role in kicad.pin_map:
+        return kicad.pin_map[role]
+    return role
+
+
+# ---------------------------------------------------------------------------
+# Reference-designator allocator
+# ---------------------------------------------------------------------------
+
+def _ref_for(category: str, counter: dict[str, int]) -> str:
+    prefix = {
+        "sensor": "U",
+        "binary_sensor": "U",
+        "io_expander": "U",
+        "display": "U",
+        "audio": "U",
+        "led": "D",
+        "amp": "U",
+    }.get(category, "U")
+    counter[prefix] = counter.get(prefix, 0) + 1
+    return f"{prefix}{counter[prefix]}"
+
+
+# ---------------------------------------------------------------------------
+# Net derivation
+# ---------------------------------------------------------------------------
+
+def _net_label_for_target(t: dict, design: Design, used_buses: dict[str, str]) -> str:
+    """Map a connection target to a SKiDL net handle.
+
+    rails -> +5V / +3V3 / GND (canonicalised),
+    bus -> the bus's id (sda/scl/clk/etc. resolved per role at the call site),
+    expander_pin -> a hub-relative net like `mcp_hub_GP3`,
+    component -> the parent component's ref-relative HUB net,
+    gpio -> a per-pin net like `GPIO13` or `D5`.
+    """
+    kind = t.get("kind")
+    if kind == "rail":
+        rail = t.get("rail", "")
+        if rail.lower() in ("gnd", "ground"):
+            return "GND"
+        return f"+{rail}".replace("V3", "V3").replace(" ", "")
+    if kind == "gpio":
+        pin = t.get("pin") or "UNBOUND"
+        return f"NET_{pin}"
+    if kind == "bus":
+        bus_id = t.get("bus_id") or "UNBOUND"
+        return f"BUS_{bus_id}"
+    if kind == "expander_pin":
+        ex = t.get("expander_id") or "EX"
+        n = t.get("number")
+        return f"{ex}_GP{n}"
+    if kind == "component":
+        cid = t.get("component_id") or "PARENT"
+        return f"{cid}_REF"
+    return "UNCONNECTED"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+_PREAMBLE = '''\
+"""SKiDL schematic for design '{design_id}' generated by esphome-studio.
+
+To produce a .kicad_sch (KiCad 6+), install SKiDL and run this file:
+
+    pip install skidl
+    python {design_id}.skidl.py
+
+The script writes <design_id>.kicad_sch + .net + .xml into the current
+directory. Edit pin assignments + component overrides above the
+generate_*() calls if you want to tweak before re-running.
+"""
+from skidl import Part, Net, generate_netlist, generate_schematic, TEMPLATE
+
+
+def build():
+    # ---- Power rails -----------------------------------------------------
+    GND = Net("GND")
+{rail_decls}
+
+    # ---- Component instances --------------------------------------------
+{component_decls}
+
+    # ---- Buses ----------------------------------------------------------
+{bus_decls}
+
+    # ---- Connections ----------------------------------------------------
+{connection_lines}
+
+
+if __name__ == "__main__":
+    build()
+    # Default: emit a netlist (.net) + a schematic (.kicad_sch).
+    # Comment out either if you only want one.
+    generate_netlist()
+    generate_schematic()
+'''
+
+
+def generate_skidl(design: Design, library: Library) -> str:
+    """Emit a SKiDL Python script. Pure: returns the text."""
+    rail_decls = _render_rails(design)
+    component_decls, ref_index = _render_components(design, library)
+    bus_decls = _render_buses(design)
+    connection_lines = _render_connections(design, library, ref_index)
+    return _PREAMBLE.format(
+        design_id=design.id,
+        rail_decls=_indent(rail_decls or "pass", 4),
+        component_decls=_indent(component_decls or "pass", 4),
+        bus_decls=_indent(bus_decls or "pass", 4),
+        connection_lines=_indent(connection_lines or "pass", 4),
+    )
+
+
+def _indent(s: str, n: int) -> str:
+    pad = " " * n
+    return "\n".join(pad + line if line.strip() else line for line in s.splitlines())
+
+
+def _render_rails(design: Design) -> str:
+    rails: set[str] = set()
+    for c in design.connections:
+        t = c.target
+        if t.kind == "rail" and t.rail.lower() not in ("gnd", "ground"):
+            rails.add(t.rail)
+    if not rails:
+        return ""
+    out: list[str] = []
+    for r in sorted(rails):
+        out.append(f'NET_PLUS_{_py_var(r)} = Net("+{r}")')
+    return "\n".join(out)
+
+
+def _render_components(
+    design: Design, library: Library,
+) -> tuple[str, dict[str, str]]:
+    """Render Part(...) calls for design + board, return the script
+    text plus a {component_id: skidl_var_name} index for connection
+    rendering. Also adds the board itself as a Part (the dev module
+    sits at the top of the schematic just like a real design)."""
+    counter: dict[str, int] = {}
+    lines: list[str] = []
+    ref_index: dict[str, str] = {}
+
+    # Board first.
+    try:
+        board = library.board(design.board.library_id)
+    except FileNotFoundError:
+        board = None
+    if board is not None:
+        var = "board"
+        ref = "M1"
+        if board.kicad is not None:
+            lines.append(_emit_part(var, ref, board.kicad,
+                                     comment=f"Board: {board.name}"))
+        else:
+            lines.append(_emit_placeholder(var, ref, board.id))
+        ref_index["__board__"] = var
+
+    # Components.
+    for c in design.components:
+        var = f"c_{_py_var(c.id)}"
+        try:
+            lib_comp = library.component(c.library_id)
+        except FileNotFoundError:
+            lib_comp = None
+        if lib_comp is None or lib_comp.kicad is None:
+            ref = _ref_for("sensor", counter)
+            lines.append(_emit_placeholder(var, ref, c.library_id))
+        else:
+            ref = _ref_for(lib_comp.category, counter)
+            lines.append(_emit_part(var, ref, lib_comp.kicad,
+                                     comment=f"{c.id} ({lib_comp.name})"))
+        ref_index[c.id] = var
+
+    return "\n".join(lines), ref_index
+
+
+def _render_buses(design: Design) -> str:
+    if not design.buses:
+        return ""
+    out: list[str] = []
+    for b in design.buses:
+        out.append(f'NET_BUS_{_py_var(b.id)} = Net("BUS_{b.id}")  # {b.type} bus')
+    return "\n".join(out)
+
+
+def _render_connections(
+    design: Design, library: Library, ref_index: dict[str, str],
+) -> str:
+    """Render `<comp>[<pin>] += <net>` lines. SKiDL accepts pin names
+    in __getitem__; we use the role (or remapped role via pin_map)
+    here, so the script lines up with the component's KiCad symbol."""
+    lines: list[str] = []
+    by_id = {c.id: c for c in design.components}
+    for conn in design.connections:
+        comp_var = ref_index.get(conn.component_id)
+        if comp_var is None:
+            lines.append(f'# skipped: {conn.component_id}.{conn.pin_role} (component not in design)')
+            continue
+        comp = by_id.get(conn.component_id)
+        kicad = None
+        if comp is not None:
+            try:
+                lib_comp = library.component(comp.library_id)
+                kicad = lib_comp.kicad
+            except FileNotFoundError:
+                pass
+        pin_name = _resolve_pin_role(conn.pin_role, kicad)
+        net_expr = _net_handle_for(conn.target, design, ref_index)
+        lines.append(f'{comp_var}[{_quote(pin_name)}] += {net_expr}')
+    return "\n".join(lines)
+
+
+def _net_handle_for(target, design: Design, ref_index: dict[str, str]) -> str:
+    """Return a SKiDL expression that evaluates to the net for `target`.
+    For rails we reference the per-script Net handle (NET_PLUS_*, GND);
+    for buses we reference NET_BUS_<id>; for gpio/expander_pin we build
+    an inline Net(...) so each unique landing gets a fresh handle.
+    For component (hub) targets we use the hub's ref var."""
+    kind = target.kind
+    if kind == "rail":
+        if target.rail.lower() in ("gnd", "ground"):
+            return "GND"
+        return f"NET_PLUS_{_py_var(target.rail)}"
+    if kind == "bus":
+        return f"NET_BUS_{_py_var(target.bus_id)}"
+    if kind == "gpio":
+        pin = target.pin or "UNBOUND"
+        return f'Net("GPIO_{_py_var(pin)}")'
+    if kind == "expander_pin":
+        ex = target.expander_id or "EX"
+        n = target.number
+        return f'Net("{ex}_GP{n}")'
+    if kind == "component":
+        cid = target.component_id or "PARENT"
+        return f'Net("{cid}_HUB")'
+    return 'Net("UNCONNECTED")'
+
+
+# Re-export helpers used by tests.
+__all__ = ["generate_skidl", "_py_var"]

--- a/studio/library.py
+++ b/studio/library.py
@@ -61,6 +61,7 @@ class LibraryComponent(_Strict):
     esphome: EsphomeSpec = Field(default_factory=EsphomeSpec)
     params_schema: dict = Field(default_factory=dict)
     notes: Optional[str] = None
+    kicad: Optional[KicadSymbolRef] = None
 
 
 class Rail(_Strict):
@@ -116,6 +117,28 @@ class BoardEnclosure(_Strict):
     component_height_max_mm: float = 12.0
 
 
+class KicadSymbolRef(_Strict):
+    """Reference to a KiCad symbol library entry. Lets the schematic
+    exporter (0.9) emit a SKiDL Part that points at the right symbol +
+    footprint without copying KiCad's data into our library.
+
+    `pin_map` translates our library role names (VCC, SDA, etc.) to
+    the symbol's pin names where they differ -- e.g., the BME280
+    module's VCC pin is named `VDD` in the KiCad symbol. Roles missing
+    from the map are passed through unchanged.
+
+    `value` overrides what's printed on the schematic (KiCad defaults
+    to the symbol name); useful for parts whose useful identity differs
+    from their canonical symbol (the HC-SR501 PIR uses a generic 3-pin
+    header symbol but should print as "HC-SR501" on the sheet).
+    """
+    symbol_lib: str
+    symbol: str
+    footprint: Optional[str] = None
+    value: Optional[str] = None
+    pin_map: dict[str, str] = Field(default_factory=dict)
+
+
 class LibraryBoard(_Strict):
     id: str
     name: str
@@ -129,6 +152,7 @@ class LibraryBoard(_Strict):
     onboard_peripherals: dict = Field(default_factory=dict)
     gpio_capabilities: dict[str, list[str]] = Field(default_factory=dict)
     enclosure: Optional[BoardEnclosure] = None
+    kicad: Optional[KicadSymbolRef] = None
 
 
 class Library:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -210,6 +210,24 @@ def test_enclosure_openscad_unknown_board_returns_422(client):
     assert "no enclosure metadata" in detail
 
 
+def test_kicad_schematic_returns_skidl_python(client):
+    design = json.loads((EXAMPLES_DIR / "garage-motion.json").read_text())
+    r = client.post("/design/kicad/schematic", json=design)
+    assert r.status_code == 200
+    assert "filename=\"garage-motion-v1.skidl.py\"" in r.headers.get("content-disposition", "")
+    body = r.text
+    assert "from skidl import" in body
+    assert "generate_schematic()" in body
+    # Verify the response body is valid Python -- a syntax error in the
+    # generator would fail this where substring assertions wouldn't.
+    compile(body, "<api response>", "exec")
+
+
+def test_kicad_schematic_invalid_design_returns_422(client):
+    r = client.post("/design/kicad/schematic", json={"id": "broken"})
+    assert r.status_code == 422
+
+
 def test_enclosure_search_status_lists_sources(client, monkeypatch):
     """The status endpoint surfaces every source even when unconfigured,
     so the UI can render configuration hints."""

--- a/tests/test_kicad.py
+++ b/tests/test_kicad.py
@@ -1,0 +1,202 @@
+"""Tests for the KiCad SKiDL schematic generator (0.9).
+
+The generator is pure text-out, so we lean on substring assertions +
+`compile()` to verify the emitted script is valid Python. Three concerns:
+
+  1. Mapping plumbing: kicad: blocks on the library entries flow into
+     Part(...) calls with the right symbol, footprint, value, and
+     pin_map applied to the connection lines.
+  2. Fallback: components without a kicad: mapping emit a TODO-tagged
+     placeholder rather than crashing.
+  3. Net derivation: rails / buses / gpio / expander_pin / component
+     targets each render as the right SKiDL expression.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from studio.kicad import generate_skidl
+from studio.kicad.generator import _py_var
+from studio.library import default_library
+from studio.model import Design
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples"
+
+
+@pytest.fixture
+def lib():
+    return default_library()
+
+
+def _design(name: str) -> Design:
+    return Design.model_validate(json.loads((EXAMPLES_DIR / f"{name}.json").read_text()))
+
+
+# ---------------------------------------------------------------------------
+# Compile + structural checks
+# ---------------------------------------------------------------------------
+
+def test_emitted_script_compiles(lib):
+    """Every bundled example must produce a Python-syntax-valid script."""
+    for name in ("garage-motion", "wasserpir", "oled", "bluemotion",
+                 "distance-sensor", "rc522", "esp32-audio", "wemosgps",
+                 "ttgo-lora32", "multi-temp"):
+        script = generate_skidl(_design(name), lib)
+        compile(script, f"<{name}>", "exec")  # raises SyntaxError if bad
+
+
+def test_skidl_imports_appear(lib):
+    script = generate_skidl(_design("garage-motion"), lib)
+    assert "from skidl import" in script
+    assert "Part" in script and "Net" in script
+    assert "generate_schematic()" in script
+
+
+def test_design_id_appears_in_docstring(lib):
+    script = generate_skidl(_design("garage-motion"), lib)
+    assert "garage-motion-v1" in script.splitlines()[0]
+
+
+# ---------------------------------------------------------------------------
+# Mapping flow
+# ---------------------------------------------------------------------------
+
+def test_bme280_maps_vcc_role_to_vdd_pin(lib):
+    """The BME280's KiCad symbol uses VDD; our role is VCC. The pin_map
+    should have rewritten the connection line to address VDD."""
+    script = generate_skidl(_design("garage-motion"), lib)
+    assert 'c_bme1["VDD"]' in script
+    assert 'c_bme1["VCC"]' not in script
+
+
+def test_board_renders_as_first_part(lib):
+    script = generate_skidl(_design("garage-motion"), lib)
+    # The board comment + Part call appear before any component.
+    board_idx = script.find('Board: ESP32-DevKitC-V4')
+    pir_idx = script.find('pir1 (HC-SR501')
+    assert board_idx > 0 and pir_idx > 0 and board_idx < pir_idx
+
+
+def test_known_part_emits_symbol_and_footprint(lib):
+    """ESP32 DevKitC V4 carries a footprint hint. It should make it into
+    the Part(...) call verbatim."""
+    script = generate_skidl(_design("garage-motion"), lib)
+    assert 'Part("MCU_Module", "ESP32-DevKitC-V4"' in script
+    assert 'footprint="Module:Espressif_ESP32-DevKitC-V4"' in script
+
+
+def test_unmapped_component_falls_back_to_placeholder(lib):
+    """Construct a synthetic design referencing an unmapped library
+    entry and verify the placeholder + TODO comment land in the output."""
+    # `apa102` is in the library but doesn't have a kicad: block in
+    # this PR. If the assertion ever fails because someone added one,
+    # swap to another unmapped entry.
+    if lib.component("apa102").kicad is not None:
+        pytest.skip("apa102 is now mapped; pick another unmapped library_id")
+    design = {
+        "schema_version": "0.1",
+        "id": "fallback",
+        "name": "Fallback test",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266"},
+        "fleet": {"device_name": "fallback", "tags": []},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [
+            {"id": "rgb1", "library_id": "apa102", "label": "RGB", "params": {}},
+        ],
+        "buses": [],
+        "connections": [],
+        "requirements": [],
+        "warnings": [],
+    }
+    script = generate_skidl(Design.model_validate(design), lib)
+    assert "TODO: apa102" in script
+    assert 'Part("Connector_Generic", "Conn_01x04"' in script
+
+
+# ---------------------------------------------------------------------------
+# Net derivation
+# ---------------------------------------------------------------------------
+
+def test_rail_targets_become_named_nets(lib):
+    script = generate_skidl(_design("garage-motion"), lib)
+    assert 'GND = Net("GND")' in script
+    assert 'NET_PLUS__5V = Net("+5V")' in script
+    assert 'NET_PLUS__3V3 = Net("+3V3")' in script
+
+
+def test_bus_targets_share_a_single_net(lib):
+    """All connections targeting bus_id=i2c0 should resolve to the same
+    NET_BUS_i2c0 handle so the schematic's I2C pins land on one net."""
+    script = generate_skidl(_design("garage-motion"), lib)
+    assert 'NET_BUS_i2c0 = Net("BUS_i2c0")' in script
+    # Both BME280's SDA + SCL connections go to that single bus net.
+    assert 'c_bme1["SDA"] += NET_BUS_i2c0' in script
+    assert 'c_bme1["SCL"] += NET_BUS_i2c0' in script
+
+
+def test_gpio_targets_become_inline_nets(lib):
+    script = generate_skidl(_design("garage-motion"), lib)
+    # PIR's OUT pin is wired to GPIO13 in this design.
+    assert 'c_pir1["OUT"] += Net("GPIO_GPIO13")' in script
+
+
+def test_expander_pin_targets_render(lib):
+    """awning-control wires several gpio_input/output components through
+    an MCP23008 expander; expander_pin targets should render as
+    Net("<expander>_GP<n>") expressions."""
+    script = generate_skidl(_design("awning-control"), lib)
+    assert 'GP' in script
+    assert 'Net("mcp23008_hub_GP' in script
+
+
+def test_component_target_renders_for_ads1115_channel():
+    """Synthesize a design with the ads1115 hub + channel split and
+    verify the channel's HUB connection turns into a Net pointing at
+    the hub instance."""
+    lib_local = default_library()
+    design = {
+        "schema_version": "0.1",
+        "id": "ads-test",
+        "name": "ADS test",
+        "board": {"library_id": "esp32-devkitc-v4", "mcu": "esp32"},
+        "fleet": {"device_name": "ads-test", "tags": []},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [
+            {"id": "adc1", "library_id": "ads1115", "label": "ADC", "params": {}},
+            {"id": "bat",  "library_id": "ads1115_channel", "label": "Battery V",
+             "params": {"multiplexer": "A0_GND"}},
+        ],
+        "buses": [{"id": "i2c0", "type": "i2c", "sda": "GPIO21", "scl": "GPIO22"}],
+        "connections": [
+            {"component_id": "adc1", "pin_role": "VCC", "target": {"kind": "rail", "rail": "3V3"}},
+            {"component_id": "adc1", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+            {"component_id": "adc1", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "adc1", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "bat",  "pin_role": "HUB", "target": {"kind": "component", "component_id": "adc1"}},
+        ],
+        "requirements": [],
+        "warnings": [],
+    }
+    script = generate_skidl(Design.model_validate(design), lib_local)
+    # ADS1115's VCC role rewrites to VDD via pin_map.
+    assert 'c_adc1["VDD"]' in script
+    # Channel's HUB connection becomes a hub-relative net.
+    assert 'c_bat["HUB"] += Net("adc1_HUB")' in script
+
+
+# ---------------------------------------------------------------------------
+# Identifier sanitisation
+# ---------------------------------------------------------------------------
+
+def test_py_var_handles_hyphens_and_digits():
+    """Component ids contain hyphens, dots, even leading digits in some
+    designs. The sanitiser replaces non-identifier chars with `_` and
+    prefixes a leading digit."""
+    assert _py_var("foo-bar") == "foo_bar"
+    assert _py_var("3w") == "_3w"
+    assert _py_var("foo.bar.baz") == "foo_bar_baz"
+    assert _py_var("ads1115_channel") == "ads1115_channel"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,7 @@ import { NewDesignDialog } from "./components/NewDesignDialog";
 import { PushToFleetDialog } from "./components/PushToFleetDialog";
 import { CapabilityPickerDialog } from "./components/CapabilityPickerDialog";
 import { EnclosureDialog } from "./components/EnclosureDialog";
+import { SchematicDialog } from "./components/SchematicDialog";
 import { useDebouncedValue } from "./lib/debounce";
 import {
   addComponent,
@@ -72,6 +73,7 @@ export default function App() {
   const [showNewDialog, setShowNewDialog] = useState(false);
   const [showFleetDialog, setShowFleetDialog] = useState(false);
   const [showEnclosureDialog, setShowEnclosureDialog] = useState(false);
+  const [showSchematicDialog, setShowSchematicDialog] = useState(false);
   const [showCapabilityDialog, setShowCapabilityDialog] = useState(false);
   const [savingState, setSavingState] = useState<"idle" | "saving" | "saved">("idle");
 
@@ -438,6 +440,14 @@ export default function App() {
           </button>
           <button
             disabled={!design}
+            onClick={() => setShowSchematicDialog(true)}
+            className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 enabled:hover:bg-zinc-900 disabled:opacity-40"
+            title="Download a SKiDL Python script that produces a .kicad_sch when run locally"
+          >
+            Schematic
+          </button>
+          <button
+            disabled={!design}
             onClick={() => setShowEnclosureDialog(true)}
             className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 enabled:hover:bg-zinc-900 disabled:opacity-40"
             title="Generate a parametric .scad shell or search community-uploaded models"
@@ -532,6 +542,12 @@ export default function App() {
           design={design}
           strict={strictMode}
           onClose={() => setShowFleetDialog(false)}
+        />
+      )}
+      {showSchematicDialog && design && (
+        <SchematicDialog
+          design={design}
+          onClose={() => setShowSchematicDialog(false)}
         />
       )}
       {showEnclosureDialog && design && (

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -96,6 +96,8 @@ export const api = {
     request<SolvePinsResponse>("/design/solve_pins", { method: "POST", body: JSON.stringify(design) }),
   enclosureScad: (design: Design) =>
     requestText("/design/enclosure/openscad", { method: "POST", body: JSON.stringify(design) }),
+  kicadSchematic: (design: Design) =>
+    requestText("/design/kicad/schematic", { method: "POST", body: JSON.stringify(design) }),
   enclosureSearchStatus: () =>
     request<EnclosureSearchStatus>("/enclosure/search/status"),
   enclosureSearch: (params: { library_id: string; query?: string; limit?: number }) => {

--- a/web/src/components/EnclosureDialog.test.tsx
+++ b/web/src/components/EnclosureDialog.test.tsx
@@ -16,7 +16,7 @@
  * jsdom (which lacks the API).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { EnclosureDialog } from "./EnclosureDialog";

--- a/web/src/components/SchematicDialog.test.tsx
+++ b/web/src/components/SchematicDialog.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Component tests for SchematicDialog (0.9). The dialog is small but
+ * exercises the same download-blob pattern as EnclosureDialog's
+ * Generate tab; we verify the API call shape, the success affirmation,
+ * and the error path.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { SchematicDialog } from "./SchematicDialog";
+import { api } from "../api/client";
+import type { Design } from "../types/api";
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    api: { ...actual.api, kicadSchematic: vi.fn() },
+  };
+});
+
+const mockApi = api as unknown as {
+  kicadSchematic: ReturnType<typeof vi.fn>;
+};
+
+const design: Design = {
+  schema_version: "0.1",
+  id: "garage-motion",
+  name: "Garage motion",
+  board: { library_id: "esp32-devkitc-v4", mcu: "esp32" },
+  components: [],
+  buses: [],
+  connections: [],
+  requirements: [],
+  warnings: [],
+} as Design;
+
+beforeEach(() => {
+  mockApi.kicadSchematic.mockReset();
+  (URL as unknown as { createObjectURL: () => string }).createObjectURL = vi.fn(() => "blob:fake");
+  (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = vi.fn();
+});
+afterEach(() => {
+  delete (URL as unknown as Record<string, unknown>).createObjectURL;
+  delete (URL as unknown as Record<string, unknown>).revokeObjectURL;
+});
+
+
+describe("SchematicDialog", () => {
+  it("downloads on click and shows the success state", async () => {
+    mockApi.kicadSchematic.mockResolvedValue("from skidl import Part\n");
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    const btn = await screen.findByRole("button", { name: /Download \.skidl\.py/ });
+    await userEvent.click(btn);
+    await waitFor(() => expect(mockApi.kicadSchematic).toHaveBeenCalledWith(design));
+    await waitFor(() => screen.getByText(/Downloaded ✓/));
+  });
+
+  it("renders a usage snippet referencing the design id", () => {
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    expect(screen.getByText(/python garage-motion\.skidl\.py/)).toBeInTheDocument();
+    expect(screen.getByText(/produces garage-motion\.kicad_sch/)).toBeInTheDocument();
+  });
+
+  it("surfaces a 422 detail in a rose banner", async () => {
+    const { ApiError } = await vi.importActual<typeof import("../api/client")>(
+      "../api/client",
+    );
+    mockApi.kicadSchematic.mockRejectedValue(
+      new ApiError(422, "POST /design/kicad/schematic -> 422", {
+        detail: "design.id is required",
+      }),
+    );
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    const btn = await screen.findByRole("button", { name: /Download \.skidl\.py/ });
+    await userEvent.click(btn);
+    await waitFor(() => screen.getByText(/design.id is required/));
+  });
+
+  it("links to the SKiDL docs", () => {
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    const link = screen.getByRole("link", { name: /SKiDL/i });
+    expect(link).toHaveAttribute("href", "https://devbisme.github.io/skidl/");
+  });
+
+  it("closes when the user clicks Close", async () => {
+    const onClose = vi.fn();
+    render(<SchematicDialog design={design} onClose={onClose} />);
+    await userEvent.click(screen.getByRole("button", { name: /Close/ }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/SchematicDialog.tsx
+++ b/web/src/components/SchematicDialog.tsx
@@ -1,0 +1,130 @@
+/**
+ * Schematic export dialog (0.9). Downloads a SKiDL Python script the
+ * user runs locally to produce `<design_id>.kicad_sch`. The studio
+ * doesn't import or run SKiDL itself -- this keeps the generated
+ * artefact transparent (the user can `cat` it, edit it, regenerate)
+ * and avoids adding numpy + an EDA toolchain to the server.
+ */
+import { useState } from "react";
+import { api, ApiError } from "../api/client";
+import type { Design } from "../types/api";
+
+interface Props {
+  design: Design;
+  onClose: () => void;
+}
+
+export function SchematicDialog({ design, onClose }: Props) {
+  const [downloading, setDownloading] = useState(false);
+  const [downloaded, setDownloaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDownload() {
+    setDownloading(true);
+    setDownloaded(false);
+    setError(null);
+    try {
+      const py = await api.kicadSchematic(design);
+      const blob = new Blob([py], { type: "text/x-python" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${design.id ?? "design"}.skidl.py`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setDownloaded(true);
+    } catch (e) {
+      let msg: string;
+      if (e instanceof ApiError) {
+        const body = e.body as { detail?: unknown } | undefined;
+        const detail = body?.detail;
+        msg = `${e.status}: ${typeof detail === "string" ? detail : e.message}`;
+      } else {
+        msg = e instanceof Error ? e.message : String(e);
+      }
+      setError(msg);
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="m-4 flex max-h-[85vh] w-full max-w-xl flex-col overflow-hidden rounded-lg border border-zinc-800 bg-zinc-950 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
+          <div>
+            <div className="text-sm font-semibold text-zinc-100">KiCad schematic</div>
+            <div className="text-xs text-zinc-500">
+              SKiDL Python script — run locally to produce a `.kicad_sch`.
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-900"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="space-y-3 p-4 text-sm text-zinc-300">
+          <p className="text-xs leading-relaxed text-zinc-400">
+            Downloads a self-contained <code className="text-zinc-200">.skidl.py</code>
+            file. Run it with{" "}
+            <a
+              href="https://devbisme.github.io/skidl/"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-blue-300 hover:underline"
+            >
+              SKiDL
+            </a>
+            {" "}installed:
+          </p>
+          <pre className="overflow-x-auto rounded border border-zinc-800 bg-black/60 p-2 font-mono text-[11px] leading-relaxed text-zinc-200">
+{`pip install skidl
+python ${design.id ?? "design"}.skidl.py
+# produces ${design.id ?? "design"}.kicad_sch in the cwd`}
+          </pre>
+          <p className="text-[11px] text-zinc-500">
+            Components without a <code>kicad:</code> mapping in the studio
+            library render as a generic 4-pin connector with a TODO
+            comment; you can either patch the .py before running or fill
+            in the library YAML and re-export. Pin-name remaps from
+            each component's <code>kicad.pin_map</code> are baked into
+            the script (e.g., the BME280's VCC role becomes VDD on the
+            schematic to match the Bosch symbol's pin name).
+          </p>
+          <button
+            onClick={handleDownload}
+            disabled={downloading}
+            className="rounded bg-blue-500/20 px-3 py-1.5 text-sm text-blue-100 ring-1 ring-blue-400/40 enabled:hover:bg-blue-500/30 disabled:opacity-40"
+          >
+            {downloading
+              ? "Generating…"
+              : downloaded
+                ? "Downloaded ✓ — generate again"
+                : "Download .skidl.py →"}
+          </button>
+          {error && (
+            <div className="rounded border border-rose-700/40 bg-rose-900/15 px-2 py-1.5 text-xs text-rose-200">
+              {error}
+            </div>
+          )}
+          <p className="text-[11px] text-zinc-500">
+            PCB layout (Freerouting + Gerber export) is on the 1.0+
+            roadmap; for now the netlist + schematic are sufficient to
+            open in KiCad and start a layout by hand.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
0.9 v1 ships the KiCad schematic export pipeline end-to-end. PCB layout (Freerouting + Gerber) stays deferred to 1.0+ as planned.

## Architecture

**The studio doesn't import or run SKiDL itself.** A hard runtime dep would pull in numpy + EDA-toolchain weight that's wrong for a server. Instead, the studio emits a SKiDL Python script and the user runs it locally:

```
pip install skidl
python <design_id>.skidl.py
# produces <design_id>.kicad_sch
```

This keeps the artefact fully transparent (the user can `cat` it, edit it, regenerate) and the studio's dep tree clean.

**Two-layer library**: our `library/components/<id>.yaml` stays canonical for ESPHome semantics; KiCad stays canonical for schematic rendering. Each component / board YAML gains a small `kicad:` reference block (KicadSymbolRef: symbol_lib + symbol + footprint + value + pin_map). 21 of 41 components + 6 of 13 boards have mappings in this PR — covering every component used in the bundled examples. The rest fall back to a generic 4-pin `Connector_Generic` with a TODO comment so the generated script always runs.

## What ships

### Library schema
- `KicadSymbolRef` model on `LibraryComponent` + `LibraryBoard`. `pin_map` handles role-name → symbol-pin-name remaps (BME280's VCC role becomes `VDD` on the schematic to match the Bosch symbol).

### Mappings (this PR)
| Boards (6) | Components (21) |
|---|---|
| `wemos-d1-mini` → `MCU_Module:WeMos_D1_mini` | BME280 / BMP180 / HTU21D / DS18B20 / MPU6050 / ADS1115 / TSL2561 / MAX31855 / HX711 |
| `esp32-devkitc-v4` → `MCU_Module:ESP32-DevKitC-V4` | SSD1306 / WS2812B / MAX98357A |
| `nodemcu-32s` → `MCU_Module:NodeMCU-32S` | MCP23008 / MCP23017 / SX1276 |
| `nodemcu-v2` → `MCU_Module:NodeMCU-1.0` | HC-SR501 / RCWL-0516 / HC-SR04 / UART GPS / RC522 / ST7789 (generic header fallbacks) |
| `ttgo-lora32-v1` → generic `Conn_02x18_Odd_Even` | |
| `esp01_1m` → `RF_Module:ESP-01` | |

### Generator
- `studio/kicad/generator.py` — `generate_skidl(design, library) -> str`. Walks rails / components / buses / connections, emits one SKiDL `Part(...)` per design component plus the board, one `Net(...)` per rail / bus, one `comp[pin_name] += net` per connection. Pin-name remaps from `kicad.pin_map` are baked into the connection lines. Net derivation: rail → `NET_PLUS_<rail>` / `GND`, bus → `NET_BUS_<id>`, gpio → `Net("GPIO_<pin>")`, expander_pin → `Net("<hub>_GP<n>")`, component → `Net("<hub>_HUB")`. Reference designators auto-allocated by category.

### API + UI
- `POST /design/kicad/schematic` returns the SKiDL Python script with a `Content-Disposition: attachment; filename="<design_id>.skidl.py"` header.
- New header **Schematic** button (between Solve pins and Push to fleet) opens `SchematicDialog` with a usage snippet, a one-click download, a link to the SKiDL docs, and an explicit note that PCB layout is deferred to 1.0+.

## Tests

| Layer | Count | Highlights |
|---|---|---|
| `test_kicad.py` | 13 | Every bundled example (`garage-motion`, `wasserpir`, `oled`, `bluemotion`, `distance-sensor`, `rc522`, `esp32-audio`, `wemosgps`, `ttgo-lora32`, `multi-temp`) compiles via `compile()`; BME280 pin_map applied; mapped parts emit symbol + footprint; unmapped fall back to TODO + Conn_01x04; rails / buses / GPIO / expander_pin / component nets each render correctly; ads1115 hub split round-trip; identifier sanitiser parametric |
| `test_api.py` (+2) | 2 | Endpoint returns valid Python under `compile()` with the right `Content-Disposition`; 422 on invalid design |
| `SchematicDialog.test.tsx` | 5 | Download round-trip + success affirmation; usage snippet references design id; 422 surfaces in rose banner; SKiDL doc link; Close wires onClose |

290 pytest (+15), 125 vitest (+5), ruff + tsc + vite build clean.

## Test plan

- [ ] `python -m pytest`
- [ ] `python -m ruff check .`
- [ ] `cd web && npm run build && npx vitest run`
- [ ] Smoke: load garage-motion in the dev UI, click **Schematic**, download `garage-motion-v1.skidl.py`. In a venv: `pip install skidl && python garage-motion-v1.skidl.py`. Open the resulting `.kicad_sch` in KiCad and confirm the BME280 / PIR / ESP32 module symbols all render with the right pin connections.

## What's queued (for follow-up sessions)

- Library mapping expansion: 20 components + 7 boards still emit the TODO placeholder. Each is ~6 lines of YAML once you've looked up the right `kicad-symbols` entry.
- `studio/kicad/scaffold.py` — read a `.kicad_sym` file and print a starter `library/components/<id>.yaml` skeleton; cuts ~80% of the boilerplate when adding a new part.
- 1.0 — KiCad PCB layout (Freerouting + Gerber + JLCPCB CPL/BOM).

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_