### PR TITLE
0.9 v2: library mapping expansion -- 100% kicad: coverage

### DIFF
--- a/START.md
+++ b/START.md
@@ -27,18 +27,43 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 + build clean.
 
 **Next up candidates:**
-- Library mapping expansion — 21 of 41 components and 6 of 13 boards
-  carry a `kicad:` block today; the rest fall back to a generic 4-pin
-  connector with a TODO. The pattern is well-pinned, so filling in
-  the rest is mechanical (look up the right `kicad-symbols` entry,
-  add ~6 lines of YAML). High-value next batch: bmp280, dht, apa102,
-  st7789, ssd1306 confirmation, the new ESP32-S3 / C3 / WROVER-CAM
-  boards.
 - `studio/kicad/scaffold.py` — read a `.kicad_sym` file and print
   a starter `library/components/<id>.yaml` skeleton so adding new
   parts becomes ~30 seconds of curation rather than ~5 minutes.
+  Less urgent now that the existing library is fully mapped, but
+  pays off the next time someone adds a part.
+- Refining the generic-header fallbacks. Several breakouts (CC1101,
+  ILI9xxx, RDM6300, the M5Stack and TTGO boards) currently use a
+  `Connector_Generic` header with the part name as `value:`. When
+  KiCad ships proper module symbols (or a community footprint
+  drops on Component Search Engine), swap the mapping in.
 - 1.0 — KiCad PCB layout. Reuse the schematic's netlist; Freerouting
   for autorouting; Gerber + JLCPCB CPL/BOM export.
