### PR TITLE
P1 YAML correctness gate: every example round-trips through `esphome config`

### DIFF
--- a/.github/workflows/esphome-config.yml
+++ b/.github/workflows/esphome-config.yml
@@ -49,12 +49,14 @@ jobs:
           cache: pip
 
       - name: Install studio + ESPHome
-        # Pinned ESPHome minor (~=2025.5). Bump deliberately when a
-        # schema change in a newer minor matters; the README's
-        # "tested against" line should track this pin.
+        # Pinned to a specific ESPHome version (NOT a minor or year
+        # range -- ~=2025.5 was misleading, PEP 440 expands it to
+        # >=2025.5,<2026 which is effectively a year-pin). Bump
+        # deliberately; the README's "tested against" line must
+        # match this pin.
         run: |
           pip install -e .
-          pip install 'esphome~=2025.5'
+          pip install 'esphome==2025.12.7'
 
       - name: Print resolved ESPHome version
         run: esphome version

--- a/.github/workflows/esphome-config.yml
+++ b/.github/workflows/esphome-config.yml
@@ -1,0 +1,63 @@
+name: esphome-config
+
+# The integrity gate the studio's surface area depends on:
+#
+# For every example in examples/*.json, render the YAML through
+# studio.generate.yaml_gen and run upstream `esphome config <file>`
+# against it. Anything the studio emits has to round-trip through
+# ESPHome's own validator -- otherwise the artifact is by definition
+# wrong, regardless of what our golden tests say.
+#
+# Pinning rationale: ESPHome's schema changes between minor releases
+# (new platforms, deprecations, renamed keys). A schema-side change
+# shouldn't fail unrelated PRs, so we pin a known-good minor and bump
+# deliberately. The pinned version is also what we cite in the README
+# as "tested against".
+#
+# Triggers:
+#   - PR / push to main: gate the merge
+#   - schedule: catch ESPHome stable releases that newly accept or
+#     reject something we emit, without waiting for the next code
+#     change
+#   - workflow_dispatch: manual rerun
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 10 * * 1'   # 10:00 UTC every Monday
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: esphome-config-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  esphome-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install studio + ESPHome
+        # Pinned ESPHome minor (~=2025.5). Bump deliberately when a
+        # schema change in a newer minor matters; the README's
+        # "tested against" line should track this pin.
+        run: |
+          pip install -e .
+          pip install 'esphome~=2025.5'
+
+      - name: Print resolved ESPHome version
+        run: esphome version
+
+      - name: Validate every example through `esphome config`
+        run: python scripts/check_examples.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ at all:
 
 Every PR runs `.github/workflows/esphome-config.yml`, which:
 
-1. Installs the pinned ESPHome (currently `~=2025.5`).
+1. Installs the pinned ESPHome (currently `==2025.12.7`).
 2. For every `examples/*.json`, renders YAML through
    `studio.generate.yaml_gen` and runs `esphome config <file>` against
    it.
@@ -41,11 +41,17 @@ gate.** It's the gate the project can be judged by from the outside.
 
 ```sh
 pip install -e .[dev]
-pip install 'esphome~=2025.5'
+pip install 'esphome==2025.12.7'
 python scripts/check_examples.py            # all examples
 python scripts/check_examples.py garage-motion oled    # just these two
 python scripts/check_examples.py --keep     # leave generated YAML on disk
 ```
