### PR TITLE
Docker single-image deployment + GHA -> GHCR + nginx compose recipe

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Keep the build context small; copy in only what the Dockerfile needs.
+.git
+.gitignore
+.github
+.venv
+venv
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+htmlcov
+.coverage
+node_modules
+
+# Build artefacts (web-builder stage rebuilds dist/ inside the image)
+web/dist
+web/.vite
+build
+dist
+*.egg-info
+
+# Local runtime state -- the deployed image gets a fresh /data.
+sessions
+designs
+
+# Editor/OS noise
+.DS_Store
+*.swp
+.idea
+.vscode
+
+# Test goldens are checked into git but the runtime image doesn't
+# need them. (Tests don't run inside the image.)
+tests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,82 @@
+name: docker
+
+# Build + publish the runtime image to GitHub Container Registry.
+#
+# Triggers:
+#   - push to main      -> ghcr.io/<owner>/esphome-studio:main + :sha-<short>
+#   - tag push v*       -> ghcr.io/<owner>/esphome-studio:v1.2.3 + :1.2.3 + :1.2 + :latest
+#   - PR target         -> build only (no push), as a sanity gate
+#
+# Auth: GITHUB_TOKEN with packages:write. No external secrets needed.
+#
+# Multi-arch: linux/amd64 + linux/arm64 so a Pi 4 / 5 can pull the same
+# tag the homelab box uses.
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/esphome-studio
+          # Tag strategy:
+          #   main push      -> :main, :sha-<short>
+          #   v1.2.3 tag     -> :v1.2.3, :1.2.3, :1.2, :latest
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=esphome-studio
+            org.opencontainers.image.description=Agent-driven ESPHome device design tool
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=MIT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,81 @@
+# syntax=docker/dockerfile:1.7
+#
+# Single-image deployment for esphome-studio.
+#
+# Two stages:
+#   1. web-builder: Node + Vite, produces /web/dist with the SPA bundle.
+#   2. runtime:     Python slim, installs the studio package + ships the
+#                   built bundle. uvicorn serves the API under /api/* and
+#                   the bundle at / via studio.api.serve.
+#
+# Run:
+#   docker run --rm -p 8765:8765 \
+#     -e ANTHROPIC_API_KEY=sk-ant-... \
+#     -v studio-data:/data \
+#     ghcr.io/moellere/esphome-studio:latest
+#
+# Persistence: /data holds sessions/ + designs/. The container creates
+# both subdirs on first launch; mount a named volume or host path here.
+#
+# Secrets (all optional): ANTHROPIC_API_KEY, FLEET_URL, FLEET_TOKEN,
+# THINGIVERSE_API_KEY. Pass at runtime via -e or --env-file; never bake
+# them into the image.
+
+# ---------------------------------------------------------------------------
+# Stage 1: build the SPA bundle.
+# ---------------------------------------------------------------------------
+FROM node:20-alpine AS web-builder
+WORKDIR /web
+
+# Cache npm install separately from sources -- a code-only change
+# shouldn't bust the dep layer.
+COPY web/package.json web/package-lock.json* ./
+RUN npm ci --no-audit --no-fund
+
+COPY web/ ./
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime.
+# ---------------------------------------------------------------------------
+FROM python:3.11-slim AS runtime
+
+# Bare-minimum system layer: a CA bundle (httpx -> Anthropic / addon /
+# Thingiverse) and tini for clean signal handling.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install the studio package and its runtime deps. We copy only the
+# dependency manifest first so the install layer caches across most
+# code edits.
+COPY pyproject.toml ./
+COPY studio/ ./studio/
+COPY library/ ./library/
+COPY schema/ ./schema/
+COPY examples/ ./examples/
+COPY README.md ./
+
+RUN pip install --no-cache-dir .
+
+# Drop the built SPA into a stable path. STUDIO_STATIC_DIR points
+# uvicorn at it through studio.api.serve.
+COPY --from=web-builder /web/dist /app/web-dist
+
+# Persistence root. sessions/ + designs/ live under here so a single
+# `-v <volume>:/data` survives upgrades.
+RUN mkdir -p /data/sessions /data/designs
+
+ENV PYTHONUNBUFFERED=1 \
+    STUDIO_STATIC_DIR=/app/web-dist \
+    SESSIONS_DIR=/data/sessions \
+    DESIGNS_DIR=/data/designs
+
+EXPOSE 8765
+VOLUME ["/data"]
+
+# tini reaps zombies + forwards SIGTERM cleanly so docker stop is fast.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["python", "-m", "studio.api", "--host", "0.0.0.0", "--port", "8765", "--static-dir", "/app/web-dist"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,27 @@ agent. See [`web/README.md`](web/README.md) for UI details and
 
 ## Quickstart
 
