### PR TITLE
Dev-loop hardening: pre-push hook + nightly `esphome compile` smoke

### DIFF
--- a/.github/workflows/esphome-compile.yml
+++ b/.github/workflows/esphome-compile.yml
@@ -1,0 +1,87 @@
+name: esphome-compile
+
+# Nightly compile smoke. The `esphome-config` gate validates that the
+# studio's YAML matches ESPHome's schema; this workflow goes one level
+# deeper and runs `esphome compile` against a representative example,
+# which exercises the C++ codegen + PlatformIO toolchain.
+#
+# Catches what `esphome config` can't:
+#   - a new PlatformIO toolchain release breaks the build
+#   - a new ESPHome release accepts our YAML but its codegen breaks
+#   - a python:3.11-slim security update knocks out a build dep
+#
+# Why nightly only:
+#   - first-time toolchain download is ~250MB and the build itself
+#     adds several minutes. Per-PR is too heavy.
+#   - the failures it catches are upstream churn, not contributor
+#     churn -- "did the world move under us overnight" is the right
+#     question to ask once a day.
+#
+# Triggers:
+#   - schedule: 11:00 UTC daily (after the weekly esphome-config
+#     schedule run at 10:00 UTC Mondays).
+#   - workflow_dispatch: manual rerun, with an optional `example`
+#     input so you can compile-smoke a specific design ad-hoc.
+
+on:
+  schedule:
+    - cron: '0 11 * * *'   # 11:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      example:
+        description: 'Example stem to compile (default: garage-motion -- the simplest representative)'
+        required: false
+        default: 'garage-motion'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: esphome-compile-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    # Cold cache (first run after a pin bump or cache eviction):
+    # toolchain pull + first compile is ~10-12min for ESP32 Arduino.
+    # Warm cache: ~2-3min. 25min is the safety margin.
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install studio + ESPHome
+        # Same pinned ESPHome the config gate uses. If you bump one,
+        # bump both in the same PR.
+        run: |
+          pip install -e .
+          pip install 'esphome==2025.12.7'
+
+      - name: Cache PlatformIO + ESPHome build artifacts
+        # The toolchain pull dominates wall-clock on a cold run.
+        # Keying on the ESPHome pin means a deliberate bump invalidates
+        # the cache, but day-to-day runs reuse it.
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: pio-${{ runner.os }}-esphome-2025.12.7
+          restore-keys: |
+            pio-${{ runner.os }}-esphome-
+
+      - name: Print resolved ESPHome version
+        run: esphome version
+
+      - name: Compile smoke
+        # `--compile` swaps the inner subcommand from `esphome config`
+        # to `esphome compile`. Same secrets-stub + render path as the
+        # config gate; just runs the heavier subcommand.
+        run: |
+          example="${{ inputs.example || 'garage-motion' }}"
+          python scripts/check_examples.py --compile "$example"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+# pre-commit hooks for esphome-studio.
+#
+# Opt-in dev-side hooks that run the same gates CI runs, before code
+# leaves your machine. Install with:
+#
+#   pip install pre-commit
+#   pre-commit install --hook-type pre-push
+#
+# The pre-push hook runs `python scripts/check_examples.py` -- the
+# same `esphome config` gate the GHA workflow runs. Skip with
+# `git push --no-verify` when you need to ship a WIP branch fast.
+#
+# Why pre-push and not pre-commit: the gate takes ~30s and shells
+# out to the esphome CLI, which is too heavy for every commit. We
+# want the early signal but not at every save.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: ruff
+        # Match the CI's lint pass; runs at commit time since it's
+        # fast (~1s) and catches things before they hit the gate.
+        args: [--fix]
+
+  - repo: local
+    hooks:
+      - id: esphome-config-gate
+        name: ESPHome config gate (every example through `esphome config`)
+        entry: python scripts/check_examples.py
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true
+        # Requires `pip install 'esphome==2025.12.7'` in the same env.
+        # On Debian-patched setuptools hosts you'll need a venv first;
+        # see CONTRIBUTING.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,13 +85,59 @@ Read the tail output the script prints. Common causes:
   zero-base64 stub; if a new component introduces a new `!secret`
   reference, extend `_stub_value` in `scripts/check_examples.py`.
 
