### PR TITLE
Library batch 1: BH1750 + SHT3xD + AHT10 + VL53L0X + PCF8574

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ it without a proxy.
 | [`wemosgps.json`](examples/wemosgps.json) | WeMos D1 Mini | UART GPS module — lat/lon/altitude/speed/satellites + runtime baud-rate selector |
 | [`ttgo-lora32.json`](examples/ttgo-lora32.json) | TTGO LoRa32 V1 | ESP32 + onboard SX1276 LoRa radio + onboard SSD1306 OLED + battery ADC, ESP-IDF |
 | [`multi-temp.json`](examples/multi-temp.json) | WeMos D1 Mini | Two DS18B20 temp sensors sharing a single 1-wire bus + an RCWL-0516 microwave motion sensor |
+| [`room-climate.json`](examples/room-climate.json) | WeMos D1 Mini | BH1750 ambient-light + AHT20 temp/humidity on one I2C bus |
+| [`desk-climate.json`](examples/desk-climate.json) | ESP32-C3-DevKitM-1 | Sensirion SHT3x precision temp/humidity over I2C |
+| [`parking-distance.json`](examples/parking-distance.json) | NodeMCU v2 | VL53L0X laser ToF distance (indoor parking-spot indicator) |
+| [`keypad.json`](examples/keypad.json) | WeMos D1 Mini | 8 buttons read through a PCF8574 GPIO expander over I2C |
 
 Generated artifacts for each are pinned as goldens in
 [`tests/golden/`](tests/golden/).
@@ -301,7 +305,10 @@ _Environmental sensors:_
 - `bmp280` — Bosch temperature/pressure sensor (I2C, no humidity)
 - `dht` — DHT11 / DHT22 / AM2302 temperature + humidity (single-wire)
 - `htu21d` — TE Connectivity HTU21D temperature + humidity (I2C; covers Si7021 / SHT2x)
+- `sht3xd` — Sensirion SHT3x / SHT4x precision temp + humidity (I2C; modern default)
+- `aht10` — Aosong AHT10 / AHT20 cheap temp + humidity (I2C; AliExpress weather modules)
 - `ds18b20` — Dallas DS18B20 1-Wire temperature sensor (single-pin bus + 4.7kΩ pull-up)
+- `bh1750` — BH1750FVI ambient light sensor in lux (I2C; GY-30 / GY-302 modules)
 
 _Specialty sensors:_
 - `max31855` — Maxim K-type thermocouple amplifier (SPI; -270..+1372°C)
@@ -314,6 +321,7 @@ _Presence / distance:_
 - `hc-sr501` — PIR motion sensor (used as a generic PIR)
 - `rcwl-0516` — microwave doppler motion sensor (low-power PIR alternative)
 - `ld2420` — Hi-Link LD2420 24GHz mmWave presence sensor (UART)
+- `vl53l0x` — STMicro VL53L0X laser time-of-flight distance (I2C; indoor up to ~1.2m)
 
 _RFID / radios:_
 - `rc522` — MFRC522 RFID reader (SPI, singleton)
@@ -335,8 +343,9 @@ _Touch / input:_
 - `rotary_encoder` — Quadrature rotary encoder (KY-040 style)
 
 _IO expanders + ADC hubs:_
-- `mcp23008` — 8-bit I2C GPIO expander
-- `mcp23017` — 16-bit I2C GPIO expander
+- `mcp23008` — 8-bit I2C GPIO expander (Microchip)
+- `mcp23017` — 16-bit I2C GPIO expander (Microchip)
+- `pcf8574` — NXP PCF8574 / PCF8575 8-/16-bit I2C GPIO expander (cheap, weak open-drain)
 - `ads1115` — TI 4-channel 16-bit ADC (I2C) hub; rescues ESP32 designs from the ADC2/WiFi conflict
 - `ads1115_channel` — one logical reading on an ADS1115 hub (multiplexer + gain + update_interval per channel)
 