+
+On Debian/Ubuntu hosts the system `python3-setuptools` ships patched in a
+way that breaks ESPHome's pinned `paho-mqtt` source build. If `pip install
+esphome` fails on the `paho-mqtt` wheel, drop into a fresh venv first:
+`python -m venv .venv && source .venv/bin/activate`. The CI workflow uses
+`actions/setup-python@v5`, which sidesteps this.
 
 ### Adding a new component or board
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,128 @@
+# Contributing to esphome-studio
+
+This file is the working bar for changes that touch the studio's
+output. Conventions for prose, comments, and architecture live in
+[`CLAUDE.md`](CLAUDE.md); this file is the *substantive* bar — what
+"working" means for the things the studio produces.
+
+## Priorities
+
+Roughly ordered by how much they decide whether the studio is useful
+at all:
+
+1. **YAML production correctness.** Whatever the studio emits has to
+   round-trip through upstream `esphome config`. This is the
+   non-negotiable bar.
+2. **Wiring schema correctness.** Generated schematics (SKiDL → KiCad)
+   open in KiCad and the nets are right. Pin solver picks legal pins.
+   Compatibility checker catches the issues it claims to (boot strap,
+   ADC2/WiFi, voltage, locked-pin).
+3. **Enclosure suggestions.** Parametric `.scad` printable + search
+   relay returns relevant community models. Lower bar than (1) and (2)
+   — a wrong enclosure is a 3D-print iteration, not a bricked device.
+4. **PCB layout.** Deferred to 1.0+. Don't add surface area here until
+   the three above are tight.
+
+## The YAML gate
+
+Every PR runs `.github/workflows/esphome-config.yml`, which:
+
+1. Installs the pinned ESPHome (currently `~=2025.5`).
+2. For every `examples/*.json`, renders YAML through
+   `studio.generate.yaml_gen` and runs `esphome config <file>` against
+   it.
+3. Fails the merge if any example doesn't validate.
+
+This is the canonical proof that the studio's output is real, not
+plausible-looking text. **Do not merge a change that breaks this
+gate.** It's the gate the project can be judged by from the outside.
+
+### Running the gate locally
+
+```sh
+pip install -e .[dev]
+pip install 'esphome~=2025.5'
+python scripts/check_examples.py            # all examples
+python scripts/check_examples.py garage-motion oled    # just these two
+python scripts/check_examples.py --keep     # leave generated YAML on disk
+```
+
+### Adding a new component or board
+
+1. Add the `library/components/<id>.yaml` (or `library/boards/<id>.yaml`)
+   entry.
+2. Add or update at least one `examples/*.json` that exercises it.
+3. Add the matching golden under `tests/golden/`.
+4. Run `python scripts/check_examples.py` locally. Fix anything that
+   fails before opening a PR.
+5. The CI gate is the bar — your component is "supported" only when
+   an example using it round-trips through `esphome config`. If the
+   component doesn't have an example yet, it isn't supported, even
+   if the YAML template "looks right."
+
+### When the gate fails
+
+Read the tail output the script prints. Common causes:
+
+- **Schema rejection.** ESPHome added/renamed a key between releases.
+  Either fix the template to emit the new shape, or pin to the
+  prior minor and document the constraint.
+- **Missing required key.** ESPHome enforces required keys per
+  platform (e.g., `address` on `bme280_i2c`). Surface it in the
+  component's `params_schema` so the design-time form catches it.
+- **Wrong pin format.** ESPHome accepts `GPIO13` or `13` for ESP32
+  but the expander-pin block has different requirements. The
+  `_pins_for` helper in `studio/generate/yaml_gen.py` is the right
+  place to extend.
+- **Stub secrets rejected.** `esphome config` validates the api
+  encryption key as base64. The script already writes a 32-byte
+  zero-base64 stub; if a new component introduces a new `!secret`
+  reference, extend `_stub_value` in `scripts/check_examples.py`.
+
+### Bumping the pinned ESPHome
+
+The pin is in two places: `.github/workflows/esphome-config.yml`
+(the version we test against) and `README.md` (the version we
+advertise). Bump both in the same diff. The bump PR's burden of
+proof is "the gate passes against the new version" — not "the new
+version is fashionable."
+
+## The schematic gate (lighter)
+
+`tests/test_kicad.py` runs the SKiDL emitter against bundled examples
+and checks the output is well-formed Python plus the expected nets.
+It does **not** run KiCad to validate. The honest bar for "schematic
+works" is: open the generated `.kicad_sch` in KiCad and verify the
+nets visually. Add one such check per new component class.
+
+## Tests
+
+```sh
+python -m pytest          # ~297 cases, ~10s
+python -m ruff check .    # lint
+cd web && npx vitest run  # ~125 cases (vitest + jsdom)
+```
+
+Goldens in `tests/golden/` are pinned. When the generator output
+legitimately changes, regenerate them in the same PR as the code
+change:
+
+```sh
+for f in examples/*.json; do
+    name=$(basename "$f" .json)
+    python -m studio.generate "$f" \
+        --out-yaml "tests/golden/${name}.yaml" \
+        --out-ascii "tests/golden/${name}.txt"
+done
+```
+
+## Quick checklist before opening a PR
+
+- [ ] `python -m pytest` passes.
+- [ ] `python -m ruff check .` passes.
+- [ ] `python scripts/check_examples.py` passes against the pinned
+      ESPHome.
+- [ ] If you added or changed a library entry, an example uses it.
+- [ ] If a golden changed, the regenerated golden is in the same diff.
+- [ ] If you bumped the ESPHome pin, README's "tested against" line
+      moved with it.

--- a/README.md
+++ b/README.md
@@ -9,17 +9,36 @@ which handles compile + OTA deploy.
 
 ## Status
 
-`v0.9.0` — first tagged release. End-to-end pipeline from
-`design.json` through ESPHome YAML + fleet push + parametric
-enclosure + KiCad schematic. Ships as a single Docker image you can
-self-host (`ghcr.io/moellere/esphome-studio`). Three-pane web UI
-covers manual editing; a Claude tool-using agent drives the design
-via natural language; a CSP solver auto-assigns pins; a port-
-compatibility checker catches boot-strap, ADC2/WiFi, voltage, and
-locked-pin issues before YAML render.
+`v0.9.0` — first tagged release. The studio has wide surface area
+(YAML, schematic, enclosure, agent, fleet handoff, web UI) and a
+narrow set of things actually verified against upstream tools. This
+section is honest about which is which, ordered by how much it
+matters that it works.
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the long form per release and
-[`START.md`](START.md) for design notes / future scope.
+Tiers, in priority order:
+
+| Tier | Area | What it does | Verified by |
+|---|---|---|---|
+| **Verified** | ESPHome YAML production | render `design.json` → ESPHome YAML | `esphome config` passes on every bundled example, every PR ([gate](.github/workflows/esphome-config.yml)) |
+| **Verified** | CSP pin solver + compat checker | assign legal pins, surface boot-strap / ADC2-WiFi / voltage / locked-pin issues | unit tests + property checks in `tests/test_pin_solver.py` + `tests/test_compatibility.py` |
+| **Verified** | Fleet handoff | push YAML to `distributed-esphome` ha-addon, optional compile + log relay | round-trip tests in `tests/test_fleet.py` |
+| **Works (lighter checks)** | KiCad schematic | emit a SKiDL Python script the user runs locally | unit tests assert the script is well-formed Python with expected nets; **not** verified by opening in KiCad |
+| **Works (lighter checks)** | Parametric enclosure | OpenSCAD `.scad` from board mount-hole metadata | unit tests + manual-print iteration; not verified by an OpenSCAD parser in CI |
+| **Experimental** | Thingiverse search relay | rank community models for a board | smoke-tested; depends on a third-party search API that ranks unevenly |
+| **Experimental** | Agent (Claude tool-using) | natural-language design driving | works in practice; tool surface is small; no auto-eval against task list yet |
+| **Deferred** | KiCad PCB layout | Freerouting + Gerber + JLCPCB CPL/BOM | 1.0+, not started |
+
+The **Verified** tier is the bar the project is asking to be judged
+on. Everything else is offered with the caveat that's spelled out in
+the table.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the bar a change has to
+clear before merging, [`CHANGELOG.md`](CHANGELOG.md) for per-release
+deltas, and [`START.md`](START.md) for the longer-form design notes.
+
+Tested against ESPHome **`~=2025.5`** (pinned in
+`.github/workflows/esphome-config.yml` + bumped deliberately). When
+that pin moves, this line moves with it.
 
 ## What it does
 
@@ -366,18 +385,29 @@ tests/                   pytest + golden artifacts; vitest tests under web/src
 deploy/                  k8s.yaml, docker-compose.yml, nginx.conf for self-hosting
 Dockerfile               multi-stage build for the published GHCR image
 .github/workflows/       GHA workflow that publishes ghcr.io/.../esphome-studio
+scripts/                 dev helpers (currently: examples → `esphome config` gate)
 CHANGELOG.md             per-release feature deltas
 START.md                 vision, decisions, phase plan
 CLAUDE.md                working conventions for both Claude and humans
+CONTRIBUTING.md          substantive bar a change has to clear (the YAML gate, etc.)
 ```
 
 ## Tests
 
 ```sh
-python -m pytest          # ~297 cases, ~10s
-python -m ruff check .    # lint
-cd web && npx vitest run  # ~125 cases, ~5s (vitest + jsdom)
+python -m pytest                          # ~297 cases, ~10s
+python -m ruff check .                    # lint
+cd web && npx vitest run                  # ~125 cases, ~5s (vitest + jsdom)
+pip install 'esphome~=2025.5'
+python scripts/check_examples.py          # the YAML gate -- every example through `esphome config`
 ```
+
+The `esphome config` gate is the headline test: it renders every
+bundled example through the studio and runs upstream ESPHome's own
+validator against the output. Anything the studio emits has to
+round-trip through that gate, and the GitHub Actions workflow
+([`.github/workflows/esphome-config.yml`](.github/workflows/esphome-config.yml))
+runs it on every PR.
 
 Golden tests pin the generator output for every bundled example.
 Regenerate goldens with the CLI when output legitimately changes;
@@ -388,35 +418,62 @@ PinoutView, PushToFleetDialog, SchematicDialog) via React Testing
 Library + jsdom; network surfaces are mocked at the api/client
 boundary so the suite stays offline.
 
-The GitHub Actions workflow runs the full suite + multi-arch image
-build on every PR + merge to main.
+The GitHub Actions workflow runs the YAML gate + the full suite +
+multi-arch image build on every PR + merge to main.
 
-## Roadmap (compressed)
+## Roadmap
 
-- **0.1** ✅ pipeline + library scaffolding
-- **0.2** ✅ HTTP API (FastAPI) — same generators, exposed over JSON
-- **0.3** ✅ Studio web UI v1 — three-pane shell + form-based editing
-- **0.4** ✅ USB device bootstrap (WebSerial + esptool-js)
-- **0.5** ✅ Agent layer (Claude tool-using; sessions in `sessions/<id>.jsonl`)
-- **0.5+** ✅ streaming agent responses + recommendation mode
-- **0.6** ✅ CSP solver — auto-assign unbound pins, detect conflicts + budget overruns; port-compatibility validation (boot straps, serial pins, input-only, A0 voltage cap, ADC2/WiFi conflict, locked-pin invariants)
-- **0.6+** ✅ server-side design persistence + **New design** dialog, capability-driven **Add by function** picker, pin-lock UI, bus editor (rename propagation + inline compat), drag-and-drop pinout, strict-mode toggle
-- **0.7** ✅ distributed-esphome handoff — push device + YAML to ha-addon, optional compile, build-log polling + SSE streaming, strict-only push gate
-- **0.8** ✅ Enclosure suggestions — parametric OpenSCAD generator + Thingiverse search relay
-- **0.9** ✅ KiCad schematic export — SKiDL Python emitter; 100% library `kicad:` mapping
-- **Deployment** ✅ Docker single-image (multi-arch GHCR) + Kubernetes manifest + nginx compose recipe
-- **1.0** KiCad PCB layout — Freerouting + Gerber + JLCPCB CPL/BOM export
-- **Future** multi-writer state backend (HA replicas)
+Reorganised by priority — what's worth working on next, ordered by
+how much it raises the floor on whether the studio is actually
+useful. The previous "ship more surface area" roadmap is preserved
+in [`CHANGELOG.md`](CHANGELOG.md) (per-release deltas) and
+[`START.md`](START.md) (decisions + phase scope).
 
-Full plan with decisions, schemas, and per-phase scope lives in
-[`START.md`](START.md). Per-release feature deltas live in
-[`CHANGELOG.md`](CHANGELOG.md).
+**Priority 1 — YAML production correctness.** *Active.* The single
+non-negotiable bar: every artifact the studio emits round-trips
+through upstream `esphome config`. Done so far: `esphome config` CI
+gate over every bundled example; pinned ESPHome version called out
+in this README + workflow; CONTRIBUTING.md establishes the gate as
+the merge bar. Next: real `esphome compile` smoke for one example;
+component-coverage matrix (which components have an example that
+validates) so additions are forced through the gate.
+
+**Priority 2 — Wiring schema correctness.** *Verified-light.* SKiDL
+emitter + 100% library `kicad:` coverage shipped. Honest gap: the
+output is unit-tested as Python text, not opened in KiCad. Next:
+container-side KiCad CLI in CI to actually open + render the
+generated schematic; pin-solver property tests on randomized
+designs; compatibility-checker fuzzing.
+
+**Priority 3 — Enclosures.** *Lower priority.* Parametric OpenSCAD
+generator + Thingiverse search relay shipped. Open question: keep
+investing here, or outsource to e.g.
+[YAPP_Box](https://github.com/mrWheel/YAPP_Box) and integrate
+instead of reimplementing? Decision deferred until P1 + P2 are
+tighter.
+
+**Priority 4 — PCB layout.** *Deferred to 1.0+.* No work in flight;
+not adding surface here until P1 is rock solid.
+
+**Plumbing — already shipped.** API (`0.2`), web UI (`0.3` +
+`0.6+`), USB bootstrap (`0.4`), agent (`0.5` + streaming), CSP
+solver (`0.6`), fleet handoff (`0.7`), enclosure (`0.8`), KiCad
+schematic (`0.9`), Docker single-image deploy + K8s manifest. See
+[`CHANGELOG.md`](CHANGELOG.md) for the per-release feature deltas.
+
+**Future** — multi-writer state backend so the studio can run as a
+HA replica; agent eval harness against a task list; ESPHome version
+matrix in CI (last 2 stables) so we can call out which components
+work where.
 
 ## Contributing
 
-See [`CLAUDE.md`](CLAUDE.md) for working conventions (concise prose, no
-emojis in code/commits, no premature abstraction, default-to-no-comments,
-boundary-only validation).
+[`CONTRIBUTING.md`](CONTRIBUTING.md) is the substantive bar — what
+"working" means for the artifacts the studio produces, including
+the `esphome config` gate every PR has to clear. [`CLAUDE.md`](CLAUDE.md)
+covers the prose / commit / comment conventions (concise, no emojis,
+default-to-no-comments, boundary-only validation, no premature
+abstraction).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the bar a change has to
 clear before merging, [`CHANGELOG.md`](CHANGELOG.md) for per-release
 deltas, and [`START.md`](START.md) for the longer-form design notes.
 
-Tested against ESPHome **`~=2025.5`** (pinned in
+Tested against ESPHome **`==2025.12.7`** (pinned in
 `.github/workflows/esphome-config.yml` + bumped deliberately). When
 that pin moves, this line moves with it.
 
@@ -236,7 +236,7 @@ it without a proxy.
 | [`distance-sensor.json`](examples/distance-sensor.json) | NodeMCU v2 | HC-SR04 ultrasonic + WS2812B NeoPixel; LED color tracks distance |
 | [`securitypanel.json`](examples/securitypanel.json) | WeMos D1 Mini | 12 door/window/motion sensors via MCP23017 expander, RTTTL piezo, GPIO siren |
 | [`rc522.json`](examples/rc522.json) | WeMos D1 Mini | MFRC522 RFID reader (SPI), NeoPixel status LED, RTTTL piezo, manual button |
-| [`esp32-audio.json`](examples/esp32-audio.json) | NodeMCU-32S | I2S audio (MAX98357A DAC) + ST7789V SPI dashboard display, ESP-IDF framework |
+| [`esp32-audio.json`](examples/esp32-audio.json) | NodeMCU-32S | I2S audio (MAX98357A DAC) + ST7789V SPI dashboard display, Arduino framework |
 | [`bluesonoff.json`](examples/bluesonoff.json) | ESP-01S 1MB | Sonoff Basic relay; front button (boot strap pin) toggles a single GPIO relay |
 | [`wemosgps.json`](examples/wemosgps.json) | WeMos D1 Mini | UART GPS module — lat/lon/altitude/speed/satellites + runtime baud-rate selector |
 | [`ttgo-lora32.json`](examples/ttgo-lora32.json) | TTGO LoRa32 V1 | ESP32 + onboard SX1276 LoRa radio + onboard SSD1306 OLED + battery ADC, ESP-IDF |
@@ -398,7 +398,7 @@ CONTRIBUTING.md          substantive bar a change has to clear (the YAML gate, e
 python -m pytest                          # ~297 cases, ~10s
 python -m ruff check .                    # lint
 cd web && npx vitest run                  # ~125 cases, ~5s (vitest + jsdom)
-pip install 'esphome~=2025.5'
+pip install 'esphome==2025.12.7'
 python scripts/check_examples.py          # the YAML gate -- every example through `esphome config`
 ```
 

--- a/examples/esp32-audio.json
+++ b/examples/esp32-audio.json
@@ -2,14 +2,14 @@
   "schema_version": "0.1",
   "id": "esp32-audio",
   "name": "Garage I2S audio + ST7789 dashboard",
-  "description": "ESP32 NodeMCU-32S, ESP-IDF framework. MAX98357A I2S DAC drives a Class-D speaker; ST7789V SPI display shows a clock + status. Hardware mute and backlight switches.",
+  "description": "ESP32 NodeMCU-32S, Arduino framework. MAX98357A I2S DAC drives a Class-D speaker; ST7789V SPI display shows a clock + status. Hardware mute and backlight switches.",
   "created_at": "2022-09-01T00:00:00Z",
-  "updated_at": "2026-05-04T00:00:00Z",
+  "updated_at": "2026-05-05T00:00:00Z",
 
   "board": {
     "library_id": "nodemcu-32s",
     "mcu": "esp32",
-    "framework": "esp-idf"
+    "framework": "arduino"
   },
 
   "power": {
@@ -23,7 +23,7 @@
     { "id": "r1", "kind": "capability", "text": "act as a media_player streaming I2S audio to an external Class-D amp" },
     { "id": "r2", "kind": "capability", "text": "render a clock + status on a 240x320 ST7789 dashboard" },
     { "id": "r3", "kind": "capability", "text": "physical mute switch + backlight switch" },
-    { "id": "r4", "kind": "constraint",  "text": "ESP-IDF framework (some I2S features need it)" }
+    { "id": "r4", "kind": "constraint",  "text": "Arduino framework (max98357a media_player is arduino-only in upstream ESPHome; revisit when esp-idf adds the platform)" }
   ],
 
   "components": [

--- a/examples/esp32-audio.json
+++ b/examples/esp32-audio.json
@@ -106,9 +106,9 @@
       { "id": "my_gray",   "red": "50%",  "green": "50%",  "blue": "50%"  }
     ],
     "font": [
-      { "file": "common/fonts/arial.ttf", "id": "arial_48", "size": 48 },
-      { "file": "common/fonts/arial.ttf", "id": "arial_24", "size": 24 },
-      { "file": "common/fonts/arial.ttf", "id": "arial_12", "size": 12 }
+      { "file": "gfonts://Roboto", "id": "arial_48", "size": 48 },
+      { "file": "gfonts://Roboto", "id": "arial_24", "size": 24 },
+      { "file": "gfonts://Roboto", "id": "arial_12", "size": 12 }
     ]
   },
 

--- a/examples/oled.json
+++ b/examples/oled.json
@@ -67,7 +67,7 @@
       { "platform": "homeassistant", "id": "time1" }
     ],
     "font": [
-      { "file": "common/fonts/arial.ttf", "id": "font1", "size": 10 }
+      { "file": "gfonts://Roboto", "id": "font1", "size": 10 }
     ],
     "sensor": [
       { "platform": "uptime",      "name": "oled System Uptime" },

--- a/library/components/mcp23008.yaml
+++ b/library/components/mcp23008.yaml
@@ -24,6 +24,11 @@ electrical:
 
 esphome:
   required_components: [i2c]
+  # ESPHome 2024+ unifies the 8- and 16-bit MCP variants under a single
+  # `mcp23xxx:` discriminator key on downstream pin blocks. Without this,
+  # the generator would emit `pin: { mcp23008: <id>, ... }`, which
+  # `esphome config` rejects.
+  expander_pin_key: mcp23xxx
   yaml_template: |
     mcp23008:
       - id: {{ id }}
@@ -36,7 +41,7 @@ params_schema:
     enum: ["0x20", "0x21", "0x22", "0x23", "0x24", "0x25", "0x26", "0x27"]
     default: "0x20"
 
-notes: "Per-pin direction/mode is configured by the downstream gpio platforms (binary_sensor, switch, output) that reference this hub via `mcp23008: <id>` in their pin block."
+notes: "Per-pin direction/mode is configured by the downstream gpio platforms (binary_sensor, switch, output) that reference this hub via `mcp23xxx: <id>` in their pin block."
 # KiCad symbol mapping (0.9 schematic export).
 kicad:
   symbol_lib: Interface_Expansion

--- a/library/components/mcp23017.yaml
+++ b/library/components/mcp23017.yaml
@@ -24,6 +24,11 @@ electrical:
 
 esphome:
   required_components: [i2c]
+  # ESPHome 2024+ unifies the 8- and 16-bit MCP variants under a single
+  # `mcp23xxx:` discriminator key on downstream pin blocks. Without this,
+  # the generator would emit `pin: { mcp23017: <id>, ... }`, which
+  # `esphome config` rejects.
+  expander_pin_key: mcp23xxx
   yaml_template: |
     mcp23017:
       - id: {{ id }}

--- a/scripts/check_examples.py
+++ b/scripts/check_examples.py
@@ -1,0 +1,152 @@
+"""Verify every bundled example renders YAML that upstream ESPHome accepts.
+
+Walks examples/*.json, renders each through studio.generate.yaml_gen, writes a
+sibling secrets.yaml stub for any !secret references, then invokes
+`esphome config <yaml>` and reports the result.
+
+Run locally:
+    pip install -e .[dev]
+    pip install esphome
+    python scripts/check_examples.py
+
+Run for one example:
+    python scripts/check_examples.py garage-motion
+
+Exit code 0 = every example passed, 1 = at least one failed. CI consumes the
+exit code as the merge gate.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from studio.generate.yaml_gen import render_yaml
+from studio.library import default_library
+from studio.model import Design
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples"
+
+# Valid 32-byte base64 string -- ESPHome's api.encryption.key validator rejects
+# anything else, even though the value is never used to encrypt traffic during
+# `esphome config`.
+STUB_API_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+_SECRET_RE = re.compile(r"!secret\s+([A-Za-z0-9_]+)")
+
+
+def _stub_value(name: str) -> str:
+    if name.endswith("api_key") or name == "api_key":
+        return STUB_API_KEY
+    if name == "wifi_ssid":
+        return "stub-ssid"
+    if name == "wifi_password":
+        return "stub-password-1234"
+    if name == "ota_password":
+        return "stub-ota-password"
+    return f"stub-{name}"
+
+
+def _write_secrets(yaml_text: str, dest: Path) -> None:
+    names = sorted(set(_SECRET_RE.findall(yaml_text)))
+    lines = [f"{n}: {json.dumps(_stub_value(n))}" for n in names]
+    dest.write_text("\n".join(lines) + ("\n" if lines else ""))
+
+
+def _check_one(example: Path, workdir: Path) -> tuple[bool, str]:
+    library = default_library()
+    design_dict = json.loads(example.read_text())
+    design = Design.model_validate(design_dict)
+    yaml_text = render_yaml(design, library)
+
+    out_dir = workdir / example.stem
+    out_dir.mkdir(parents=True, exist_ok=True)
+    yaml_path = out_dir / f"{example.stem}.yaml"
+    yaml_path.write_text(yaml_text)
+    _write_secrets(yaml_text, out_dir / "secrets.yaml")
+
+    try:
+        result = subprocess.run(
+            ["esphome", "config", str(yaml_path)],
+            capture_output=True,
+            text=True,
+            cwd=out_dir,
+        )
+    except FileNotFoundError:
+        print(
+            "esphome CLI not found. Install with: pip install 'esphome~=2025.5'",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if result.returncode == 0:
+        return True, ""
+    tail = (result.stdout + result.stderr).strip().splitlines()[-40:]
+    return False, "\n".join(tail)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "names",
+        nargs="*",
+        help="example stems to check (default: all in examples/)",
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="leave the generated YAML + secrets.yaml on disk for inspection",
+    )
+    args = parser.parse_args(argv)
+
+    if args.names:
+        examples = [EXAMPLES_DIR / f"{n}.json" for n in args.names]
+        missing = [p for p in examples if not p.exists()]
+        if missing:
+            print(f"unknown example(s): {[p.stem for p in missing]}", file=sys.stderr)
+            return 2
+    else:
+        examples = sorted(EXAMPLES_DIR.glob("*.json"))
+
+    if not examples:
+        print("no examples found", file=sys.stderr)
+        return 2
+
+    workdir_ctx = (
+        tempfile.TemporaryDirectory()
+        if not args.keep
+        else None
+    )
+    workdir = Path(workdir_ctx.name) if workdir_ctx else REPO_ROOT / "build" / "esphome-config"
+    if args.keep:
+        workdir.mkdir(parents=True, exist_ok=True)
+
+    failures: list[tuple[str, str]] = []
+    for example in examples:
+        ok, detail = _check_one(example, workdir)
+        marker = "PASS" if ok else "FAIL"
+        print(f"  {marker}  {example.stem}")
+        if not ok:
+            failures.append((example.stem, detail))
+
+    if workdir_ctx is not None:
+        workdir_ctx.cleanup()
+
+    print()
+    if failures:
+        print(f"{len(failures)} of {len(examples)} examples failed:")
+        for name, detail in failures:
+            print(f"\n--- {name} ---")
+            print(detail)
+        return 1
+
+    print(f"all {len(examples)} examples validate under upstream ESPHome.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_examples.py
+++ b/scripts/check_examples.py
@@ -79,7 +79,7 @@ def _check_one(example: Path, workdir: Path) -> tuple[bool, str]:
         )
     except FileNotFoundError:
         print(
-            "esphome CLI not found. Install with: pip install 'esphome~=2025.5'",
+            "esphome CLI not found. Install with: pip install 'esphome==2025.12.7'",
             file=sys.stderr,
         )
         sys.exit(2)

--- a/studio/generate/yaml_gen.py
+++ b/studio/generate/yaml_gen.py
@@ -66,12 +66,13 @@ def _parent_for(component_id: str, design: Design) -> dict[str, Any] | None:
     return None
 
 
-def _pins_for(component_id: str, design: Design) -> dict[str, Any]:
+def _pins_for(component_id: str, design: Design, library: Library) -> dict[str, Any]:
     """Return a dict of pin_role -> pin spec.
 
     For native GPIO connections, the value is the bare pin string (e.g. "GPIO13").
     For expander_pin connections, the value is the dict ESPHome expects under
-    `pin:` -- with the expander's library_id as the discriminator key.
+    `pin:` -- discriminated by the expander's `esphome.expander_pin_key` if set
+    (mcp23008/mcp23017 both use `mcp23xxx`), falling back to library_id otherwise.
     """
     pins: dict[str, Any] = {}
     by_id = {c.id: c for c in design.components}
@@ -87,7 +88,9 @@ def _pins_for(component_id: str, design: Design) -> dict[str, Any]:
                 raise ValueError(
                     f"connection {component_id}.{c.pin_role} references unknown expander '{t.expander_id}'"
                 )
-            block: dict[str, Any] = {expander.library_id: t.expander_id, "number": t.number}
+            lib_expander = library.component(expander.library_id)
+            key = lib_expander.esphome.expander_pin_key or expander.library_id
+            block: dict[str, Any] = {key: t.expander_id, "number": t.number}
             if t.mode:
                 block["mode"] = t.mode
             if t.inverted:
@@ -118,7 +121,7 @@ def _render_component(comp: Component, design: Design, library: Library) -> dict
         "id": comp.id,
         "label": comp.label,
         "params": dict(comp.params),
-        "pins": _pins_for(comp.id, design),
+        "pins": _pins_for(comp.id, design, library),
         "bus": bus.model_dump() if bus else None,
         "parent": parent,
     }

--- a/studio/library.py
+++ b/studio/library.py
@@ -49,6 +49,7 @@ class Electrical(_Strict):
 class EsphomeSpec(_Strict):
     required_components: list[str] = Field(default_factory=list)
     yaml_template: str = ""
+    expander_pin_key: Optional[str] = None
 
 
 class LibraryComponent(_Strict):

--- a/tests/golden/awning-control.yaml
+++ b/tests/golden/awning-control.yaml
@@ -23,7 +23,7 @@ mcp23008:
 binary_sensor:
 - platform: gpio
   pin:
-    mcp23008: mcp23008_hub
+    mcp23xxx: mcp23008_hub
     number: 0
     mode: INPUT_PULLUP
     inverted: true
@@ -32,7 +32,7 @@ binary_sensor:
   device_class: opening
 - platform: gpio
   pin:
-    mcp23008: mcp23008_hub
+    mcp23xxx: mcp23008_hub
     number: 1
     mode: INPUT_PULLUP
     inverted: true
@@ -41,7 +41,7 @@ binary_sensor:
   device_class: opening
 - platform: gpio
   pin:
-    mcp23008: mcp23008_hub
+    mcp23xxx: mcp23008_hub
     number: 2
     mode: INPUT_PULLUP
     inverted: true
@@ -60,7 +60,7 @@ binary_sensor:
   - cover.stop: awning_cover
 - platform: gpio
   pin:
-    mcp23008: mcp23008_hub
+    mcp23xxx: mcp23008_hub
     number: 3
     mode: INPUT_PULLUP
     inverted: true
@@ -80,7 +80,7 @@ binary_sensor:
 switch:
 - platform: gpio
   pin:
-    mcp23008: mcp23008_hub
+    mcp23xxx: mcp23008_hub
     number: 7
     mode: OUTPUT
     inverted: true
@@ -89,7 +89,7 @@ switch:
   icon: mdi:power-plug
 - platform: gpio
   pin:
-    mcp23008: mcp23008_hub
+    mcp23xxx: mcp23008_hub
     number: 6
     mode: OUTPUT
   name: Motor Enable

--- a/tests/golden/esp32-audio.yaml
+++ b/tests/golden/esp32-audio.yaml
@@ -93,12 +93,12 @@ color:
   green: 50%
   blue: 50%
 font:
-- file: common/fonts/arial.ttf
+- file: gfonts://Roboto
   id: arial_48
   size: 48
-- file: common/fonts/arial.ttf
+- file: gfonts://Roboto
   id: arial_24
   size: 24
-- file: common/fonts/arial.ttf
+- file: gfonts://Roboto
   id: arial_12
   size: 12

--- a/tests/golden/esp32-audio.yaml
+++ b/tests/golden/esp32-audio.yaml
@@ -3,7 +3,7 @@ esphome:
 esp32:
   board: nodemcu-32s
   framework:
-    type: esp-idf
+    type: arduino
 logger: {}
 api:
   encryption:

--- a/tests/golden/oled.yaml
+++ b/tests/golden/oled.yaml
@@ -32,7 +32,7 @@ time:
 - platform: homeassistant
   id: time1
 font:
-- file: common/fonts/arial.ttf
+- file: gfonts://Roboto
   id: font1
   size: 10
 sensor:

--- a/tests/golden/securitypanel.yaml
+++ b/tests/golden/securitypanel.yaml
@@ -37,7 +37,7 @@ mcp23017:
 binary_sensor:
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 4
     mode: INPUT
     inverted: true
@@ -48,7 +48,7 @@ binary_sensor:
   - rtttl.play: short:d=4,o=5,b=100:16e6,16e6
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 5
     mode: INPUT
     inverted: true
@@ -59,7 +59,7 @@ binary_sensor:
   - rtttl.play: short:d=4,o=5,b=100:16e6,16e6
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 6
     mode: INPUT
     inverted: true
@@ -70,7 +70,7 @@ binary_sensor:
   - rtttl.play: short:d=4,o=5,b=100:16e6,16e6
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 7
     mode: INPUT
     inverted: true
@@ -80,7 +80,7 @@ binary_sensor:
   - rtttl.play: short:d=4,o=5,b=100:16e6,16e6
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 8
     mode: INPUT
     inverted: true
@@ -91,7 +91,7 @@ binary_sensor:
   - rtttl.play: short:d=4,o=5,b=100:16e6,16e6
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 9
     mode: INPUT
     inverted: true
@@ -102,7 +102,7 @@ binary_sensor:
   - rtttl.play: short:d=4,o=5,b=100:16e6,16e6
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 10
     mode: INPUT
     inverted: true
@@ -111,7 +111,7 @@ binary_sensor:
   device_class: motion
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 11
     mode: INPUT
     inverted: true
@@ -122,7 +122,7 @@ binary_sensor:
   - rtttl.play: short:d=4,o=5,b=100:16e6,16e6
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 12
     mode: INPUT
     inverted: true
@@ -133,7 +133,7 @@ binary_sensor:
   - rtttl.play: short:d=4,o=5,b=100:16e6,16e6
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 13
     mode: INPUT
     inverted: true
@@ -144,7 +144,7 @@ binary_sensor:
   - rtttl.play: short:d=4,o=5,b=100:16e6,16e6
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 14
     mode: INPUT
     inverted: true
@@ -154,7 +154,7 @@ binary_sensor:
   - rtttl.play: short:d=4,o=5,b=100:16e6,16e6
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 15
     mode: INPUT
     inverted: true
@@ -165,7 +165,7 @@ binary_sensor:
 switch:
 - platform: gpio
   pin:
-    mcp23017: mcp_hub
+    mcp23xxx: mcp_hub
     number: 3
     mode: OUTPUT
     inverted: true

--- a/tests/test_yaml_gen.py
+++ b/tests/test_yaml_gen.py
@@ -145,20 +145,24 @@ def test_securitypanel_matches_golden(securitypanel_design, library, golden_dir)
 def test_securitypanel_expander_pins_render(securitypanel_design, library):
     parsed = yaml.unsafe_load(render_yaml(securitypanel_design, library))
     sensors = parsed["binary_sensor"]
-    # All 12 sensors should be on the mcp23017 hub.
+    # All 12 sensors should be on the mcp_hub via the unified mcp23xxx key.
     assert len(sensors) == 12
     for s in sensors:
-        assert "mcp23017" in s["pin"]
-        assert s["pin"]["mcp23017"] == "mcp_hub"
+        assert "mcp23xxx" in s["pin"]
+        assert s["pin"]["mcp23xxx"] == "mcp_hub"
         assert s["pin"]["mode"] == "INPUT"
         assert s["pin"]["inverted"] is True
         assert isinstance(s["pin"]["number"], int)
 
 
-def test_securitypanel_expander_uses_library_id_as_pin_key(securitypanel_design, library):
+def test_securitypanel_expander_uses_unified_mcp23xxx_pin_key(securitypanel_design, library):
+    # ESPHome 2024+ accepts only `mcp23xxx:` as the pin discriminator on
+    # downstream platforms, regardless of whether the hub is a mcp23008
+    # (8-bit) or mcp23017 (16-bit). The pre-fix studio emitted
+    # `mcp23017:` here, which `esphome config` rejected.
     text = render_yaml(securitypanel_design, library)
-    assert "mcp23017: mcp_hub" in text
-    assert "mcp23xxx" not in text
+    assert "mcp23xxx: mcp_hub" in text
+    assert "mcp23017: mcp_hub" not in text
 
 
 def test_rc522_matches_golden(rc522_design, library, golden_dir):
@@ -189,9 +193,14 @@ def test_esp32_audio_i2s_bus_emits_singleton(esp32_audio_design, library):
     assert parsed["media_player"][0]["i2s_dout_pin"] == "GPIO32"
 
 
-def test_esp32_audio_uses_idf_framework(esp32_audio_design, library):
+def test_esp32_audio_uses_arduino_framework(esp32_audio_design, library):
+    # max98357a's media_player platform is arduino-only in upstream ESPHome
+    # (`cv.only_with_arduino`); the example used to set framework=esp-idf,
+    # which `esphome config` rejected. Revisit when esp-idf gains the
+    # platform or we route audio through speaker: + media_player: speaker
+    # chained.
     parsed = yaml.unsafe_load(render_yaml(esp32_audio_design, library))
-    assert parsed["esp32"]["framework"]["type"] == "esp-idf"
+    assert parsed["esp32"]["framework"]["type"] == "arduino"
 
 
 def test_bluesonoff_matches_golden(bluesonoff_design, library, golden_dir):
@@ -247,11 +256,12 @@ def test_awning_uses_expander_pins_not_extras(awning_control_design, library):
     sensors = parsed["binary_sensor"]
     assert len(sensors) == 4  # closed, open, out_button, in_button
     for s in sensors:
-        assert s["pin"]["mcp23008"] == "mcp23008_hub"
+        # mcp23xxx is the unified pin discriminator (ESPHome 2024+).
+        assert s["pin"]["mcp23xxx"] == "mcp23008_hub"
     switches = [s for s in parsed["switch"] if s["platform"] == "gpio"]
     assert len(switches) == 2  # awning_power, motor_enable
     for s in switches:
-        assert s["pin"]["mcp23008"] == "mcp23008_hub"
+        assert s["pin"]["mcp23xxx"] == "mcp23008_hub"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The Reddit "AI slop" critique landed on a real gap: the studio shipped wide
surface area (CSP solver, KiCad export, enclosures, agent, fleet handoff)
without integration-level proof that what it emits actually compiles under
upstream ESPHome. This PR plants the gate that closes that gap and
reorganises the README's claims to match what's actually verified.

This is the **Priority 1** deliverable from the new roadmap (YAML production
correctness > wiring schema > enclosures > PCB).

## What

- **`scripts/check_examples.py`** — for every `examples/*.json`, render YAML
  through `studio.generate.yaml_gen`, write a stub `secrets.yaml` next to
  it, run `esphome config <file>`. Exit 0 = all pass. Runs locally and in
  CI.
- **`.github/workflows/esphome-config.yml`** — runs the script on every PR
  + push to main + weekly schedule (catches ESPHome schema drift between
  code changes). Pinned to `esphome==2025.12.7`.
- **`CONTRIBUTING.md`** — the substantive merge bar: "your component is
  supported only when an example using it round-trips through the gate."
  Includes the priority tiers, local-run flow, ESPHome-bump discipline,
  and a Debian-host `paho-mqtt` venv-workaround note.
- **`README.md`** — Status section rewritten as a **Verified /
  Works (lighter checks) / Experimental / Deferred** tier table so the
  surface is honest about what's actually checked end-to-end. Roadmap
  reorganised by P1–P4 priority instead of phase number. "Tested against
  ESPHome `==2025.12.7`" called out on the front page.

## Bugs the gate caught (and this PR fixes)

The first dev-VM run against ESPHome 2025.12.7 surfaced four real issues:

1. **`mcp23xxx` expander pin key.** ESPHome 2024+ unifies the 8-/16-bit
   MCP variants under one `mcp23xxx:` discriminator on downstream pin
   blocks; the studio was emitting `mcp23008:` / `mcp23017:`, which
   `esphome config` rejects. Fix: added
   `esphome.expander_pin_key` to the library schema, set on both MCP
   entries, generator (`_pins_for`) honours it. Affected:
   `awning-control`, `securitypanel`. Goldens regenerated.
2. **`esp32-audio` framework.** `max98357a`'s `media_player` platform is
   `cv.only_with_arduino` in upstream; the example was esp-idf. Flipped
   the example to arduino. The structurally correct fix (chained
   `speaker:` + `media_player: speaker`, which works on esp-idf) is
   noted as a P1 follow-up.
3. **`oled` and `esp32-audio` fonts.** Both referenced
   `common/fonts/arial.ttf`, which isn't shipped. Swapped to
   `gfonts://Roboto` so the examples are self-contained.
4. **Pin spec.** PEP 440 expands `~=2025.5` to `>=2025.5,<2026` — a
   year-pin disguised as a minor-pin. Repinned to `==2025.12.7`
   (the exact version the dev-VM run validated).

## Verified

- 297/297 pytest pass (`mcp23xxx` shape baked into existing tests with
  comments explaining *why*, so future readers understand the
  constraint isn't arbitrary).
- `ruff check .` clean.
- Dev VM run against ESPHome 2025.12.7: **13/13 examples PASS, exit 0.**

## Honest limits

- One example per platform/framework. A component is "supported" only
  insofar as an example uses it; coverage matrix is the obvious next
  P1 step.
- This is `esphome config`, not `esphome compile`. Real compile smoke
  for one representative is also called out as the next P1 step in
  CONTRIBUTING.md.
- KiCad output is unit-tested as Python text, not opened in KiCad.
  P2 work.

## Test plan

- [x] `python -m pytest`
- [x] `python -m ruff check .`
- [x] `python scripts/check_examples.py` against ESPHome 2025.12.7 on a
      clean dev VM (13/13 PASS)
- [ ] CI run on this PR (the new workflow exercises itself)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_