+### Pre-push hook (recommended)
+
+Run the same gate before any push leaves your machine. One-time
+setup:
+
+```sh
+pip install pre-commit
+pre-commit install --hook-type pre-push
+```
+
+After that, `git push` will run
+`python scripts/check_examples.py` automatically and abort the push
+if the gate fails. The hook also runs `ruff` at commit time. Skip a
+single push with `git push --no-verify` when iterating on a WIP
+feature branch.
+
+The pre-commit config lives at `.pre-commit-config.yaml`. Same
+`esphome==2025.12.7` install applies; same Debian-host venv
+caveat above applies if the install trips on `paho-mqtt`.
+
 ### Bumping the pinned ESPHome
 
-The pin is in two places: `.github/workflows/esphome-config.yml`
-(the version we test against) and `README.md` (the version we
-advertise). Bump both in the same diff. The bump PR's burden of
-proof is "the gate passes against the new version" — not "the new
-version is fashionable."
+The pin is in **three** places: `.github/workflows/esphome-config.yml`,
+`.github/workflows/esphome-compile.yml` (nightly compile smoke; see
+below), and `README.md` (the version we advertise). Bump all three
+in the same diff. The bump PR's burden of proof is "the gate passes
+against the new version" — not "the new version is fashionable."
+
+### Nightly compile smoke
+
+`.github/workflows/esphome-compile.yml` runs `esphome compile`
+(not just `config`) against one representative example
+(`garage-motion` by default) every night at 11:00 UTC, plus on
+manual dispatch. It catches things `esphome config` can't:
+
+- a new PlatformIO toolchain release breaks the build
+- a new ESPHome release accepts our YAML but its codegen breaks
+- a `python:3.11-slim` security update knocks out a build dep
+
+Compile is slow (cold-cache: ~10min; warm: ~3min) and the failures
+are upstream churn rather than contributor churn, so it's
+intentionally gated to nightly + manual rather than running on
+every PR. To trigger an ad-hoc compile against a specific example,
+use the **Run workflow** button on the workflow's Actions tab and
+pass the example stem as input.
+
+To run the same compile-smoke locally:
+
+```sh
+python scripts/check_examples.py --compile garage-motion
+```
+
+(First-time toolchain pull will take several minutes.)
 
 ## The schematic gate (lighter)
 
@@ -127,8 +173,8 @@ done
 - [ ] `python -m pytest` passes.
 - [ ] `python -m ruff check .` passes.
 - [ ] `python scripts/check_examples.py` passes against the pinned
-      ESPHome.
+      ESPHome (or the pre-push hook ran on `git push`).
 - [ ] If you added or changed a library entry, an example uses it.
 - [ ] If a golden changed, the regenerated golden is in the same diff.
-- [ ] If you bumped the ESPHome pin, README's "tested against" line
-      moved with it.
+- [ ] If you bumped the ESPHome pin, all three pin sites (config
+      workflow, compile workflow, README) moved together.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Tiers, in priority order:
 
 | Tier | Area | What it does | Verified by |
 |---|---|---|---|
-| **Verified** | ESPHome YAML production | render `design.json` → ESPHome YAML | `esphome config` passes on every bundled example, every PR ([gate](.github/workflows/esphome-config.yml)) |
+| **Verified** | ESPHome YAML production | render `design.json` → ESPHome YAML | `esphome config` passes on every bundled example, every PR ([gate](.github/workflows/esphome-config.yml)); nightly `esphome compile` smoke against a representative example ([compile](.github/workflows/esphome-compile.yml)) |
 | **Verified** | CSP pin solver + compat checker | assign legal pins, surface boot-strap / ADC2-WiFi / voltage / locked-pin issues | unit tests + property checks in `tests/test_pin_solver.py` + `tests/test_compatibility.py` |
 | **Verified** | Fleet handoff | push YAML to `distributed-esphome` ha-addon, optional compile + log relay | round-trip tests in `tests/test_fleet.py` |
 | **Works (lighter checks)** | KiCad schematic | emit a SKiDL Python script the user runs locally | unit tests assert the script is well-formed Python with expected nets; **not** verified by opening in KiCad |