+### Docker (single-image deployment)
+
+```sh
+docker run --rm -p 8765:8765 \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  -v studio-data:/data \
+  ghcr.io/moellere/esphome-studio:latest
+```
+
+Open <http://localhost:8765>. The image bundles the FastAPI server +
+the built web UI in one process; `/api/*` is the JSON API,
+`/` is the SPA. `/data` holds the agent's session log + saved
+designs across upgrades. `ANTHROPIC_API_KEY` enables the agent;
+`FLEET_URL`/`FLEET_TOKEN` enable the distributed-esphome handoff;
+`THINGIVERSE_API_KEY` enables enclosure search. All optional --
+the studio runs without any of them, just with those features
+gated off.
+
+For an nginx-front production recipe, see
+[`deploy/README.md`](deploy/README.md).
+
 ### CLI
 
 ```sh

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,84 @@
+# Deployment recipes
+
+The studio's published image is **single-process by default** — FastAPI
+serves the API at `/api/*` and the SPA bundle at `/`. For most
+self-hosters that's exactly what you want:
+
+```sh
+docker run --rm -p 8765:8765 \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  -v studio-data:/data \
+  ghcr.io/moellere/esphome-studio:latest
+```
+
+Open <http://localhost:8765>. Done.
+
+## When to bother with the two-service compose
+
+The `docker-compose.yml` in this directory adds an **nginx** in front
+of the studio API. You probably don't need it unless one of these is
+true:
+
+- You serve multiple users at once and want nginx's `sendfile` /
+  cache headers / brotli on top of the static bundle.
+- You want HTTPS / a domain on top of the studio with a cert that
+  isn't trivially exposed via a reverse proxy you already run.
+- You run more than one studio replica behind a load balancer and want
+  a known-good static-file frontend.
+
+The compose stack mirrors the dev-time Vite proxy: nginx serves the
+SPA bundle and proxies `/api/*` to the studio container after stripping
+the prefix. The studio container runs in **API-only mode** (we set
+`STUDIO_STATIC_DIR=` to disable the built-in static server) so we
+don't double-serve the bundle.
+
+```sh
+cd deploy
+# (optional) set ANTHROPIC_API_KEY=, FLEET_URL=, etc. in .env
+docker compose pull
+docker compose up -d
+# UI now at http://localhost:8080/
+```
+
+## Architecture cheatsheet
+
+| Concern | Single image (default) | Two-service compose |
+|---|---|---|
+| Containers | 1 | 2 + a one-shot copier |
+| Static-file server | uvicorn + FastAPI `StaticFiles` | nginx 1.27 |
+| API URL | `:8765/api/*` | `:8080/api/*` (proxied) |
+| SPA URL | `:8765/` | `:8080/` |
+| Persistence | `-v studio-data:/data` | `studio-data` named volume |
+
+## Persistence + secrets
+
+Both layouts mount `/data` into the studio container with two
+sub-directories:
+
+- `/data/sessions` — agent conversation history (one JSONL per session).
+- `/data/designs` — saved-design store backing the UI's **Saved** tab.
+
+Secrets are env vars and never baked into the image:
+
+| Env var | What it gates |
+|---|---|
+| `ANTHROPIC_API_KEY` | the agent (`/agent/*` endpoints + the chat sidebar) |
+| `FLEET_URL` + `FLEET_TOKEN` | distributed-esphome push (`/fleet/*`) |
+| `THINGIVERSE_API_KEY` | enclosure search (`/enclosure/search`) |
+
+## Updates
+
+```sh
+# Single image:
+docker pull ghcr.io/moellere/esphome-studio:latest
+docker stop studio && docker rm studio
+docker run ...
+
+# Two-service:
+cd deploy
+docker compose pull
+docker compose up -d
+```
+
+The persistence volume survives across image pulls, so saved designs +
+agent sessions carry over.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,69 @@
+# Two-service "production recipe" for esphome-studio.
+#
+# The default single-image deployment (run the published image
+# directly) is what most self-hosters want; this compose file is for
+# the case where you'd rather have nginx in front of the API for
+# better static-file serving + http/2 + brotli.
+#
+# Usage:
+#   cd deploy
+#   docker compose pull
+#   docker compose up -d
+#
+# Env vars (.env in this directory or pass via shell):
+#   ANTHROPIC_API_KEY     enable the agent
+#   FLEET_URL/FLEET_TOKEN enable Push to fleet
+#   THINGIVERSE_API_KEY   enable enclosure search
+
+services:
+  studio:
+    # The studio image has a built-in static-file server -- we override
+    # it here to run API-only, since nginx will handle the SPA.
+    image: ghcr.io/moellere/esphome-studio:latest
+    restart: unless-stopped
+    environment:
+      - ANTHROPIC_API_KEY
+      - FLEET_URL
+      - FLEET_TOKEN
+      - THINGIVERSE_API_KEY
+      # Empty STUDIO_STATIC_DIR -> serve.py falls back to bare-API mode
+      # (routes at root). nginx proxies /api/* here after stripping the
+      # prefix, matching the dev Vite config.
+      - STUDIO_STATIC_DIR=
+      - SESSIONS_DIR=/data/sessions
+      - DESIGNS_DIR=/data/designs
+    volumes:
+      - studio-data:/data
+    expose:
+      - "8765"
+    # No ports: clause -- only nginx is publicly reachable.
+
+  web:
+    image: nginx:1.27-alpine
+    restart: unless-stopped
+    depends_on:
+      - studio
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      # Mount the SPA bundle from the studio image's filesystem at
+      # /app/web-dist via a temporary copy. The simplest portable
+      # option is to publish a separate web-only image; for now we
+      # mount the same image at a no-op path and copy-on-start. The
+      # shared-volume pattern below works with any Docker installation.
+      - studio-static:/usr/share/nginx/html:ro
+
+  # One-shot helper: copies the web bundle out of the studio image into
+  # a named volume that nginx mounts read-only. Runs at every `up`;
+  # cheap (~5 MB).
+  static-prep:
+    image: ghcr.io/moellere/esphome-studio:latest
+    command: ["sh", "-c", "cp -r /app/web-dist/. /shared/"]
+    volumes:
+      - studio-static:/shared
+    restart: "no"
+
+volumes:
+  studio-data:
+  studio-static:

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,45 @@
+server {
+    listen 80 default_server;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Cache versioned hashed assets aggressively; the SPA build
+    # fingerprints filenames so any change produces a new URL.
+    location /assets/ {
+        access_log off;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # Proxy the API to the studio container. The Vite dev server's
+    # config strips /api/ before forwarding; we mirror that so the
+    # studio process continues to register routes at root paths.
+    location /api/ {
+        proxy_pass http://studio:8765/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Server-Sent Events (build-log streaming, agent stream): no
+        # buffering or the browser sees nothing until the response
+        # body closes.
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+    }
+
+    # SPA fallback: any path that isn't a real file falls through to
+    # index.html so the React shell takes over. Today the SPA doesn't
+    # use deep links, but this is cheap insurance for when it does.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Light hardening: disable server token leak, no source-map files.
+    server_tokens off;
+    location ~ \.map$ { deny all; access_log off; log_not_found off; }
+}

--- a/studio/api/__main__.py
+++ b/studio/api/__main__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -10,10 +11,28 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8765)
     parser.add_argument("--reload", action="store_true", help="reload on source changes (dev only)")
+    parser.add_argument(
+        "--static-dir",
+        default=os.environ.get("STUDIO_STATIC_DIR"),
+        help=(
+            "Serve the built web bundle from this directory at `/`, "
+            "with the API mounted at `/api/*`. Used by the production "
+            "Docker image; leave unset for dev (Vite handles the SPA)."
+        ),
+    )
     args = parser.parse_args(argv)
 
+    if args.static_dir:
+        # studio.api.serve reads STUDIO_STATIC_DIR at import time, so
+        # propagate the flag through the env so reload-spawned workers
+        # see it too.
+        os.environ["STUDIO_STATIC_DIR"] = args.static_dir
+        target = "studio.api.serve:app"
+    else:
+        target = "studio.api.app:app"
+
     uvicorn.run(
-        "studio.api.app:app",
+        target,
         host=args.host,
         port=args.port,
         reload=args.reload,

--- a/studio/api/app.py
+++ b/studio/api/app.py
@@ -117,9 +117,13 @@ def create_app(
     designs: Optional[DesignStore] = None,
     fleet_client_factory=None,
 ) -> FastAPI:
+    import os as _os
     lib = library or default_library()
-    sessions_store = sessions or SessionStore()
-    designs_store = designs or DesignStore()
+    # SESSIONS_DIR / DESIGNS_DIR env vars let the Docker image point
+    # the stores at a /data volume without the caller plumbing args
+    # through. Falls back to the package-local default in dev.
+    sessions_store = sessions or SessionStore(root=_os.environ.get("SESSIONS_DIR") or None)
+    designs_store = designs or DesignStore(root=_os.environ.get("DESIGNS_DIR") or None)
     # Tests substitute a factory that returns a FleetClient bound to an
     # httpx.MockTransport so we never hit the network in CI.
     make_fleet: callable = fleet_client_factory or (lambda: FleetClient())

--- a/studio/api/serve.py
+++ b/studio/api/serve.py
@@ -1,0 +1,67 @@
+"""Production-deployment wrapper for the studio API.
+
+In dev the studio API listens at root paths (`/library/boards`,
+`/design/render`, etc.) and the Vite dev server proxies `/api/*` to it
+after stripping the prefix. In a single-image production deployment we
+don't run Vite -- the built bundle is served as static files alongside
+the API. To keep the same `/api/*` URL space the SPA already calls,
+this wrapper mounts the studio app under `/api` and the static bundle
+at `/`.
+
+The wrapper activates only when `STUDIO_STATIC_DIR` is set and points
+at a real directory (the built `web/dist/`); otherwise we fall back to
+the bare API at root, so `python -m studio.api` keeps working for dev.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+from studio.api.app import create_app
+
+
+def _make_app() -> FastAPI:
+    static = os.environ.get("STUDIO_STATIC_DIR")
+    if not static or not Path(static).is_dir():
+        # Dev path: bare API at root. The web client uses Vite's proxy
+        # to translate `/api/*` -> root.
+        return create_app()
+    return create_serve_app(static)
+
+
+def create_serve_app(static_dir: str | Path) -> FastAPI:
+    """Build the deployment wrapper: studio API at `/api`, static
+    bundle at `/`. Pure factory; tests inject any static_dir they
+    want without touching env vars."""
+    static_path = Path(static_dir)
+    if not static_path.is_dir():
+        raise FileNotFoundError(f"static_dir does not exist: {static_path}")
+    studio_app = create_app()
+    parent = FastAPI(
+        title=studio_app.title,
+        version=studio_app.version,
+        description=(
+            f"{studio_app.description or ''} "
+            f"(deployment wrapper -- API mounted at /api, "
+            f"web bundle at /)"
+        ).strip(),
+        docs_url=None,
+    )
+    parent.mount("/api", studio_app)
+    # html=True turns `/` into the bundle's index.html and serves any
+    # other static asset under its actual path. The SPA doesn't use
+    # client-side deep links today; if it ever does we'll need a
+    # catchall that falls back to index.html for non-asset paths.
+    parent.mount(
+        "/",
+        StaticFiles(directory=str(static_path), html=True),
+        name="ui",
+    )
+    return parent
+
+
+# Module-level app for `uvicorn studio.api.serve:app` import strings.
+app = _make_app()

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,0 +1,82 @@
+"""Tests for the production-deployment wrapper (studio.api.serve).
+
+Verify that:
+  - When STUDIO_STATIC_DIR is unset, the bare API still serves at root.
+  - With a static_dir, the studio API moves under /api/* and the
+    static bundle's index.html is served at /.
+  - Missing static_dir raises FileNotFoundError cleanly.
+
+Build artefacts aren't available in CI, so we synthesise a tiny dist/
+in tmp_path with an index.html + an asset and confirm both are served.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from studio.api.app import create_app
+from studio.api.serve import create_serve_app
+
+
+@pytest.fixture
+def fake_dist(tmp_path: Path) -> Path:
+    """A bare-bones built bundle: index.html + a JS asset under /assets/."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<!doctype html>\n<title>studio</title>\n")
+    assets = dist / "assets"
+    assets.mkdir()
+    (assets / "index-fake.js").write_text("// fake bundle\n")
+    return dist
+
+
+def test_bare_api_still_works_at_root():
+    """The dev path (no static_dir) keeps API endpoints at root,
+    matching the existing test surface and the Vite proxy contract."""
+    client = TestClient(create_app())
+    r = client.get("/health")
+    assert r.status_code == 200
+
+
+def test_serve_wrapper_serves_index_html_at_root(fake_dist: Path):
+    client = TestClient(create_serve_app(fake_dist))
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "<title>studio</title>" in r.text
+
+
+def test_serve_wrapper_serves_static_assets(fake_dist: Path):
+    client = TestClient(create_serve_app(fake_dist))
+    r = client.get("/assets/index-fake.js")
+    assert r.status_code == 200
+    assert "fake bundle" in r.text
+
+
+def test_serve_wrapper_mounts_api_under_prefix(fake_dist: Path):
+    """Studio API endpoints land under /api/* once the wrapper is in
+    play -- that's the URL space the SPA's API_BASE = "/api" already
+    expects."""
+    client = TestClient(create_serve_app(fake_dist))
+    r = client.get("/api/health")
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+
+def test_serve_wrapper_root_does_not_leak_api_routes(fake_dist: Path):
+    """A request for /health (without /api) must not match the API --
+    it should fall through to StaticFiles and 404 (we don't have a
+    file by that name)."""
+    client = TestClient(create_serve_app(fake_dist))
+    r = client.get("/health")
+    # StaticFiles 404s for a non-existent path; the API isn't reachable
+    # at root anymore.
+    assert r.status_code == 404
+
+
+def test_serve_wrapper_rejects_missing_static_dir(tmp_path: Path):
+    nonexistent = tmp_path / "does-not-exist"
+    with pytest.raises(FileNotFoundError) as exc:
+        create_serve_app(nonexistent)
+    assert "does-not-exist" in str(exc.value)


### PR DESCRIPTION
Ships a self-hostable image and the publishing automation behind it. **Single-image is the default** (FastAPI serves API at `/api/*` + SPA at `/`); a two-service nginx compose recipe in `deploy/` is documented for users who want that.

## What ships

### Production-deployment wrapper
- **`studio/api/serve.py`** — `create_serve_app(static_dir)` returns a thin FastAPI parent that mounts the existing studio app under `/api` and `StaticFiles` at `/`. Module-level `app` reads `STUDIO_STATIC_DIR` and falls back to bare-API mode when unset, so existing tests stay green.
- **`studio/api/__main__.py`** — new `--static-dir` flag (defaults to env var). Picks `studio.api.serve:app` vs `studio.api.app:app` at uvicorn dispatch so reload-spawned workers see the same env.
- **`studio/api/app.py`** — `SessionStore` / `DesignStore` honour `SESSIONS_DIR` / `DESIGNS_DIR` env vars so the Docker image points them at `/data/sessions` and `/data/designs` without arg plumbing.

### Dockerfile (multi-stage)
- Stage 1 (`node:20-alpine`): `npm ci && npm run build` → `web/dist/`. Cached via separate dep / source layers.
- Stage 2 (`python:3.11-slim`): installs the studio package + system `tini` for signal handling, copies the SPA bundle from stage 1 to `/app/web-dist`, sets `STUDIO_STATIC_DIR` + `SESSIONS_DIR` + `DESIGNS_DIR`. `EXPOSE 8765`, `VOLUME /data`. Entry: `tini -- python -m studio.api ...`.
- `.dockerignore` keeps the build context lean (no `node_modules`, no `dist`, no `tests`, no caches).

### GitHub Actions (`docker.yml`)
- Triggers: push to main, `v*` tag push, PR (build-only). Multi-arch `linux/amd64` + `linux/arm64` so a Pi 4/5 pulls the same tag a homelab x86 box uses.
- Tag strategy via `docker/metadata-action`:
  - `main` push → `:main`, `:sha-<short>`
  - `v1.2.3` tag → `:v1.2.3`, `:1.2.3`, `:1.2`, `:latest`
- Push to `ghcr.io/<owner>/esphome-studio` using `GITHUB_TOKEN` (no external secrets). GHA cache (`type=gha`) for layer reuse.

### Two-service compose recipe (`deploy/`)
For users who want nginx in front. **Not the default** — the README's docker quickstart points at the single-image path; this is documented as the "production recipe" in `deploy/README.md`.
- `docker-compose.yml`: studio container in API-only mode (`STUDIO_STATIC_DIR=` empty) + nginx + one-shot copier that ships the SPA bundle out of the studio image into a shared named volume.
- `nginx.conf`: cache-immutable for `/assets/`, SSE-friendly `/api/` proxy (no buffering, long read timeout for build-log streaming), SPA fallback to `index.html`, light hardening.
- `deploy/README.md`: when to bother, tradeoff matrix vs single-image, persistence + secrets, update flow.

### README
New **Docker (single-image deployment)** subsection at the top of Quickstart:

```sh
docker run --rm -p 8765:8765 \
  -e ANTHROPIC_API_KEY=sk-ant-... \
  -v studio-data:/data \
  ghcr.io/moellere/esphome-studio:latest
```

## Tradeoff cheatsheet (mirrored from `deploy/README.md`)

| Concern | Single image (default) | Two-service compose |
|---|---|---|
| Containers | 1 | 2 + a one-shot copier |
| Static-file server | uvicorn + FastAPI `StaticFiles` | nginx 1.27 |
| API URL | `:8765/api/*` | `:8080/api/*` (proxied) |
| SPA URL | `:8765/` | `:8080/` |
| Persistence | `-v studio-data:/data` | `studio-data` named volume |
| When to use | hobbyists, homelab, single-user | multi-user, http/2 + brotli, scaling api workers |

## Tests

- **`tests/test_serve.py` (6)**: bare API still works at root (dev contract); wrapper serves `index.html` at `/`; assets at `/assets/`; API moves to `/api/*`; `/` does not leak the API; missing `static_dir` raises `FileNotFoundError` cleanly.

297 pytest (+6 serve), 125 vitest, ruff + tsc + vite build clean. The Dockerfile + GHA workflow can't run under pytest; the GHA workflow doubles as the integration check on every PR + merge.

## Test plan

- [ ] `python -m pytest`
- [ ] `python -m ruff check .`
- [ ] `cd web && npm run build && npx vitest run`
- [ ] First time: enable GitHub Packages on the repo (Settings → Actions → General → Workflow permissions: Read and write). After this PR merges, the workflow's first run on `main` populates `ghcr.io/moellere/esphome-studio:main` + `:sha-<short>`.
- [ ] After tagging a release (`git tag v0.9.0 && git push --tags`), confirm `:latest`, `:0.9.0`, `:0.9` all land.
- [ ] Smoke: `docker run --rm -p 8765:8765 ghcr.io/moellere/esphome-studio:main`, browse to `http://localhost:8765`, click around.

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_