+
+**0.9 v2 -- library mapping expansion shipped.** The remaining 20
+components + 7 boards now carry a `kicad:` block, taking coverage
+from 21/41 + 6/13 to 41/41 + 13/13. Real-symbol mappings: BMP280,
+DHT11/22, Rotary_Encoder_Switch, Buzzer (for RTTTL piezo). Generic-
+header fallbacks (with the part name as `value:`) for breakouts
+that lack a first-party `kicad-symbols` entry: CC1101, ILI9xxx,
+LCD-PCF8574, LD2420, MAX7219, RDM6300, RF-Bridge, TM1638, XPT2046,
+APA102, the four ESP32-S3/C3/CAM boards, M5Stack Atom + AtomS3,
+TTGO T-Beam. Virtual ESPHome platforms (`adc`, `ads1115_channel`,
+`gpio_input`, `gpio_output`, `pulse_counter`, `esp32_camera`) map
+to small (1-2 pin) labelled headers so the schematic shows where
+the real-world part connects -- the user replaces with the actual
+switch / relay / camera-FPC after import.
+
+New regression test (`test_every_library_entry_has_a_kicad_block`)
+asserts 100% coverage going forward; the next library addition
+without a `kicad:` block fails it loudly with a "add one referencing
+the matching kicad-symbols entry, or a generic Connector_Generic
+header with the part name as `value:`" hint. Existing fallback
+test rewritten to inject a synthetic unmapped entry rather than
+depending on a real-but-unmapped library_id (which drifts as
+mappings land).
+
+291 pytest (+1 guardrail), 125 vitest, ruff + tsc + vite build clean.
 - Printables search source. Currently deferred -- Printables
   doesn't expose a public REST/GraphQL API and scraping their
   internals is fragile (the page-level GraphQL endpoint changes
@@ -57,13 +82,22 @@ stays as a back-compat wrapper. Pytest +21 (179 total), vitest 49, ruff
 **0.9 v1 -- KiCad schematic export shipped.** New `kicad:` reference
 block on `LibraryComponent` + `LibraryBoard` (KicadSymbolRef:
 symbol_lib + symbol + footprint + pin_map + value override).
-Mappings landed for 21 components (BME280, DS18B20, MPU6050,
-ADS1115, MCP23008/17, SSD1306, WS2812B, MAX31855, HX711, TSL2561,
-SX1276, MAX98357A, plus generic-connector fallbacks for HC-SR501,
-HC-SR04, RCWL-0516, RC522, ST7789, UART GPS) and 6 boards (D1 Mini,
-ESP32 DevKitC V4, NodeMCU-32S, NodeMCU v2, ESP-01S, TTGO LoRa32 V1).
-Components without a mapping fall back to a generic 4-pin
-Connector_Generic with a TODO comment so the script always runs.
+Mappings landed for the entire library: every one of the 41
+library components and 13 boards carries a `kicad:` block (v1
+shipped 21+6, v2 closed the rest). Real-symbol mappings cover the
+parts with first-party `kicad-symbols` entries (BME280, BMP280,
+DS18B20, MPU6050, ADS1115, MCP23008/17, SSD1306, WS2812B,
+MAX31855, HX711, TSL2561, SX1276, MAX98357A, DHT11/22,
+Rotary_Encoder_Switch, Buzzer for RTTTL piezo). Generic
+`Connector_Generic` headers with the part name as `value:` cover
+breakouts without a first-party entry (HC-SR501, HC-SR04,
+RCWL-0516, RC522, ST7789, UART GPS, CC1101, ILI9xxx, LCD-PCF8574,
+LD2420, MAX7219, RDM6300, RF-Bridge, TM1638, XPT2046, APA102,
+ESP32-S3/C3 DevKits, ESP32-CAM AI-Thinker, ESP32-WROVER-CAM,
+M5Stack Atom + AtomS3, TTGO T-Beam). Virtual ESPHome platforms
+(`adc`, `ads1115_channel`, `gpio_input`, `gpio_output`,
+`pulse_counter`, `esp32_camera`) map to 1-2 pin labelled headers
+so the schematic shows where the real-world part connects.
 
 `studio/kicad/generator.py` walks the design and emits a SKiDL Python
 script. The studio doesn't import or run SKiDL itself -- a hard

--- a/library/boards/esp32-c3-devkitm-1.yaml
+++ b/library/boards/esp32-c3-devkitm-1.yaml
@@ -44,3 +44,10 @@ gpio_capabilities:
   GPIO19: [gpio, usb_jtag]
   GPIO20: [gpio, uart_rx, serial_rx]
   GPIO21: [gpio, uart_tx, serial_tx]
+# KiCad symbol mapping (0.9). No dedicated DevKitM-1 module symbol in
+# kicad-symbols today; the closest is the standard 2x9 dual-row
+# header that matches the board's pin pitch.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_02x09_Odd_Even
+  value: ESP32-C3-DevKitM-1

--- a/library/boards/esp32-s3-devkitc-1.yaml
+++ b/library/boards/esp32-s3-devkitc-1.yaml
@@ -69,3 +69,9 @@ gpio_capabilities:
   GPIO46: [gpio, strap, boot_low, pwm]
   GPIO47: [gpio, pwm]
   GPIO48: [gpio, builtin_led, pwm]
+# KiCad symbol mapping (0.9). 44-pin board, modelled as a 2x22
+# header until KiCad ships a dedicated S3-DevKitC module symbol.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_02x22_Odd_Even
+  value: ESP32-S3-DevKitC-1

--- a/library/boards/esp32-wrover-cam.yaml
+++ b/library/boards/esp32-wrover-cam.yaml
@@ -64,3 +64,8 @@ gpio_capabilities:
   GPIO35: [gpio, adc, adc1, input_only, no_pull_internal]
   GPIO36: [gpio, camera_data, adc, adc1, input_only, no_pull_internal]
   GPIO39: [gpio, camera_data, adc, adc1, input_only, no_pull_internal]
+# KiCad symbol mapping (0.9). Generic single-row header fallback.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x14
+  value: ESP32-WROVER-CAM

--- a/library/boards/esp32cam-ai-thinker.yaml
+++ b/library/boards/esp32cam-ai-thinker.yaml
@@ -70,3 +70,9 @@ gpio_capabilities:
   GPIO35: [gpio, camera_data, adc, adc1, input_only, no_pull_internal]
   GPIO36: [gpio, camera_data, adc, adc1, input_only, no_pull_internal]
   GPIO39: [gpio, camera_data, adc, adc1, input_only, no_pull_internal]
+# KiCad symbol mapping (0.9). 16-pin AI-Thinker breakout; modelled
+# as a 2x8 dual-row header.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_02x08_Odd_Even
+  value: AI-Thinker ESP32-CAM

--- a/library/boards/m5stack-atom.yaml
+++ b/library/boards/m5stack-atom.yaml
@@ -41,3 +41,9 @@ gpio_capabilities:
   GPIO32: [gpio, adc, adc1, pwm]
   GPIO33: [gpio, adc, adc1, pwm, i2s_lrclk]
   GPIO39: [gpio, button, adc, adc1, input_only, no_pull_internal]
+# KiCad symbol mapping (0.9). M5Stack Atom Lite/Matrix has a 9-pin
+# bottom header (HY2.0 + GPIO).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x09
+  value: M5Stack Atom

--- a/library/boards/m5stack-atoms3.yaml
+++ b/library/boards/m5stack-atoms3.yaml
@@ -59,3 +59,9 @@ gpio_capabilities:
   GPIO41: [gpio, button]
   GPIO43: [gpio, uart_tx, serial_tx]
   GPIO44: [gpio, uart_rx, serial_rx]
+# KiCad symbol mapping (0.9). Same 9-pin bottom header as the Atom
+# but ESP32-S3 internals.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x09
+  value: M5Stack AtomS3

--- a/library/boards/ttgo-t-beam.yaml
+++ b/library/boards/ttgo-t-beam.yaml
@@ -67,3 +67,9 @@ gpio_capabilities:
   GPIO36: [gpio, adc, adc1, input_only, no_pull_internal]
   GPIO38: [gpio, button, input_only, no_pull_internal]
   GPIO39: [gpio, adc, adc1, input_only, no_pull_internal]
+# KiCad symbol mapping (0.9). 28-pin board (LoRa + GPS + battery
+# manager); modelled as a 2x14 dual-row header.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_02x14_Odd_Even
+  value: TTGO T-Beam

--- a/library/components/adc.yaml
+++ b/library/components/adc.yaml
@@ -61,3 +61,11 @@ params_schema:
     type: integer
 
 notes: "ESP8266 only has one ADC pin (A0) and reads 0-1.0V via the onboard divider on most dev boards (3.2V max at the screw terminal on a D1 Mini / NodeMCU). ESP32 ADC2 conflicts with WiFi; the pin solver prefers ADC1 and surfaces a warning if you pin to ADC2. For battery monitoring, multiply by your divider ratio in `filters: - multiply: ...`."
+# KiCad symbol mapping (0.9). The `adc` ESPHome platform reads an
+# analog GPIO -- it isn't a physical part of its own. Single-pin
+# header marks the sense net so the schematic shows where the
+# analog source enters the board.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x01
+  value: ADC sense

--- a/library/components/ads1115_channel.yaml
+++ b/library/components/ads1115_channel.yaml
@@ -58,3 +58,12 @@ notes: |
   modes Ax_Ay use the two pins as a differential pair. Gain is the
   full-scale range in volts -- pick the lowest one ≥ your expected
   signal range to maximise resolution.
+# KiCad symbol mapping (0.9). Each ADS1115 channel is a logical
+# reading on the hub -- there's no separate physical part. We render
+# a 1-pin header on the schematic so the channel's HUB connection
+# has somewhere to land; KiCad users typically delete these and let
+# the hub's input pin label the net by itself.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x01
+  value: ADS1115 channel

--- a/library/components/apa102.yaml
+++ b/library/components/apa102.yaml
@@ -56,3 +56,11 @@ params_schema:
     type: array
 
 notes: "DotStar-class strips use a 2-wire (data + clock) SPI-style protocol, so they don't suffer from the 800kHz timing constraints of WS2812B. They share an SPI bus only awkwardly because they don't have a CS pin -- give them dedicated GPIOs rather than mixing on a bus with other SPI devices. Current rises ~60mA per LED at full white; a 1000uF bulk cap close to the strip is recommended above ~8 LEDs."
+# KiCad symbol mapping (0.9). APA102 strips ship as 4-wire pigtails
+# (VCC, GND, DATA, CLK); the chip itself is also in some KiCad libs as
+# `LED:APA102` but the pigtail header captures what the user actually
+# solders to.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  value: APA102

--- a/library/components/bmp280.yaml
+++ b/library/components/bmp280.yaml
@@ -52,3 +52,10 @@ params_schema:
     default: "60s"
 
 notes: "Pressure-only Bosch sibling of the BME280; same I2C protocol, no humidity channel. 3V3 only. SDO pin selects the I2C address (0x76 GND, 0x77 VCC)."
+# KiCad symbol mapping (0.9). BMP280 in Sensor lib; same VDD/GND/SDA/SCL
+# pinout as BME280 minus humidity.
+kicad:
+  symbol_lib: Sensor
+  symbol: BMP280
+  pin_map:
+    VCC: VDD

--- a/library/components/cc1101.yaml
+++ b/library/components/cc1101.yaml
@@ -67,3 +67,11 @@ params_schema:
     type: integer
 
 notes: "CC1101 needs an external_components dependency on the radiolib_cc1101 fork. GDO2 is optional but used by the receive-only `remote_receiver` flow when `packet_mode: false`. The module pulls >30mA on TX bursts, so add the 10uF bulk cap close to VCC. ESPHome's `cc1101` block is a singleton."
+# KiCad symbol mapping (0.9). CC1101 sub-GHz radio. The bare chip is
+# QFN-20 in `RF:CC1101` on some KiCad installs, but the typical
+# hobbyist module is an 8-pin breakout -- generic header captures
+# the soldering surface.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x08
+  value: CC1101

--- a/library/components/dht.yaml
+++ b/library/components/dht.yaml
@@ -44,3 +44,11 @@ params_schema:
     default: "60s"
 
 notes: "Single-wire bidirectional protocol. DHT22 / AM2302 modules ship with the 10K pull-up populated; bare DHT11s do not. Polling faster than 1Hz returns stale data and the ESPHome platform will warn."
+# KiCad symbol mapping (0.9). DHT11 + DHT22 share a symbol + 4-pin
+# breakout; the module form omits the unused NC pin.
+kicad:
+  symbol_lib: Sensor
+  symbol: DHT11
+  value: DHT11/DHT22
+  pin_map:
+    VCC: VDD

--- a/library/components/esp32_camera.yaml
+++ b/library/components/esp32_camera.yaml
@@ -91,3 +91,13 @@ params_schema:
     description: "Optional `[{ port: 8080, mode: stream }, { port: 8081, mode: snapshot }]` list."
 
 notes: "ESP32 only -- OV2640 needs the dedicated parallel bus + DMA the classic ESP32 / ESP32-S3 expose, and won't work on C3/H2/etc. The sensor pulls >300mA on capture and is intolerant of a sagging 3V3 rail; bring out the 10uF cap on the camera board (most modules already have it). For boards with the camera baked into the board file (AI-Thinker, Wrover, M5Camera, TTGO T-Camera) prefer pinning every camera role to the equivalent `expander_pin: camera` slots from the board's onboard_peripherals."
+# KiCad symbol mapping (0.9). The ESP32-CAM camera FPC has 24 pins
+# but the typical AI-Thinker board doesn't break them out -- the
+# camera plugs into the board's onboard FPC connector. We render a
+# 1-pin header as a placeholder so designs that reference
+# esp32_camera don't break the schematic; the user replaces it with
+# their actual breakout / FPC connector after import.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x01
+  value: ESP32 Camera FPC

--- a/library/components/gpio_input.yaml
+++ b/library/components/gpio_input.yaml
@@ -52,3 +52,10 @@ params_schema:
     default: false
 
 notes: "Pin mode (INPUT, INPUT_PULLUP, etc.) and inverted are properties of the connection target, not the sensor. Set them on the connection's expander_pin entry; native GPIO connections inherit ESPHome defaults."
+# KiCad symbol mapping (0.9). 2-pin header captures the wired input
+# (switch contact, door sensor, etc.). Replace with Switch:SW_Push
+# or the right manufacturer symbol after import.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x02
+  value: Input

--- a/library/components/gpio_output.yaml
+++ b/library/components/gpio_output.yaml
@@ -42,3 +42,10 @@ params_schema:
     enum: [RESTORE_DEFAULT_OFF, RESTORE_DEFAULT_ON, ALWAYS_OFF, ALWAYS_ON, RESTORE_INVERTED_DEFAULT_OFF, RESTORE_INVERTED_DEFAULT_ON, DISABLED]
 
 notes: "Pin mode (OUTPUT, OUTPUT_OPEN_DRAIN) and inverted are properties of the connection target. For a hardware relay driver, model the relay as a separate downstream component if you need its electrical metadata."
+# KiCad symbol mapping (0.9). 2-pin header captures the wired load
+# (relay coil, indicator LED, motor leg, etc.). Replace with the
+# actual driven part after import.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x02
+  value: Output

--- a/library/components/ili9xxx.yaml
+++ b/library/components/ili9xxx.yaml
@@ -69,3 +69,10 @@ params_schema:
     default: "5s"
 
 notes: "MISO is required only if your code reads back from the panel (touch-on-the-same-bus boards do, the typical ESPHome lambda flow does not). The 3.5\" Pi-style ILI9486 panels need an `init_sequence` override -- copy from the in-tree 35display.yaml for the Waveshare/Adafruit-style boards. Backlight on most clones is a passive 5V LED; tie it to a GPIO via `backlight_pin` in a `light:` block if you need PWM dimming."
+# KiCad symbol mapping (0.9). Generic header for the ILI9341 / 9488 /
+# 9486 family of SPI displays. Pin count varies (8-14) by breakout;
+# 14 is the upper bound that covers most commodity boards.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x14
+  value: ILI9xxx

--- a/library/components/lcd_pcf8574.yaml
+++ b/library/components/lcd_pcf8574.yaml
@@ -51,3 +51,9 @@ params_schema:
     default: "1s"
 
 notes: "5V LCD running over a 3.3V I2C bus through a level-shifting PCF8574 backpack. Common backpack addresses are 0x27 (most clones) and 0x3F (some Adafruit-style boards); the in-tree corpus also has 0x26 for a custom variant. Backlight control is exposed as `display.{id}.backlight()` / `no_backlight()`."
+# KiCad symbol mapping (0.9). Generic 4-pin header (VCC/GND/SDA/SCL)
+# matching the I2C backpack on a 16x2 / 20x4 character LCD.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  value: LCD I2C backpack

--- a/library/components/ld2420.yaml
+++ b/library/components/ld2420.yaml
@@ -49,3 +49,9 @@ params_schema:
     maximum: 16
 
 notes: "UART runs at 256000 baud (LD2420) or 256000/115200 (LD2410). Wire the module's TX to the MCU RX and vice versa. ESPHome's `ld2420` integration is a singleton -- one mmWave per device. The sister `ld2410` integration mirrors this template if you swap the platform name."
+# KiCad symbol mapping (0.9). 24GHz radar presence sensor; standard
+# 4-pin breakout (5V, GND, RX, TX).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  value: LD2420

--- a/library/components/max7219.yaml
+++ b/library/components/max7219.yaml
@@ -53,3 +53,10 @@ params_schema:
     default: "1s"
 
 notes: "ESPHome ships two flavors: `max7219` for stock 7-segment + decimal modules and `max7219digit` for daisy-chained 8x8 matrices and graphics-style 7-segments. This template uses `max7219digit` since most boards in the wild are matrix or scrolling-text style. Each chip pulls up to ~320mA at full brightness on a single digit; budget accordingly for chains."
+# KiCad symbol mapping (0.9). Generic 5-pin header captures the
+# MAX7219 LED matrix breakout (VCC, GND, DIN, CS, CLK). The bare
+# DIP-24 chip is also in `Display_Driver:MAX7219` if you swap by hand.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x05
+  value: MAX7219

--- a/library/components/pulse_counter.yaml
+++ b/library/components/pulse_counter.yaml
@@ -62,3 +62,9 @@ params_schema:
     description: "Standard ESPHome sensor filters; commonly `multiply: 0.5` for 2-pulse-per-rev fan tachs."
 
 notes: "On ESP8266 the pulse counter is software-driven and tops out around ~10kHz. ESP32 uses the dedicated PCNT peripheral and is good for several hundred kHz. For 4-pin PWM fan tachs, two pulses are produced per revolution -- divide by 2 with a `multiply: 0.5` filter to read RPM."
+# KiCad symbol mapping (0.9). 2-pin header captures the pulse source
+# (water meter reed switch, anemometer, encoder, etc.).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x02
+  value: Pulse source

--- a/library/components/rdm6300.yaml
+++ b/library/components/rdm6300.yaml
@@ -35,3 +35,9 @@ params_schema:
     description: "ESPHome action list to run when a tag is read; receives `x` as the decimal tag ID."
 
 notes: "UART at 9600 baud, 8N1. ESPHome's `rdm6300:` is a singleton and emits an event per scan; wire the module's TX to the bus RX and leave the bus TX unbound. Antenna sensitivity is a few cm -- tags need to be within ~3cm of the coil. For longer range or HF tags use the rc522 (MFRC522) component instead."
+# KiCad symbol mapping (0.9). 125 kHz RFID reader; 6-pin breakout
+# (VCC, GND, TX, RX, ANT1, ANT2).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x06
+  value: RDM6300

--- a/library/components/rf_bridge.yaml
+++ b/library/components/rf_bridge.yaml
@@ -33,3 +33,9 @@ params_schema:
     description: "Action list run when an RF code is received; receives `data` with `sync`, `low`, `high`, `code` fields."
 
 notes: "Inside the Sonoff RF Bridge, an EFM8BB1 microcontroller decodes 433MHz signals and ships them to the host ESP8266 over a 19200-baud UART (TX = GPIO1, RX = GPIO3 -- the same pins used by the USB serial console, so set `logger: baud_rate: 0` on stock hardware). ESPHome's `rf_bridge:` block is a singleton. Send codes via `rf_bridge.send_code`; learn new codes via `rf_bridge.learn`."
+# KiCad symbol mapping (0.9). 433 MHz RF bridge module (Sonoff RF
+# Bridge etc.); 4-pin header.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  value: RF bridge

--- a/library/components/rotary_encoder.yaml
+++ b/library/components/rotary_encoder.yaml
@@ -68,3 +68,9 @@ params_schema:
     type: array
 
 notes: "Both pins must support edge interrupts -- on the ESP8266 D0/GPIO16 does not. KY-040 modules ship with the pull-ups populated; bare EC11 encoders need external 10K pull-ups on both A and B. The integrated pushbutton on KY-040s should be modeled as a separate `gpio_input` component with `device_class: button`."
+# KiCad symbol mapping (0.9). Standard 5-pin incremental encoder with
+# integrated push switch (KY-040 / EC11-style breakout).
+kicad:
+  symbol_lib: Switch
+  symbol: Rotary_Encoder_Switch
+  value: Rotary encoder

--- a/library/components/rtttl.yaml
+++ b/library/components/rtttl.yaml
@@ -39,3 +39,9 @@ params_schema:
     type: array
 
 notes: "RTTTL needs a PWM-capable output, not a plain GPIO. ESP8266 can only PWM on a subset of pins (see board capabilities); ESP32 LEDC works on any GPIO. The piezo itself is passive -- a typical 5V active buzzer should NOT be wired here, since RTTTL drives a frequency, not a level. Calls look like `rtttl.play: 'success:d=24,o=5,b=100:c,g,b'`."
+# KiCad symbol mapping (0.9). RTTTL plays melodies through a piezo
+# buzzer; the schematic part is just the buzzer itself.
+kicad:
+  symbol_lib: Device
+  symbol: Buzzer
+  value: Piezo

--- a/library/components/tm1638.yaml
+++ b/library/components/tm1638.yaml
@@ -48,3 +48,9 @@ params_schema:
     default: "1s"
 
 notes: "All-in-one module: 8 7-segment digits, 8 red LEDs, 8 momentary buttons. Buttons surface as a `binary_sensor: tm1638` (`key: 0..7`) and the LEDs as `switch: tm1638` (`led: 0..7`); the library template only emits the display block. The bus is bit-banged and not 5V-tolerant, so always run the module from 3V3 if your MCU is 3V3 -- many clones tolerate it."
+# KiCad symbol mapping (0.9). Generic 5-pin header captures the
+# TM1638 LED + key-scan module (VCC, GND, STB, CLK, DIO).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x05
+  value: TM1638

--- a/library/components/xpt2046.yaml
+++ b/library/components/xpt2046.yaml
@@ -57,3 +57,9 @@ params_schema:
     description: "{ x_min: int, x_max: int, y_min: int, y_max: int } -- raw ADC values for the four corners of the touch panel."
 
 notes: "Lives on a typical 3.5\" Pi-style display alongside the ILI9486 panel and shares the same SPI bus with its own CS. Calibration values vary panel-to-panel: log raw values in a lambda for one device of each model, then bake them into the library entry's params_schema defaults. The interrupt pin should support edge interrupts (avoid ESP8266 GPIO16)."
+# KiCad symbol mapping (0.9). Resistive touch controller; 5-pin SPI
+# breakout (VCC, GND, CLK, MOSI, MISO with optional CS, IRQ, T_DO).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x05
+  value: XPT2046

--- a/tests/test_kicad.py
+++ b/tests/test_kicad.py
@@ -90,13 +90,21 @@ def test_known_part_emits_symbol_and_footprint(lib):
 
 
 def test_unmapped_component_falls_back_to_placeholder(lib):
-    """Construct a synthetic design referencing an unmapped library
-    entry and verify the placeholder + TODO comment land in the output."""
-    # `apa102` is in the library but doesn't have a kicad: block in
-    # this PR. If the assertion ever fails because someone added one,
-    # swap to another unmapped entry.
-    if lib.component("apa102").kicad is not None:
-        pytest.skip("apa102 is now mapped; pick another unmapped library_id")
+    """Construct a synthetic design referencing a fictional library
+    entry and verify the placeholder + TODO comment land in the
+    output. We monkeypatch the library to inject an unmapped entry
+    rather than relying on a real-but-unmapped one (the latter
+    drifts as new mappings land)."""
+    from copy import deepcopy
+    from studio.library import LibraryComponent
+    fake = LibraryComponent(
+        id="zz_fake_unmapped",
+        name="Fake unmapped component",
+        category="sensor",
+    )
+    # Mutate a deep-copied library so the global default isn't touched.
+    lib_local = deepcopy(lib)
+    lib_local._components["zz_fake_unmapped"] = fake
     design = {
         "schema_version": "0.1",
         "id": "fallback",
@@ -105,16 +113,38 @@ def test_unmapped_component_falls_back_to_placeholder(lib):
         "fleet": {"device_name": "fallback", "tags": []},
         "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
         "components": [
-            {"id": "rgb1", "library_id": "apa102", "label": "RGB", "params": {}},
+            {"id": "x1", "library_id": "zz_fake_unmapped", "label": "X", "params": {}},
         ],
         "buses": [],
         "connections": [],
         "requirements": [],
         "warnings": [],
     }
-    script = generate_skidl(Design.model_validate(design), lib)
-    assert "TODO: apa102" in script
+    script = generate_skidl(Design.model_validate(design), lib_local)
+    assert "TODO: zz_fake_unmapped" in script
     assert 'Part("Connector_Generic", "Conn_01x04"' in script
+
+
+def test_every_library_entry_has_a_kicad_block(lib):
+    """Going-forward guardrail: every component + board ships with a
+    `kicad:` mapping. New library entries that miss the block fall
+    through to the TODO placeholder, which still works but is sub-
+    optimal -- this test surfaces the gap loudly so the author either
+    adds a block or explicitly opts out by deleting this assertion."""
+    from pathlib import Path
+    unmapped_components = [c.id for c in lib.list_components() if c.kicad is None]
+    unmapped_boards = [
+        p.stem for p in Path(__file__).resolve().parent.parent.glob("library/boards/*.yaml")
+        if lib.board(p.stem).kicad is None
+    ]
+    assert unmapped_components == [], (
+        f"Components missing a `kicad:` block: {unmapped_components}. "
+        f"Add one referencing the matching kicad-symbols entry, or a "
+        f"generic Connector_Generic header with the part name as `value:`."
+    )
+    assert unmapped_boards == [], (
+        f"Boards missing a `kicad:` block: {unmapped_boards}."
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the v1 PR's queue note ("20 components + 7 boards still emit TODO placeholders"). Every library entry now carries a `kicad:` block; the schematic generator no longer falls through to the generic-`Conn_01x04` + TODO fallback in normal use.

## Coverage delta

| | v1 (last PR) | v2 (this PR) |
|---|---|---|
| Components | 21 / 41 | **41 / 41** (100%) |
| Boards | 6 / 13 | **13 / 13** (100%) |

## What's mapped (this PR)

### Real first-party `kicad-symbols` entries
- `bmp280` → `Sensor:BMP280`
- `dht` (covers DHT11 + DHT22) → `Sensor:DHT11`
- `rotary_encoder` → `Switch:Rotary_Encoder_Switch`
- `rtttl` (the piezo it drives) → `Device:Buzzer`

### Generic `Connector_Generic` headers with the part name as `value:`
For breakouts without a first-party entry. The schematic gets a labelled connector that reads as the right part; the user can swap to a manufacturer footprint after import once one's available.

| Component | Symbol |
|---|---|
| `apa102` | `Conn_01x04` |
| `cc1101` | `Conn_01x08` |
| `ili9xxx` | `Conn_01x14` |
| `lcd_pcf8574` | `Conn_01x04` |
| `ld2420` | `Conn_01x04` |
| `max7219` | `Conn_01x05` |
| `rdm6300` | `Conn_01x06` |
| `rf_bridge` | `Conn_01x04` |
| `tm1638` | `Conn_01x05` |
| `xpt2046` | `Conn_01x05` |

### Virtual ESPHome platforms
These don't represent a single physical part — `gpio_input` could be a switch, a door sensor, a button. Mapping each to a small (1-2 pin) labelled header makes the schematic show where the real-world part connects; the user replaces the connector with the actual switch / relay / pulse source after import.

| Component | Symbol | Why |
|---|---|---|
| `adc` | `Conn_01x01` "ADC sense" | analog source enters via a single net |
| `ads1115_channel` | `Conn_01x01` "ADS1115 channel" | logical reading on the hub |
| `gpio_input` | `Conn_01x02` "Input" | the wired input device |
| `gpio_output` | `Conn_01x02` "Output" | the driven load |
| `pulse_counter` | `Conn_01x02` "Pulse source" | meter / encoder / switch |
| `esp32_camera` | `Conn_01x01` "ESP32 Camera FPC" | the camera lives on the carrier board |

### Boards (generic-header fallbacks)
KiCad doesn't ship dedicated module symbols for these; we use a 2-row pin header that matches the board's pin pitch with the part name as `value:`.

| Board | Symbol |
|---|---|
| `esp32-c3-devkitm-1` | `Conn_02x09_Odd_Even` |
| `esp32-s3-devkitc-1` | `Conn_02x22_Odd_Even` |
| `esp32-wrover-cam` | `Conn_01x14` |
| `esp32cam-ai-thinker` | `Conn_02x08_Odd_Even` |
| `m5stack-atom` | `Conn_01x09` |
| `m5stack-atoms3` | `Conn_01x09` |
| `ttgo-t-beam` | `Conn_02x14_Odd_Even` |

## Going-forward guardrail

New `test_every_library_entry_has_a_kicad_block` asserts 100% coverage. The next library addition without a `kicad:` block fails it loudly with a hint pointing at the right action:

> Components missing a `kicad:` block: ['some_new_part']. Add one referencing the matching kicad-symbols entry, or a generic Connector_Generic header with the part name as `value:`.

The existing `test_unmapped_component_falls_back_to_placeholder` was rewritten to inject a synthetic unmapped `LibraryComponent` into a deep-copied library rather than depending on a real-but-unmapped library_id (which drifts as mappings land). The fallback path stays valuable as a safety net for new library authors who haven't gotten to the `kicad:` block yet, and as a runtime guarantee that the script always produces valid Python.

## Tests

291 pytest (+1 guardrail), 125 vitest, ruff + tsc + vite build clean.

## Test plan

- [ ] `python -m pytest`
- [ ] `python -m ruff check .`
- [ ] `cd web && npm run build && npx vitest run`
- [ ] Smoke: load any bundled example, click **Schematic**, run the resulting `.skidl.py`, eyeball the produced `.kicad_sch` in KiCad.

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_