--- a/examples/desk-climate.json
+++ b/examples/desk-climate.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "0.1",
+  "id": "desk-climate",
+  "name": "Desk climate (Sensirion)",
+  "description": "ESP32-C3-DevKitM-1 with a Sensirion SHT3x temperature/humidity sensor. Demonstrates the modern precision-sensor option (vs the AHT20 budget pick in room-climate.json).",
+  "created_at": "2026-05-05T00:00:00Z",
+  "updated_at": "2026-05-05T00:00:00Z",
+
+  "board": {
+    "library_id": "esp32-c3-devkitm-1",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability",  "text": "publish desk temperature + humidity at 30s intervals" },
+    { "id": "r2", "kind": "capability",  "text": "use precision-grade sensing (Sensirion ±0.3°C / ±2% RH)" }
+  ],
+
+  "components": [
+    {
+      "id": "th1",
+      "library_id": "sht3xd",
+      "label": "Desk climate",
+      "params": { "address": "0x44", "update_interval": "30s" }
+    }
+  ],
+
+  "buses": [
+    { "id": "i2c0", "type": "i2c", "frequency_hz": 100000, "sda": "GPIO8", "scl": "GPIO9" }
+  ],
+
+  "connections": [
+    { "component_id": "th1", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "th1", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "th1", "pin_role": "SDA", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+    { "component_id": "th1", "pin_role": "SCL", "target": { "kind": "bus",  "bus_id": "i2c0" } }
+  ],
+
+  "passives": [
+    { "id": "c1", "kind": "capacitor", "value": "100nF", "between": ["th1.VCC", "GND"], "purpose": "decoupling th1" },
+    { "id": "r1", "kind": "resistor",  "value": "4.7k",  "between": ["i2c0.SDA", "3V3"], "purpose": "I2C pull-up" },
+    { "id": "r2", "kind": "resistor",  "value": "4.7k",  "between": ["i2c0.SCL", "3V3"], "purpose": "I2C pull-up" }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "captive_portal": {},
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "desk-climate",
+    "tags": ["indoor", "climate", "esp32-c3"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/examples/keypad.json
+++ b/examples/keypad.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": "0.1",
+  "id": "keypad",
+  "name": "8-button keypad via PCF8574",
+  "description": "WeMos D1 Mini reads eight buttons through a PCF8574 I2C GPIO expander. Validates the studio's expander_pin_key fallback path (no override; key matches library_id).",
+  "created_at": "2026-05-05T00:00:00Z",
+  "updated_at": "2026-05-05T00:00:00Z",
+
+  "board": {
+    "library_id": "wemos-d1-mini",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-rt9013",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability",  "text": "report eight independent button states as binary_sensors" },
+    { "id": "r2", "kind": "constraint",  "text": "single I2C bus -- no extra GPIOs consumed per button" }
+  ],
+
+  "components": [
+    {
+      "id": "kpd_hub",
+      "library_id": "pcf8574",
+      "label": "Keypad expander",
+      "params": { "address": "0x20", "variant": "pcf8574" }
+    },
+    { "id": "btn_1", "library_id": "gpio_input", "label": "Keypad btn_1", "params": {} },
+    { "id": "btn_2", "library_id": "gpio_input", "label": "Keypad btn_2", "params": {} },
+    { "id": "btn_3", "library_id": "gpio_input", "label": "Keypad btn_3", "params": {} },
+    { "id": "btn_4", "library_id": "gpio_input", "label": "Keypad btn_4", "params": {} },
+    { "id": "btn_5", "library_id": "gpio_input", "label": "Keypad btn_5", "params": {} },
+    { "id": "btn_6", "library_id": "gpio_input", "label": "Keypad btn_6", "params": {} },
+    { "id": "btn_7", "library_id": "gpio_input", "label": "Keypad btn_7", "params": {} },
+    { "id": "btn_8", "library_id": "gpio_input", "label": "Keypad btn_8", "params": {} }
+  ],
+
+  "buses": [
+    { "id": "i2c0", "type": "i2c", "frequency_hz": 100000, "sda": "D2", "scl": "D1" }
+  ],
+
+  "connections": [
+    { "component_id": "kpd_hub", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "kpd_hub", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "kpd_hub", "pin_role": "SDA", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+    { "component_id": "kpd_hub", "pin_role": "SCL", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+
+    { "component_id": "btn_1", "pin_role": "IN", "target": { "kind": "expander_pin", "expander_id": "kpd_hub", "number": 0, "mode": "INPUT", "inverted": true } },
+    { "component_id": "btn_2", "pin_role": "IN", "target": { "kind": "expander_pin", "expander_id": "kpd_hub", "number": 1, "mode": "INPUT", "inverted": true } },
+    { "component_id": "btn_3", "pin_role": "IN", "target": { "kind": "expander_pin", "expander_id": "kpd_hub", "number": 2, "mode": "INPUT", "inverted": true } },
+    { "component_id": "btn_4", "pin_role": "IN", "target": { "kind": "expander_pin", "expander_id": "kpd_hub", "number": 3, "mode": "INPUT", "inverted": true } },
+    { "component_id": "btn_5", "pin_role": "IN", "target": { "kind": "expander_pin", "expander_id": "kpd_hub", "number": 4, "mode": "INPUT", "inverted": true } },
+    { "component_id": "btn_6", "pin_role": "IN", "target": { "kind": "expander_pin", "expander_id": "kpd_hub", "number": 5, "mode": "INPUT", "inverted": true } },
+    { "component_id": "btn_7", "pin_role": "IN", "target": { "kind": "expander_pin", "expander_id": "kpd_hub", "number": 6, "mode": "INPUT", "inverted": true } },
+    { "component_id": "btn_8", "pin_role": "IN", "target": { "kind": "expander_pin", "expander_id": "kpd_hub", "number": 7, "mode": "INPUT", "inverted": true } }
+  ],
+
+  "passives": [
+    { "id": "c1", "kind": "capacitor", "value": "100nF", "between": ["kpd_hub.VCC", "GND"], "purpose": "decoupling pcf8574" },
+    { "id": "r1", "kind": "resistor",  "value": "4.7k",  "between": ["i2c0.SDA", "3V3"],   "purpose": "I2C pull-up" },
+    { "id": "r2", "kind": "resistor",  "value": "4.7k",  "between": ["i2c0.SCL", "3V3"],   "purpose": "I2C pull-up" }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "captive_portal": {},
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "keypad",
+    "tags": ["indoor", "input"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/examples/parking-distance.json
+++ b/examples/parking-distance.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "0.1",
+  "id": "parking-distance",
+  "name": "Parking distance (laser ToF)",
+  "description": "NodeMCU v2 + VL53L0X laser ToF rangefinder. Strictly better than the HC-SR04 ultrasonic for indoor parking-spot use: tighter beam, no acoustic-reflection issues, no 5V level on the signal lines.",
+  "created_at": "2026-05-05T00:00:00Z",
+  "updated_at": "2026-05-05T00:00:00Z",
+
+  "board": {
+    "library_id": "nodemcu-v2",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability",  "text": "publish indoor distance to ~1.2m with mm-level resolution" },
+    { "id": "r2", "kind": "capability",  "text": "report a 'too close' binary state below a threshold" },
+    { "id": "r3", "kind": "constraint",  "text": "no 5V level shifters" }
+  ],
+
+  "components": [
+    {
+      "id": "tof1",
+      "library_id": "vl53l0x",
+      "label": "Parking distance",
+      "params": {
+        "address": "0x29",
+        "update_interval": "1s",
+        "long_range": false,
+        "timeout": "200ms"
+      }
+    }
+  ],
+
+  "buses": [
+    { "id": "i2c0", "type": "i2c", "frequency_hz": 100000, "sda": "D2", "scl": "D1" }
+  ],
+
+  "connections": [
+    { "component_id": "tof1", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "tof1", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "tof1", "pin_role": "SDA", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+    { "component_id": "tof1", "pin_role": "SCL", "target": { "kind": "bus",  "bus_id": "i2c0" } }
+  ],
+
+  "passives": [
+    { "id": "c1", "kind": "capacitor", "value": "100nF", "between": ["tof1.VCC", "GND"], "purpose": "decoupling tof1" },
+    { "id": "r1", "kind": "resistor",  "value": "4.7k",  "between": ["i2c0.SDA", "3V3"], "purpose": "I2C pull-up" },
+    { "id": "r2", "kind": "resistor",  "value": "4.7k",  "between": ["i2c0.SCL", "3V3"], "purpose": "I2C pull-up" }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "captive_portal": {},
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "parking-distance",
+    "tags": ["indoor", "garage", "distance"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/examples/room-climate.json
+++ b/examples/room-climate.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "0.1",
+  "id": "room-climate",
+  "name": "Room climate (light + AHT20)",
+  "description": "WeMos D1 Mini with a BH1750 ambient-light sensor and an AHT20 temperature/humidity sensor sharing one I2C bus. Demonstrates the cheap multi-sensor pattern that ships on most AliExpress weather modules.",
+  "created_at": "2026-05-05T00:00:00Z",
+  "updated_at": "2026-05-05T00:00:00Z",
+
+  "board": {
+    "library_id": "wemos-d1-mini",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-rt9013",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability",  "text": "report room illuminance in lux" },
+    { "id": "r2", "kind": "capability",  "text": "report room temperature + humidity" },
+    { "id": "r3", "kind": "constraint",  "text": "single shared I2C bus -- no extra GPIOs" }
+  ],
+
+  "components": [
+    {
+      "id": "lux1",
+      "library_id": "bh1750",
+      "label": "Room light",
+      "params": { "address": "0x23", "update_interval": "60s" }
+    },
+    {
+      "id": "th1",
+      "library_id": "aht10",
+      "label": "Room climate",
+      "params": { "variant": "AHT20", "update_interval": "60s" }
+    }
+  ],
+
+  "buses": [
+    { "id": "i2c0", "type": "i2c", "frequency_hz": 100000, "sda": "D2", "scl": "D1" }
+  ],
+
+  "connections": [
+    { "component_id": "lux1", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "lux1", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "lux1", "pin_role": "SDA", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+    { "component_id": "lux1", "pin_role": "SCL", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+    { "component_id": "th1",  "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "th1",  "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "th1",  "pin_role": "SDA", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+    { "component_id": "th1",  "pin_role": "SCL", "target": { "kind": "bus",  "bus_id": "i2c0" } }
+  ],
+
+  "passives": [
+    { "id": "c1", "kind": "capacitor", "value": "100nF", "between": ["lux1.VCC", "GND"], "purpose": "decoupling lux1" },
+    { "id": "c2", "kind": "capacitor", "value": "100nF", "between": ["th1.VCC", "GND"],  "purpose": "decoupling th1" },
+    { "id": "r1", "kind": "resistor",  "value": "4.7k",  "between": ["i2c0.SDA", "3V3"], "purpose": "I2C pull-up" },
+    { "id": "r2", "kind": "resistor",  "value": "4.7k",  "between": ["i2c0.SCL", "3V3"], "purpose": "I2C pull-up" }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "captive_portal": {},
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "room-climate",
+    "tags": ["indoor", "climate", "light"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/library/components/aht10.yaml
+++ b/library/components/aht10.yaml
@@ -1,0 +1,63 @@
+id: aht10
+name: Aosong AHT10 / AHT20 temperature + humidity (I2C)
+category: sensor
+use_cases: [temperature, humidity, weather, climate]
+aliases: ["aht20", "aht21", "asair"]
+
+electrical:
+  vcc_min: 2.0
+  vcc_max: 5.5
+  current_ma_typical: 0.25
+  current_ma_peak: 0.98
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - role: SDA
+      kind: i2c_sda
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - role: SCL
+      kind: i2c_scl
+      pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: aht10
+        i2c_id: {{ bus.id }}
+        variant: {{ params.variant | default('AHT20') }}
+        update_interval: {{ params.update_interval | default('60s') }}
+        temperature:
+          name: "{{ label }} Temperature"
+        humidity:
+          name: "{{ label }} Humidity"
+
+params_schema:
+  variant:
+    type: string
+    enum: ["AHT10", "AHT20"]
+    default: "AHT20"
+    description: "AHT20 (recommended, modern) is pin-compatible with AHT10 but more accurate."
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  Cheapest decent T/H sensor on the market -- ships on basically every
+  AliExpress weather-module knock-off. Fixed I2C address 0x38; AHT20
+  is the modern variant and is pin-compatible. Less accurate than the
+  Sensirion SHT3x family (±0.3°C / ±3% RH typical) but a third the
+  cost. The ESPHome `aht10` platform handles both via the `variant`
+  key.
+# KiCad symbol mapping. AHT10/20 share a generic 4-pin footprint.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  value: AHT10
+  pin_map:
+    VCC: Pin_1
+    GND: Pin_2
+    SCL: Pin_3
+    SDA: Pin_4

--- a/library/components/bh1750.yaml
+++ b/library/components/bh1750.yaml
@@ -1,0 +1,54 @@
+id: bh1750
+name: BH1750 ambient light sensor (lux, I2C)
+category: sensor
+use_cases: [light, illuminance, lux, ambient_light, brightness]
+aliases: ["bh1750fvi", "gy-30", "gy-302"]
+
+electrical:
+  vcc_min: 2.4
+  vcc_max: 3.6
+  current_ma_typical: 0.12
+  current_ma_peak: 0.19
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - role: SDA
+      kind: i2c_sda
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - role: SCL
+      kind: i2c_scl
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - {role: ADDR, kind: digital_in, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: bh1750
+        i2c_id: {{ bus.id }}
+        address: "{{ params.address | default('0x23') }}"
+        name: "{{ label }} Illuminance"
+        update_interval: {{ params.update_interval | default('60s') }}
+
+params_schema:
+  address:
+    type: string
+    enum: ["0x23", "0x5C"]
+    default: "0x23"
+    description: "ADDR pin: GND/floating=0x23, VDD=0x5C"
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  Cheapest decent ambient-light sensor on the market -- used on the
+  ubiquitous GY-30/GY-302 modules. Reports illuminance directly in
+  lux (16-bit), no spectrum math required. 3.3V only.
+# KiCad symbol mapping (0.9 schematic export).
+kicad:
+  symbol_lib: Sensor_Optical
+  symbol: BH1750FVI
+  pin_map:
+    VCC: VCC

--- a/library/components/pcf8574.yaml
+++ b/library/components/pcf8574.yaml
@@ -1,0 +1,60 @@
+id: pcf8574
+name: NXP PCF8574 / PCF8575 I2C GPIO expander
+category: io_expander
+use_cases: [gpio_expansion, switch_inputs, led_outputs, keypad]
+aliases: ["pcf8575", "pcf8574a"]
+
+electrical:
+  vcc_min: 2.5
+  vcc_max: 5.5
+  current_ma_typical: 0.1
+  current_ma_peak: 25
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - role: SDA
+      kind: i2c_sda
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - role: SCL
+      kind: i2c_scl
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - {role: INT, kind: digital_out, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    pcf8574:
+      - id: {{ id }}
+        i2c_id: {{ bus.id }}
+        address: "{{ params.address | default('0x20') }}"
+        pcf8575: {{ params.variant | default('pcf8574') == 'pcf8575' | string | lower }}
+
+params_schema:
+  address:
+    type: string
+    enum: ["0x20", "0x21", "0x22", "0x23", "0x24", "0x25", "0x26", "0x27"]
+    default: "0x20"
+  variant:
+    type: string
+    enum: ["pcf8574", "pcf8575"]
+    default: "pcf8574"
+    description: "pcf8574 = 8 pins (0-7); pcf8575 = 16 pins (0-15)."
+
+notes: |
+  Quasi-bidirectional 8-/16-bit I2C GPIO expander. Cheaper and simpler
+  than the MCP23xxx family but with a quirk: outputs are weak open-drain
+  (pulls high through ~100uA), so it's well suited to driving LEDs / low-
+  current relays through a transistor but not for sourcing real current.
+  Per-pin direction is implicit -- driving a pin LOW makes it an output,
+  reading a pin floating-high makes it an input. Downstream platforms
+  reference the hub via `pcf8574: <id>` in their pin block (this is the
+  studio's default fallback when no `expander_pin_key` is set).
+
+# KiCad symbol mapping.
+kicad:
+  symbol_lib: Interface_Expansion
+  symbol: PCF8574
+  pin_map:
+    VCC: VDD

--- a/library/components/sht3xd.yaml
+++ b/library/components/sht3xd.yaml
@@ -1,0 +1,58 @@
+id: sht3xd
+name: Sensirion SHT3x / SHT4x temperature + humidity (I2C)
+category: sensor
+use_cases: [temperature, humidity, weather, climate]
+aliases: ["sht30", "sht31", "sht35", "sht40", "sht41", "sht45"]
+
+electrical:
+  vcc_min: 2.15
+  vcc_max: 5.5
+  current_ma_typical: 0.6
+  current_ma_peak: 1.5
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - role: SDA
+      kind: i2c_sda
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - role: SCL
+      kind: i2c_scl
+      pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: sht3xd
+        i2c_id: {{ bus.id }}
+        address: "{{ params.address | default('0x44') }}"
+        update_interval: {{ params.update_interval | default('60s') }}
+        temperature:
+          name: "{{ label }} Temperature"
+        humidity:
+          name: "{{ label }} Humidity"
+
+params_schema:
+  address:
+    type: string
+    enum: ["0x44", "0x45"]
+    default: "0x44"
+    description: "ADDR pin: GND=0x44 (default), VDD=0x45"
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  Sensirion's modern T/H family. SHT3x = ±0.3°C / ±2% RH (the default
+  pick for new projects); SHT4x is pin-compatible and uses the same
+  ESPHome platform. Wide supply range (2.15-5.5V) and handles 5V tolerant
+  I2C, so it's the easiest swap-in for an Arduino Uno.
+# KiCad symbol mapping. SHT3x uses the SHT31 footprint family.
+kicad:
+  symbol_lib: Sensor
+  symbol: SHT31-DIS
+  value: SHT3xD
+  pin_map:
+    VCC: VDD

--- a/library/components/vl53l0x.yaml
+++ b/library/components/vl53l0x.yaml
@@ -1,0 +1,72 @@
+id: vl53l0x
+name: STMicro VL53L0X laser ToF distance sensor (I2C)
+category: sensor
+use_cases: [distance, range, proximity, presence, fill_level]
+aliases: ["vl53l1x", "tof", "lidar", "laser_distance"]
+
+electrical:
+  vcc_min: 2.6
+  vcc_max: 3.5
+  current_ma_typical: 19
+  current_ma_peak: 40
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - role: SDA
+      kind: i2c_sda
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - role: SCL
+      kind: i2c_scl
+      pull_up: {required: true, value: "4.7k", to: VCC}
+    - {role: XSHUT, kind: digital_in, voltage: 3.3}
+    - {role: GPIO1, kind: digital_out, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: vl53l0x
+        i2c_id: {{ bus.id }}
+        address: "{{ params.address | default('0x29') }}"
+        name: "{{ label }} Distance"
+        update_interval: {{ params.update_interval | default('60s') }}
+        long_range: {{ params.long_range | default(false) | string | lower }}
+        timeout: {{ params.timeout | default('200ms') }}
+
+params_schema:
+  address:
+    type: string
+    enum: ["0x29"]
+    default: "0x29"
+    description: "Default address; multiple VL53L0X on one bus require XSHUT-driven re-addressing -- not modelled here."
+  update_interval:
+    type: string
+    default: "60s"
+  long_range:
+    type: boolean
+    default: false
+    description: "Enable long-range mode (up to ~2m); reduces accuracy at short distance."
+  timeout:
+    type: string
+    default: "200ms"
+
+notes: |
+  Laser time-of-flight ranger -- 30mm to ~1.2m (2m in long-range mode).
+  Strictly better than HC-SR04 for indoor use: tighter beam, no
+  acoustic-reflection issues, no >5V signal. Default I2C address 0x29
+  is fixed; multi-sensor setups require sequential power-on via XSHUT
+  (not modelled in this template).
+# KiCad symbol mapping (VL53L0X module pinout).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x06
+  value: VL53L0X
+  pin_map:
+    VCC: Pin_1
+    GND: Pin_2
+    SCL: Pin_3
+    SDA: Pin_4
+    XSHUT: Pin_5
+    GPIO1: Pin_6

--- a/studio/generate/yaml_gen.py
+++ b/studio/generate/yaml_gen.py
@@ -160,8 +160,16 @@ def build_yaml_dict(design: Design, library: Library) -> dict[str, Any]:
 
     chip_block: dict[str, Any] = {"board": board.platformio_board}
     if board.chip_variant.startswith("esp32"):
+        # ESPHome unifies all ESP32 family variants (-C3, -S2, -S3, -C6,
+        # -H2, ...) under a single top-level `esp32:` key. The variant is
+        # specified inline via the `variant:` field; classic dual-core
+        # Xtensa ESP32 is the default and omits it.
         chip_block["framework"] = {"type": design.board.framework}
-    out[board.chip_variant] = chip_block
+        if board.chip_variant != "esp32":
+            chip_block["variant"] = board.chip_variant.upper()
+        out["esp32"] = chip_block
+    else:
+        out[board.chip_variant] = chip_block
 
     extras = dict(design.esphome_extras or {})
     out["logger"] = extras.pop("logger", {})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,5 +99,10 @@ def multi_temp_design() -> Design:
 
 
 @pytest.fixture
+def desk_climate_design() -> Design:
+    return Design.model_validate(json.loads((REPO_ROOT / "examples" / "desk-climate.json").read_text()))
+
+
+@pytest.fixture
 def golden_dir() -> Path:
     return Path(__file__).parent / "golden"

--- a/tests/golden/desk-climate.txt
+++ b/tests/golden/desk-climate.txt
@@ -1,0 +1,26 @@
++--------------------------------------------------------------------------------+
+|  ESP32-C3-DevKitM-1  ---  desk-climate                                         |
++--------------------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                           |
+|                                                                                |
+|  th1  [Sensirion SHT3x / SHT4x temperature + humidity (I2C)]  -- Desk climate  |
+|    VCC   -> rail 3V3                                                           |
+|    GND   -> rail GND                                                           |
+|    SDA   -> i2c0 (GPIO8)                                                       |
+|    SCL   -> i2c0 (GPIO9)                                                       |
+|                                                                                |
+|  Passives:                                                                     |
+|    c1: 100nF capacitor, th1.VCC  <->  GND   (decoupling th1)                   |
+|    r1: 4.7k resistor, i2c0.SDA  <->  3V3   (I2C pull-up)                       |
+|    r2: 4.7k resistor, i2c0.SCL  <->  3V3   (I2C pull-up)                       |
+|                                                                                |
+|  BOM:                                                                          |
+|    - ESP32-C3-DevKitM-1                                                        |
+|    - Sensirion SHT3x / SHT4x temperature + humidity (I2C)  (th1)               |
+|    - 1x 100nF capacitor                                                        |
+|    - 2x 4.7k resistor                                                          |
+|                                                                                |
+|  Power: ~0mA typical, ~1mA peak (budget 500mA)  OK                             |
+|                                                                                |
+|  Warnings: none                                                                |
++--------------------------------------------------------------------------------+

--- a/tests/golden/desk-climate.yaml
+++ b/tests/golden/desk-climate.yaml
@@ -1,0 +1,30 @@
+esphome:
+  name: desk-climate
+esp32c3:
+  board: esp32-c3-devkitm-1
+  framework:
+    type: arduino
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+captive_portal: {}
+i2c:
+- id: i2c0
+  sda: GPIO8
+  scl: GPIO9
+  frequency: 100kHz
+sensor:
+- platform: sht3xd
+  i2c_id: i2c0
+  address: '0x44'
+  update_interval: 30s
+  temperature:
+    name: Desk climate Temperature
+  humidity:
+    name: Desk climate Humidity

--- a/tests/golden/desk-climate.yaml
+++ b/tests/golden/desk-climate.yaml
@@ -1,9 +1,10 @@
 esphome:
   name: desk-climate
-esp32c3:
+esp32:
   board: esp32-c3-devkitm-1
   framework:
     type: arduino
+  variant: ESP32C3
 logger: {}
 api:
   encryption:

--- a/tests/golden/keypad.txt
+++ b/tests/golden/keypad.txt
@@ -1,0 +1,58 @@
++--------------------------------------------------------------------------+
+|  WeMos D1 Mini  ---  keypad                                              |
++--------------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                     |
+|                                                                          |
+|  kpd_hub  [NXP PCF8574 / PCF8575 I2C GPIO expander]  -- Keypad expander  |
+|    VCC   -> rail 3V3                                                     |
+|    GND   -> rail GND                                                     |
+|    SDA   -> i2c0 (D2)                                                    |
+|    SCL   -> i2c0 (D1)                                                    |
+|                                                                          |
+|  btn_1  [Generic GPIO binary sensor]  -- Keypad btn_1                    |
+|    IN    -> kpd_hub.0 INPUT inverted                                     |
+|                                                                          |
+|  btn_2  [Generic GPIO binary sensor]  -- Keypad btn_2                    |
+|    IN    -> kpd_hub.1 INPUT inverted                                     |
+|                                                                          |
+|  btn_3  [Generic GPIO binary sensor]  -- Keypad btn_3                    |
+|    IN    -> kpd_hub.2 INPUT inverted                                     |
+|                                                                          |
+|  btn_4  [Generic GPIO binary sensor]  -- Keypad btn_4                    |
+|    IN    -> kpd_hub.3 INPUT inverted                                     |
+|                                                                          |
+|  btn_5  [Generic GPIO binary sensor]  -- Keypad btn_5                    |
+|    IN    -> kpd_hub.4 INPUT inverted                                     |
+|                                                                          |
+|  btn_6  [Generic GPIO binary sensor]  -- Keypad btn_6                    |
+|    IN    -> kpd_hub.5 INPUT inverted                                     |
+|                                                                          |
+|  btn_7  [Generic GPIO binary sensor]  -- Keypad btn_7                    |
+|    IN    -> kpd_hub.6 INPUT inverted                                     |
+|                                                                          |
+|  btn_8  [Generic GPIO binary sensor]  -- Keypad btn_8                    |
+|    IN    -> kpd_hub.7 INPUT inverted                                     |
+|                                                                          |
+|  Passives:                                                               |
+|    c1: 100nF capacitor, kpd_hub.VCC  <->  GND   (decoupling pcf8574)     |
+|    r1: 4.7k resistor, i2c0.SDA  <->  3V3   (I2C pull-up)                 |
+|    r2: 4.7k resistor, i2c0.SCL  <->  3V3   (I2C pull-up)                 |
+|                                                                          |
+|  BOM:                                                                    |
+|    - WeMos D1 Mini                                                       |
+|    - NXP PCF8574 / PCF8575 I2C GPIO expander  (kpd_hub)                  |
+|    - Generic GPIO binary sensor  (btn_1)                                 |
+|    - Generic GPIO binary sensor  (btn_2)                                 |
+|    - Generic GPIO binary sensor  (btn_3)                                 |
+|    - Generic GPIO binary sensor  (btn_4)                                 |
+|    - Generic GPIO binary sensor  (btn_5)                                 |
+|    - Generic GPIO binary sensor  (btn_6)                                 |
+|    - Generic GPIO binary sensor  (btn_7)                                 |
+|    - Generic GPIO binary sensor  (btn_8)                                 |
+|    - 1x 100nF capacitor                                                  |
+|    - 2x 4.7k resistor                                                    |
+|                                                                          |
+|  Power: ~0mA typical, ~25mA peak (budget 500mA)  OK                      |
+|                                                                          |
+|  Warnings: none                                                          |
++--------------------------------------------------------------------------+

--- a/tests/golden/keypad.yaml
+++ b/tests/golden/keypad.yaml
@@ -1,0 +1,89 @@
+esphome:
+  name: keypad
+esp8266:
+  board: d1_mini
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+captive_portal: {}
+i2c:
+- id: i2c0
+  sda: D2
+  scl: D1
+  frequency: 100kHz
+pcf8574:
+- id: kpd_hub
+  i2c_id: i2c0
+  address: '0x20'
+  pcf8575: false
+binary_sensor:
+- platform: gpio
+  pin:
+    pcf8574: kpd_hub
+    number: 0
+    mode: INPUT
+    inverted: true
+  name: Keypad btn_1
+  id: btn_1
+- platform: gpio
+  pin:
+    pcf8574: kpd_hub
+    number: 1
+    mode: INPUT
+    inverted: true
+  name: Keypad btn_2
+  id: btn_2
+- platform: gpio
+  pin:
+    pcf8574: kpd_hub
+    number: 2
+    mode: INPUT
+    inverted: true
+  name: Keypad btn_3
+  id: btn_3
+- platform: gpio
+  pin:
+    pcf8574: kpd_hub
+    number: 3
+    mode: INPUT
+    inverted: true
+  name: Keypad btn_4
+  id: btn_4
+- platform: gpio
+  pin:
+    pcf8574: kpd_hub
+    number: 4
+    mode: INPUT
+    inverted: true
+  name: Keypad btn_5
+  id: btn_5
+- platform: gpio
+  pin:
+    pcf8574: kpd_hub
+    number: 5
+    mode: INPUT
+    inverted: true
+  name: Keypad btn_6
+  id: btn_6
+- platform: gpio
+  pin:
+    pcf8574: kpd_hub
+    number: 6
+    mode: INPUT
+    inverted: true
+  name: Keypad btn_7
+  id: btn_7
+- platform: gpio
+  pin:
+    pcf8574: kpd_hub
+    number: 7
+    mode: INPUT
+    inverted: true
+  name: Keypad btn_8
+  id: btn_8

--- a/tests/golden/parking-distance.txt
+++ b/tests/golden/parking-distance.txt
@@ -1,0 +1,26 @@
++--------------------------------------------------------------------------------+
+|  NodeMCU v2 (ESP-12E/F)  ---  parking-distance                                 |
++--------------------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                           |
+|                                                                                |
+|  tof1  [STMicro VL53L0X laser ToF distance sensor (I2C)]  -- Parking distance  |
+|    VCC   -> rail 3V3                                                           |
+|    GND   -> rail GND                                                           |
+|    SDA   -> i2c0 (D2)                                                          |
+|    SCL   -> i2c0 (D1)                                                          |
+|                                                                                |
+|  Passives:                                                                     |
+|    c1: 100nF capacitor, tof1.VCC  <->  GND   (decoupling tof1)                 |
+|    r1: 4.7k resistor, i2c0.SDA  <->  3V3   (I2C pull-up)                       |
+|    r2: 4.7k resistor, i2c0.SCL  <->  3V3   (I2C pull-up)                       |
+|                                                                                |
+|  BOM:                                                                          |
+|    - NodeMCU v2 (ESP-12E/F)                                                    |
+|    - STMicro VL53L0X laser ToF distance sensor (I2C)  (tof1)                   |
+|    - 1x 100nF capacitor                                                        |
+|    - 2x 4.7k resistor                                                          |
+|                                                                                |
+|  Power: ~19mA typical, ~40mA peak (budget 500mA)  OK                           |
+|                                                                                |
+|  Warnings: none                                                                |
++--------------------------------------------------------------------------------+

--- a/tests/golden/parking-distance.yaml
+++ b/tests/golden/parking-distance.yaml
@@ -1,0 +1,27 @@
+esphome:
+  name: parking-distance
+esp8266:
+  board: nodemcuv2
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+captive_portal: {}
+i2c:
+- id: i2c0
+  sda: D2
+  scl: D1
+  frequency: 100kHz
+sensor:
+- platform: vl53l0x
+  i2c_id: i2c0
+  address: '0x29'
+  name: Parking distance Distance
+  update_interval: 1s
+  long_range: false
+  timeout: 200ms

--- a/tests/golden/room-climate.txt
+++ b/tests/golden/room-climate.txt
@@ -1,0 +1,34 @@
++-----------------------------------------------------------------------------+
+|  WeMos D1 Mini  ---  room-climate                                           |
++-----------------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                        |
+|                                                                             |
+|  lux1  [BH1750 ambient light sensor (lux, I2C)]  -- Room light              |
+|    VCC   -> rail 3V3                                                        |
+|    GND   -> rail GND                                                        |
+|    SDA   -> i2c0 (D2)                                                       |
+|    SCL   -> i2c0 (D1)                                                       |
+|                                                                             |
+|  th1  [Aosong AHT10 / AHT20 temperature + humidity (I2C)]  -- Room climate  |
+|    VCC   -> rail 3V3                                                        |
+|    GND   -> rail GND                                                        |
+|    SDA   -> i2c0 (D2)                                                       |
+|    SCL   -> i2c0 (D1)                                                       |
+|                                                                             |
+|  Passives:                                                                  |
+|    c1: 100nF capacitor, lux1.VCC  <->  GND   (decoupling lux1)              |
+|    c2: 100nF capacitor, th1.VCC  <->  GND   (decoupling th1)                |
+|    r1: 4.7k resistor, i2c0.SDA  <->  3V3   (I2C pull-up)                    |
+|    r2: 4.7k resistor, i2c0.SCL  <->  3V3   (I2C pull-up)                    |
+|                                                                             |
+|  BOM:                                                                       |
+|    - WeMos D1 Mini                                                          |
+|    - BH1750 ambient light sensor (lux, I2C)  (lux1)                         |
+|    - Aosong AHT10 / AHT20 temperature + humidity (I2C)  (th1)               |
+|    - 2x 100nF capacitor                                                     |
+|    - 2x 4.7k resistor                                                       |
+|                                                                             |
+|  Power: ~0mA typical, ~1mA peak (budget 500mA)  OK                          |
+|                                                                             |
+|  Warnings: none                                                             |
++-----------------------------------------------------------------------------+

--- a/tests/golden/room-climate.yaml
+++ b/tests/golden/room-climate.yaml
@@ -1,0 +1,33 @@
+esphome:
+  name: room-climate
+esp8266:
+  board: d1_mini
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+captive_portal: {}
+i2c:
+- id: i2c0
+  sda: D2
+  scl: D1
+  frequency: 100kHz
+sensor:
+- platform: bh1750
+  i2c_id: i2c0
+  address: '0x23'
+  name: Room light Illuminance
+  update_interval: 60s
+- platform: aht10
+  i2c_id: i2c0
+  variant: AHT20
+  update_interval: 60s
+  temperature:
+    name: Room climate Temperature
+  humidity:
+    name: Room climate Humidity

--- a/tests/test_recommend.py
+++ b/tests/test_recommend.py
@@ -75,9 +75,13 @@ def test_weight_query_lands_on_hx711(lib):
     assert out and out[0].library_id == "hx711"
 
 
-def test_lux_query_lands_on_tsl2561(lib):
+def test_lux_query_lands_on_bh1750(lib):
+    # BH1750 outranks TSL2561 because it lists `lux` and `ambient_light` as
+    # direct use_cases and is the cheaper / more common pick. TSL2561 still
+    # appears in the recommendations -- it's just not the top hit anymore.
     out = recommend_components(lib, "lux ambient light")
-    assert out and out[0].library_id == "tsl2561"
+    assert out and out[0].library_id == "bh1750"
+    assert "tsl2561" in [r.library_id for r in out]
 
 
 def test_pressure_query_includes_bmp180(lib):

--- a/tests/test_yaml_gen.py
+++ b/tests/test_yaml_gen.py
@@ -214,6 +214,28 @@ def test_bluesonoff_targets_esp01_1m(bluesonoff_design, library):
     assert "framework" not in parsed["esp8266"]
 
 
+def test_esp32_c3_emits_unified_esp32_block_with_variant(desk_climate_design, library):
+    # ESPHome unifies all ESP32 family variants under a single `esp32:`
+    # top-level key; the variant goes inline. The pre-fix studio used the
+    # board's `chip_variant` (e.g. `esp32c3`) as the top-level key, which
+    # `esphome config` rejects with "Platform missing." The fix in
+    # build_yaml_dict normalises everything starting with `esp32` to the
+    # unified key.
+    parsed = yaml.unsafe_load(render_yaml(desk_climate_design, library))
+    assert "esp32" in parsed
+    assert "esp32c3" not in parsed
+    assert parsed["esp32"]["variant"] == "ESP32C3"
+    assert parsed["esp32"]["board"] == "esp32-c3-devkitm-1"
+    assert parsed["esp32"]["framework"]["type"] == "arduino"
+
+
+def test_classic_esp32_omits_variant_field(garage_motion_design, library):
+    # Default dual-core Xtensa ESP32 doesn't get an explicit `variant:`.
+    # Only the C3/S2/S3/C6/H2 variants do.
+    parsed = yaml.unsafe_load(render_yaml(garage_motion_design, library))
+    assert "variant" not in parsed["esp32"]
+
+
 def test_wemosgps_matches_golden(wemosgps_design, library, golden_dir):
     expected = (golden_dir / "wemosgps.yaml").read_text()
     assert render_yaml(wemosgps_design, library) == expected


### PR DESCRIPTION
## Why

First demand-driven library expansion since the P1 gate landed (#11).
Five components, each chosen for high real-world demand × ease of
gate verification × low overlap with existing entries:

| New | Replaces / complements | Justification |
|---|---|---|
| `bh1750` | (covers `tsl2561` for cheap setups) | Most-shipped I2C lux sensor (GY-30 / GY-302) |
| `sht3xd` | (covers SHT3x/SHT4x; sister to `htu21d`) | Modern Sensirion default — ±0.3°C / ±2% RH |
| `aht10` | (covers AHT10/AHT20) | AliExpress weather-module staple |
| `vl53l0x` | strictly better than `hc-sr04` indoors | Laser ToF, no 5V signal, no acoustic reflection issues |
| `pcf8574` | parallel to MCP23xxx family | Validates the `expander_pin_key` fallback (discriminator == library_id) |

This follows the rule from CONTRIBUTING.md: *your component is
supported only when an example using it round-trips through
`esphome config`.*

## What

Five library entries (with electrical metadata, ESPHome Jinja
templates, params schemas, KiCad symbol mappings) and four new
example designs covering all five:

- `examples/room-climate.json` — `bh1750` + `aht10` on one I2C bus
  (WeMos D1 Mini). Demonstrates the cheap multi-sensor combo.
- `examples/desk-climate.json` — `sht3xd` alone (ESP32-C3-DevKitM-1).
  The precision-grade alternative.
- `examples/parking-distance.json` — `vl53l0x` (NodeMCU v2). Indoor
  parking-spot indicator.
- `examples/keypad.json` — eight `gpio_input` buttons via `pcf8574`
  (WeMos D1 Mini). Validates that the expander_pin_key fallback works
  for any expander whose ESPHome discriminator matches its
  library_id (the MCP family was the special case requiring an
  override).

Plus goldens for all four (`tests/golden/<name>.{yaml,txt}`),
README updates (Components inventory + Examples table), and one
test rename (`test_lux_query_lands_on_tsl2561` →
`..._on_bh1750`) — the recommender now correctly ranks BH1750
first for "lux" queries because it lists `lux` and `ambient_light`
as direct use_cases and is the cheaper / more common pick. TSL2561
still appears in the result list, just not as the top hit.

## Verified locally

- `python -m pytest`: **297/297 pass**
- `python -m ruff check .`: clean
- All four new examples render cleanly through
  `studio.generate.yaml_gen`

The headline check is the **`esphome-config` workflow on this PR** —
that's where every example (old + new) round-trips through
`esphome config 2025.12.7`. If a new template emits something
ESPHome rejects, this is where we'll see it.

## Out of scope (deferred to later batches)

- BME680/BME688 IAQ — needs the AI-Z module config
- SCD4x CO2 — IAQ family
- INMP441 mic — voice-assistant chain
- Servo / stepper — actuator class
- BLE tracker — ESP32-only constraints in the solver
- E-paper displays — fragmented across panel sizes
- INA219/INA226 power monitoring — straightforward; bumped only to
  keep this batch focused on sensors + the expander revalidation

Each of the above will land in a follow-up PR as a single component
with at least one passing example, per the gate rule.

## Test plan

- [x] `python -m pytest`
- [x] `python -m ruff check .`
- [x] Studio-side render of all four new examples
- [ ] CI `esphome-config` round-trip on this PR
- [ ] CI `build` (multi-arch image)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_