@@ -400,6 +400,7 @@ python -m ruff check .                    # lint
 cd web && npx vitest run                  # ~125 cases, ~5s (vitest + jsdom)
 pip install 'esphome==2025.12.7'
 python scripts/check_examples.py          # the YAML gate -- every example through `esphome config`
+python scripts/check_examples.py --compile garage-motion    # the compile-smoke; slow (~10min cold)
 ```
 
 The `esphome config` gate is the headline test: it renders every
@@ -407,7 +408,21 @@ bundled example through the studio and runs upstream ESPHome's own
 validator against the output. Anything the studio emits has to
 round-trip through that gate, and the GitHub Actions workflow
 ([`.github/workflows/esphome-config.yml`](.github/workflows/esphome-config.yml))
-runs it on every PR.
+runs it on every PR. A nightly compile-smoke
+([`.github/workflows/esphome-compile.yml`](.github/workflows/esphome-compile.yml))
+goes one level deeper -- it runs `esphome compile` against a
+representative example so we catch upstream toolchain / codegen
+regressions even when no code has changed.
+
+To run the same gate before every push, install the pre-commit
+hooks once:
+
+```sh
+pip install pre-commit
+pre-commit install --hook-type pre-push
+```
+
+After that, `git push` runs the gate locally and aborts on failure.
 
 Golden tests pin the generator output for every bundled example.
 Regenerate goldens with the CLI when output legitimately changes;

--- a/scripts/check_examples.py
+++ b/scripts/check_examples.py
@@ -58,7 +58,7 @@ def _write_secrets(yaml_text: str, dest: Path) -> None:
     dest.write_text("\n".join(lines) + ("\n" if lines else ""))
 
 
-def _check_one(example: Path, workdir: Path) -> tuple[bool, str]:
+def _check_one(example: Path, workdir: Path, subcommand: str) -> tuple[bool, str]:
     library = default_library()
     design_dict = json.loads(example.read_text())
     design = Design.model_validate(design_dict)
@@ -72,7 +72,7 @@ def _check_one(example: Path, workdir: Path) -> tuple[bool, str]:
 
     try:
         result = subprocess.run(
-            ["esphome", "config", str(yaml_path)],
+            ["esphome", subcommand, str(yaml_path)],
             capture_output=True,
             text=True,
             cwd=out_dir,
@@ -101,7 +101,17 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="leave the generated YAML + secrets.yaml on disk for inspection",
     )
+    parser.add_argument(
+        "--compile",
+        action="store_true",
+        help=(
+            "run `esphome compile` instead of `esphome config` (slow -- "
+            "first-time toolchain download is several minutes; intended "
+            "for the nightly compile-smoke job, not per-PR)."
+        ),
+    )
     args = parser.parse_args(argv)
+    subcommand = "compile" if args.compile else "config"
 
     if args.names:
         examples = [EXAMPLES_DIR / f"{n}.json" for n in args.names]
@@ -127,7 +137,7 @@ def main(argv: list[str] | None = None) -> int:
 
     failures: list[tuple[str, str]] = []
     for example in examples:
-        ok, detail = _check_one(example, workdir)
+        ok, detail = _check_one(example, workdir, subcommand)
         marker = "PASS" if ok else "FAIL"
         print(f"  {marker}  {example.stem}")
         if not ok:
@@ -144,7 +154,8 @@ def main(argv: list[str] | None = None) -> int:
             print(detail)
         return 1
 
-    print(f"all {len(examples)} examples validate under upstream ESPHome.")
+    verb = "compile" if args.compile else "validate"
+    print(f"all {len(examples)} examples {verb} under upstream ESPHome.")
     return 0
 
 


### PR DESCRIPTION
## Why

Closes the contributor feedback loop around the P1 gate (#11). Two
automation pieces, ordered from cheapest to deepest:

1. **Pre-push hook** — runs the same `esphome config` gate locally
   on every `git push`, ~30s earlier than CI. Cheap to set up
   (`pre-commit install --hook-type pre-push`), opt-in, skippable
   with `--no-verify` for WIP pushes.
2. **Nightly compile smoke** — runs `esphome compile` (not just
   `config`) against a representative example every night, catching
   regressions `config` can't see: PlatformIO toolchain breakage,
   ESPHome codegen vs schema drift, base-image dep-resolution
   failures.

Both stack: pre-push catches obvious issues before they reach CI;
nightly compile catches deeper issues without slowing PR feedback.

## What

### `.pre-commit-config.yaml`
- `ruff` runs at commit time (fast, ~1s, fixes auto-applied)
- `esphome-config-gate` runs at pre-push time as a `language: system`
  local hook — invokes `python scripts/check_examples.py`
- Opt-in: contributors run `pre-commit install --hook-type pre-push`
  once. Documented in CONTRIBUTING.md alongside the venv pitfall
  note for Debian-patched setuptools hosts.

### `.github/workflows/esphome-compile.yml`
- Triggers: `schedule: '0 11 * * *'` (11:00 UTC daily) + manual
  dispatch with an `example` input.
- Steps: install studio + `esphome==2025.12.7` + cache
  `~/.platformio` + `~/.cache/pip` keyed on the ESPHome pin so a
  deliberate version bump invalidates the cache, then run
  `python scripts/check_examples.py --compile <example>`.
- Default example: `garage-motion` (simplest representative; ESP32
  + I2C + arduino framework + a couple of sensors).
- `timeout-minutes: 25` — cold-cache run is ~10-12 min; warm
  ~2-3 min; 25 is the safety margin.

### `scripts/check_examples.py`
- New `--compile` flag swaps the inner subcommand from `esphome
  config` to `esphome compile`. Same secrets-stub + render
  pipeline; just runs the heavier subcommand. Used by both the
  nightly workflow and the local compile-smoke command.
- Output verb adapts: "all N examples compile/validate under
  upstream ESPHome."

### Docs
- `CONTRIBUTING.md`:
  - New **Pre-push hook (recommended)** section.
  - New **Nightly compile smoke** section explaining what it
    catches that `config` can't, why it's nightly + manual rather
    than per-PR, and the local `--compile` command.
  - **Bumping the pinned ESPHome** now lists three pin sites
    (config workflow, compile workflow, README) instead of two.
  - PR checklist last item updated accordingly.
- `README.md`:
  - Status table's Verified-tier YAML row now cites both gates
    (config workflow + nightly compile workflow).
  - Tests section adds the local `--compile` command and the
    `pre-commit install` recipe.

## Verified locally

- `python -m pytest`: **297/297 pass**
- `python -m ruff check .`: clean
- `pre-commit validate-config`: schema OK
- `pre-commit run --all-files --hook-stage pre-commit`: ruff hook
  passes
- The pre-push hook's `esphome-config-gate` invocation is exactly
  the script that's been verified end-to-end on a dev VM
  (13/13 PASS, exit 0)
- The compile workflow itself can't be smoke-tested without the
  `esphome` toolchain pull on this sandbox; first real run is
  whichever fires first — the schedule trigger or a manual
  `workflow_dispatch`. If the cold-cache compile takes more than
  the 25-min timeout, that's the diagnostic signal to bump it
  rather than fail silently.

## Out of scope

- The third option from earlier (auto-fix-on-failure Claude
  workflow that proposes a fix commit when the gate breaks) is
  intentionally not in this PR. It needs more thought on
  prompt-injection / spurious-fix risk and isn't worth building
  until evidence shows the gate fails often enough to justify it.

## Test plan

- [x] `python -m pytest`
- [x] `python -m ruff check .`
- [x] `pre-commit validate-config`
- [x] `pre-commit run --all-files --hook-stage pre-commit` (ruff)
- [ ] CI `esphome-config` round-trip on this PR (validates the
      `--compile` flag didn't regress the default `config` path)
- [ ] First nightly run of `esphome-compile` (or a manual
      `workflow_dispatch` from the Actions tab) — green confirms
      the workflow itself, the cache key, and the
      `garage-motion` representative all work

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_