### PR TITLE
Library batch 2: cse7766 + hlw8012 + esp32_rmt_led_strip + esp8285 board

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ it without a proxy.
 | [`desk-climate.json`](examples/desk-climate.json) | ESP32-C3-DevKitM-1 | Sensirion SHT3x precision temp/humidity over I2C |
 | [`parking-distance.json`](examples/parking-distance.json) | NodeMCU v2 | VL53L0X laser ToF distance (indoor parking-spot indicator) |
 | [`keypad.json`](examples/keypad.json) | WeMos D1 Mini | 8 buttons read through a PCF8574 GPIO expander over I2C |
+| [`smart-plug.json`](wirestudio/examples/smart-plug.json) | ESP8285 1MB | Athom-style smart plug — relay + button + CSE7766 AC power metering over UART 4800 8E1 |
+| [`smart-plug-v1.json`](wirestudio/examples/smart-plug-v1.json) | ESP8285 1MB | Older Athom v1 / Sonoff POW R1 plug — same topology with the HLW8012 / BL0937 3-pin pulse meter |
+| [`desk-matrix.json`](wirestudio/examples/desk-matrix.json) | ESP32-DevKitC | 8x8 WS2812 matrix driven by the ESP32 RMT peripheral (no bit-banging) |
 
 Generated artifacts for each are pinned as goldens in
 [`tests/golden/`](tests/golden/).
@@ -298,6 +301,7 @@ Currently shipped:
 - `wemos-d1-mini` — WeMos D1 Mini (ESP-12F module, ESP8266)
 - `nodemcu-v2` — NodeMCU v2 (ESP-12E/F module, ESP8266, breaks out RX/TX/MISO/MOSI as D9-D12)
 - `esp01_1m` — ESP-01S 1MB module / Sonoff Basic-class devices
+- `esp8285-1m` — Generic ESP8285 1MB SoC (Athom / Sonoff Basic R3+ / Tuya smart plugs)
 
 **Components** (`library/components/`)
 
@@ -358,11 +362,16 @@ _Generic IO:_
 - `pulse_counter` — pulse counter / tachometer (RPM, flow, energy meters)
 
 _Light / audio / camera:_
-- `ws2812b` — WS2812B / SK6812 addressable RGB LED (1-wire NeoPixel)
+- `ws2812b` — WS2812B / SK6812 addressable RGB LED (1-wire NeoPixel; bit-banged or ESP8266-DMA)
+- `esp32_rmt_led_strip` — same WS2812 / SK6812 silicon, ESP32 RMT-driven (preferred on ESP32 / S2 / S3 / C3)
 - `apa102` — APA102 / SK9822 addressable RGB strip (DotStar, SPI-style)
 - `max98357a` — Maxim Class-D mono I2S amp + DAC
 - `rtttl` — piezo buzzer + RTTTL melody player (PWM output)
 - `esp32_camera` — ESP32 OV2640 / OV7670 / OV5640 camera
+
+_Power metering:_
+- `cse7766` — Chipsea AC voltage / current / power / energy over UART 4800 8E1 (Athom v2/c3 + Sonoff plugs)
+- `hlw8012` — HLW8012 / BL0937 / CSE7759 AC power meter via 3-pin pulse interface (older Athom v1 + Sonoff POW R1)
 
 _Location:_
 - `uart_gps` — generic UART GPS module (NEO-6M / NEO-8M)

--- a/tests/golden/desk-matrix.txt
+++ b/tests/golden/desk-matrix.txt
@@ -1,0 +1,24 @@
++-----------------------------------------------------------------------------------------------------------------------+
+|  ESP32-DevKitC-V4  ---  desk-matrix                                                                                   |
++-----------------------------------------------------------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                                                                  |
+|                                                                                                                       |
+|  matrix  [ESP32 RMT-driven addressable LED strip (WS2812 / SK6812)]  -- Desk matrix                                   |
+|    VCC   -> rail 5V                                                                                                   |
+|    GND   -> rail GND                                                                                                  |
+|    DIN   -> GPIO13                                                                                                    |
+|                                                                                                                       |
+|  Passives:                                                                                                            |
+|    c1: 1000uF capacitor, matrix.VCC  <->  GND   (bulk decoupling for 64-LED current spikes)                           |
+|    r1: 330ohm resistor, matrix.DIN  <->  GPIO13   (series resistor on data line; tames overshoot at the first pixel)  |
+|                                                                                                                       |
+|  BOM:                                                                                                                 |
+|    - ESP32-DevKitC-V4                                                                                                 |
+|    - ESP32 RMT-driven addressable LED strip (WS2812 / SK6812)  (matrix)                                               |
+|    - 1x 1000uF capacitor                                                                                              |
+|    - 1x 330ohm resistor                                                                                               |
+|                                                                                                                       |
+|  Power: ~20mA typical, ~60mA peak (budget 4000mA)  OK                                                                 |
+|                                                                                                                       |
+|  Warnings: none                                                                                                       |
++-----------------------------------------------------------------------------------------------------------------------+

--- a/tests/golden/desk-matrix.yaml
+++ b/tests/golden/desk-matrix.yaml
@@ -1,0 +1,24 @@
+esphome:
+  name: desk-matrix
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+captive_portal: {}
+light:
+- platform: esp32_rmt_led_strip
+  rgb_order: GRB
+  pin: GPIO13
+  num_leds: 64
+  chipset: WS2812
+  name: Desk matrix
+  id: matrix

--- a/tests/golden/smart-plug-v1.txt
+++ b/tests/golden/smart-plug-v1.txt
@@ -1,0 +1,32 @@
++----------------------------------------------------------------------------------------+
+|  Generic ESP8285 1MB module (Athom / Sonoff Basic R3 / Tuya plug)  ---  smart-plug-v1  |
++----------------------------------------------------------------------------------------+
+|  Rails: MAINS, 5V, 3V3, GND                                                            |
+|                                                                                        |
+|  meter  [HLW8012 / BL0937 AC power meter (3-pin pulse output)]  -- Plug                |
+|    VCC   -> rail 5V                                                                    |
+|    GND   -> rail GND                                                                   |
+|    SEL   -> GPIO5                                                                      |
+|    CF    -> GPIO4                                                                      |
+|    CF1   -> GPIO14                                                                     |
+|                                                                                        |
+|  relay  [Generic GPIO switch / relay output]  -- Plug relay                            |
+|    OUT   -> GPIO12                                                                     |
+|                                                                                        |
+|  btn  [Generic GPIO binary sensor]  -- Plug button                                     |
+|    IN    -> GPIO0                                                                      |
+|                                                                                        |
+|  Passives:                                                                             |
+|    c1: 100nF capacitor, meter.VCC  <->  GND   (decoupling hlw8012)                     |
+|                                                                                        |
+|  BOM:                                                                                  |
+|    - Generic ESP8285 1MB module (Athom / Sonoff Basic R3 / Tuya plug)                  |
+|    - HLW8012 / BL0937 AC power meter (3-pin pulse output)  (meter)                     |
+|    - Generic GPIO switch / relay output  (relay)                                       |
+|    - Generic GPIO binary sensor  (btn)                                                 |
+|    - 1x 100nF capacitor                                                                |
+|                                                                                        |
+|  Power: ~5mA typical, ~15mA peak (budget 200mA)  OK                                    |
+|                                                                                        |
+|  Warnings: none                                                                        |
++----------------------------------------------------------------------------------------+

--- a/tests/golden/smart-plug-v1.yaml
+++ b/tests/golden/smart-plug-v1.yaml
@@ -1,0 +1,43 @@
+esphome:
+  name: smart-plug-v1
+esp8266:
+  board: esp8285
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+captive_portal: {}
+sensor:
+- platform: hlw8012
+  sel_pin:
+    number: GPIO5
+    inverted: true
+  cf_pin: GPIO4
+  cf1_pin: GPIO14
+  update_interval: 30s
+  model: BL0937
+  current_resistor: 0.001 ohm
+  voltage_divider: 2351
+  current:
+    name: Plug Current
+  voltage:
+    name: Plug Voltage
+  power:
+    name: Plug Power
+  energy:
+    name: Plug Energy
+switch:
+- platform: gpio
+  pin: GPIO12
+  name: Plug relay
+  id: relay
+binary_sensor:
+- platform: gpio
+  pin: GPIO0
+  name: Plug button
+  id: btn

--- a/tests/golden/smart-plug.txt
+++ b/tests/golden/smart-plug.txt
@@ -1,0 +1,32 @@
++-------------------------------------------------------------------------------------------------------------------+
+|  Generic ESP8285 1MB module (Athom / Sonoff Basic R3 / Tuya plug)  ---  smart-plug                                |
++-------------------------------------------------------------------------------------------------------------------+
+|  Rails: MAINS, 5V, 3V3, GND                                                                                       |
+|                                                                                                                   |
+|  meter  [Chipsea CSE7766 AC power meter (UART, 4800 baud, EVEN parity)]  -- Plug                                  |
+|    VCC   -> rail 3V3                                                                                              |
+|    GND   -> rail GND                                                                                              |
+|    TX    -> plug_uart (GPIO3)                                                                                     |
+|                                                                                                                   |
+|  relay  [Generic GPIO switch / relay output]  -- Plug relay                                                       |
+|    OUT   -> GPIO12                                                                                                |
+|                                                                                                                   |
+|  btn  [Generic GPIO binary sensor]  -- Plug button                                                                |
+|    IN    -> GPIO0                                                                                                 |
+|                                                                                                                   |
+|  Passives:                                                                                                        |
+|    c1: 100nF capacitor, meter.VCC  <->  GND   (decoupling cse7766)                                                |
+|                                                                                                                   |
+|  BOM:                                                                                                             |
+|    - Generic ESP8285 1MB module (Athom / Sonoff Basic R3 / Tuya plug)                                             |
+|    - Chipsea CSE7766 AC power meter (UART, 4800 baud, EVEN parity)  (meter)                                       |
+|    - Generic GPIO switch / relay output  (relay)                                                                  |
+|    - Generic GPIO binary sensor  (btn)                                                                            |
+|    - 1x 100nF capacitor                                                                                           |
+|                                                                                                                   |
+|  Power: ~5mA typical, ~15mA peak (budget 200mA)  OK                                                               |
+|                                                                                                                   |
+|  Warnings:                                                                                                        |
+|    [warn] logger_baud_collision: Disable the ESPHome serial logger or move it off UART0 -- GPIO3 is owned by the  |
+|                                  CSE7766 4800-baud stream.                                                        |
++-------------------------------------------------------------------------------------------------------------------+

--- a/tests/golden/smart-plug.yaml
+++ b/tests/golden/smart-plug.yaml
@@ -1,0 +1,46 @@
+esphome:
+  name: smart-plug
+esp8266:
+  board: esp8285
+logger:
+  baud_rate: 0
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+captive_portal: {}
+uart:
+- id: plug_uart
+  rx_pin: GPIO3
+  tx_pin: GPIO1
+  baud_rate: 4800
+  parity: EVEN
+sensor:
+- platform: cse7766
+  uart_id: plug_uart
+  current:
+    name: Plug Current
+  voltage:
+    name: Plug Voltage
+  power:
+    name: Plug Power
+  energy:
+    name: Plug Energy
+  apparent_power:
+    name: Plug Apparent Power
+  power_factor:
+    name: Plug Power Factor
+switch:
+- platform: gpio
+  pin: GPIO12
+  name: Plug relay
+  id: relay
+binary_sensor:
+- platform: gpio
+  pin: GPIO0
+  name: Plug button
+  id: btn

--- a/wirestudio/examples/desk-matrix.json
+++ b/wirestudio/examples/desk-matrix.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "0.1",
+  "id": "desk-matrix",
+  "name": "Desk LED matrix (ESP32 RMT-driven WS2812)",
+  "description": "ESP32-DevKitC driving an 8x8 (64 LEDs) WS2812 matrix via the chip's RMT peripheral. Strictly preferred over the bit-banged neopixelbus driver on ESP32 hardware: doesn't disable interrupts, doesn't fight WiFi, hits frame rates the bit-banger can't.",
+  "created_at": "2026-05-06T00:00:00Z",
+  "updated_at": "2026-05-06T00:00:00Z",
+
+  "board": {
+    "library_id": "esp32-devkitc-v4",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117",
+    "budget_ma": 4000
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "drive 64 WS2812 LEDs at full frame rate" },
+    { "id": "r2", "kind": "constraint",  "text": "use ESP32 RMT (not bit-banged neopixelbus) so WiFi + LED rendering coexist cleanly" },
+    { "id": "r3", "kind": "constraint",  "text": "8x8 matrix at full white peaks at ~3.8A; budget the supply accordingly" }
+  ],
+
+  "components": [
+    {
+      "id": "matrix",
+      "library_id": "esp32_rmt_led_strip",
+      "label": "Desk matrix",
+      "params": {
+        "rgb_order": "GRB",
+        "num_leds": 64,
+        "chipset": "WS2812"
+      }
+    }
+  ],
+
+  "buses": [],
+
+  "connections": [
+    { "component_id": "matrix", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "matrix", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "matrix", "pin_role": "DIN", "target": { "kind": "gpio", "pin": "GPIO13" } }
+  ],
+
+  "passives": [
+    { "id": "c1", "kind": "capacitor", "value": "1000uF",
+      "between": ["matrix.VCC", "GND"], "purpose": "bulk decoupling for 64-LED current spikes" },
+    { "id": "r1", "kind": "resistor", "value": "330ohm",
+      "between": ["matrix.DIN", "GPIO13"], "purpose": "series resistor on data line; tames overshoot at the first pixel" }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "captive_portal": {},
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "desk-matrix",
+    "tags": ["indoor", "light", "matrix"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/examples/smart-plug-v1.json
+++ b/wirestudio/examples/smart-plug-v1.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "0.1",
+  "id": "smart-plug-v1",
+  "name": "Athom v1 / Sonoff POW R1 smart plug (HLW8012)",
+  "description": "ESP8285 1MB module with the older HLW8012 / BL0937 power-meter chip -- three pulse outputs (SEL drives the chip's mode, CF + CF1 carry the pulse rates back to the MCU). Same physical plug topology as smart-plug.json but the cse7766 UART is replaced by the HLW8012 multiplexed-pulse interface.",
+  "created_at": "2026-05-06T00:00:00Z",
+  "updated_at": "2026-05-06T00:00:00Z",
+
+  "board": {
+    "library_id": "esp8285-1m",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "ac-mains",
+    "rail_voltage_v": 230.0,
+    "regulator": "onboard-acdc-3v3",
+    "budget_ma": 200
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "drive the load relay via GPIO12" },
+    { "id": "r2", "kind": "capability", "text": "publish AC metering via the older HLW8012 / BL0937 chip (3 pulse pins)" },
+    { "id": "r3", "kind": "capability", "text": "expose the front button as a binary_sensor" },
+    { "id": "r4", "kind": "constraint", "text": "calibration values (current_resistor, voltage_divider) are stock Athom v1 defaults; tweak per-board for accuracy" }
+  ],
+
+  "components": [
+    {
+      "id": "meter",
+      "library_id": "hlw8012",
+      "label": "Plug",
+      "params": { "model": "BL0937", "update_interval": "30s" }
+    },
+    {
+      "id": "relay",
+      "library_id": "gpio_output",
+      "label": "Plug relay",
+      "params": {}
+    },
+    {
+      "id": "btn",
+      "library_id": "gpio_input",
+      "label": "Plug button",
+      "params": {}
+    }
+  ],
+
+  "buses": [],
+
+  "connections": [
+    { "component_id": "meter", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "meter", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "meter", "pin_role": "SEL", "target": { "kind": "gpio", "pin": "GPIO5" } },
+    { "component_id": "meter", "pin_role": "CF",  "target": { "kind": "gpio", "pin": "GPIO4" } },
+    { "component_id": "meter", "pin_role": "CF1", "target": { "kind": "gpio", "pin": "GPIO14" } },
+
+    { "component_id": "relay", "pin_role": "OUT", "target": { "kind": "gpio", "pin": "GPIO12" } },
+    { "component_id": "btn",   "pin_role": "IN",  "target": { "kind": "gpio", "pin": "GPIO0" } }
+  ],
+
+  "passives": [
+    { "id": "c1", "kind": "capacitor", "value": "100nF",
+      "between": ["meter.VCC", "GND"], "purpose": "decoupling hlw8012" }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "captive_portal": {},
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "smart-plug-v1",
+    "tags": ["plug", "power", "legacy"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/examples/smart-plug.json
+++ b/wirestudio/examples/smart-plug.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": "0.1",
+  "id": "smart-plug",
+  "name": "Athom-style smart plug (CSE7766 power metering)",
+  "description": "ESP8285 1MB module wired the way Athom / Sonoff Basic R3+ smart plugs are: GPIO12 drives the relay coil, GPIO13 is the active-low status LED, GPIO0 is the front button, and the CSE7766 streams AC voltage/current/power/energy into UART RX (GPIO3) at 4800 8E1.",
+  "created_at": "2026-05-06T00:00:00Z",
+  "updated_at": "2026-05-06T00:00:00Z",
+
+  "board": {
+    "library_id": "esp8285-1m",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "ac-mains",
+    "rail_voltage_v": 230.0,
+    "regulator": "onboard-acdc-3v3",
+    "budget_ma": 200
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "drive the load relay via GPIO12 with HA-controllable state" },
+    { "id": "r2", "kind": "capability", "text": "publish AC power metering (voltage / current / power / energy)" },
+    { "id": "r3", "kind": "capability", "text": "expose the front button as a binary_sensor + the status LED" },
+    { "id": "r4", "kind": "constraint",  "text": "ESPHome logger must NOT use UART0 because GPIO3 (RX) is wired to the CSE7766 stream" }
+  ],
+
+  "components": [
+    {
+      "id": "meter",
+      "library_id": "cse7766",
+      "label": "Plug",
+      "params": {}
+    },
+    {
+      "id": "relay",
+      "library_id": "gpio_output",
+      "label": "Plug relay",
+      "params": {}
+    },
+    {
+      "id": "btn",
+      "library_id": "gpio_input",
+      "label": "Plug button",
+      "params": {}
+    }
+  ],
+
+  "buses": [
+    { "id": "plug_uart", "type": "uart", "rx": "GPIO3", "tx": "GPIO1", "baud_rate": 4800, "parity": "EVEN" }
+  ],
+
+  "connections": [
+    { "component_id": "meter", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "meter", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "meter", "pin_role": "TX",  "target": { "kind": "bus",  "bus_id": "plug_uart" } },
+
+    { "component_id": "relay", "pin_role": "OUT", "target": { "kind": "gpio", "pin": "GPIO12" } },
+    { "component_id": "btn",   "pin_role": "IN",  "target": { "kind": "gpio", "pin": "GPIO0" } }
+  ],
+
+  "passives": [
+    { "id": "c1", "kind": "capacitor", "value": "100nF",
+      "between": ["meter.VCC", "GND"], "purpose": "decoupling cse7766" }
+  ],
+
+  "warnings": [
+    { "level": "warn", "code": "logger_baud_collision",
+      "text": "Disable the ESPHome serial logger or move it off UART0 -- GPIO3 is owned by the CSE7766 4800-baud stream." }
+  ],
+
+  "esphome_extras": {
+    "captive_portal": {},
+    "logger": { "baud_rate": 0 }
+  },
+
+  "fleet": {
+    "device_name": "smart-plug",
+    "tags": ["plug", "power"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -220,6 +220,8 @@ def build_yaml_dict(design: Design, library: Library) -> dict[str, Any]:
                 uart_entry["tx_pin"] = bus.tx
             if bus.baud_rate:
                 uart_entry["baud_rate"] = bus.baud_rate
+            if bus.parity:
+                uart_entry["parity"] = bus.parity
             out.setdefault("uart", []).append(uart_entry)
         elif bus.type == "1wire":
             # Single-pin bus. ESPHome's `one_wire:` block lists each

--- a/wirestudio/library/boards/esp8285-1m.yaml
+++ b/wirestudio/library/boards/esp8285-1m.yaml
@@ -1,0 +1,45 @@
+id: esp8285-1m
+name: Generic ESP8285 1MB module (Athom / Sonoff Basic R3 / Tuya plug)
+mcu: esp8266
+chip_variant: esp8266
+framework: arduino
+platformio_board: esp8285
+flash_size_mb: 1
+
+rails:
+  - {name: "MAINS",  voltage: 230.0, source: external}
+  - {name: "5V",  voltage: 5.0, source: onboard_psu}
+  - {name: "3V3", voltage: 3.3, source: onboard_regulator}
+  - {name: "GND", voltage: 0.0}
+
+# The ESP8285 is an ESP8266 with 1 MB flash baked into the SoC, used in
+# basically every cheap smart plug / inline switch / relay module you'll
+# meet (Athom, Sonoff Basic R3+, Kogan, Smartape). Pinout is the bare
+# ESP8266 minus the external flash pins. Conventional wiring across the
+# Athom / Sonoff plug ecosystem:
+#   GPIO0  = button (boot strap, active-low, pulls high through a 10k)
+#   GPIO12 = relay coil drive
+#   GPIO13 = status LED (active-low; blue on Athom, green on Sonoff)
+#   GPIO1  = serial TX (free for cse7766/hlw8012 if you disable logger)
+#   GPIO3  = UART RX -- this is where cse7766 streams its 4800-baud frames
+# Designs override these with explicit pin connections in design.json;
+# the entries here are what gpio_capabilities should warn about.
+gpio_capabilities:
+  GPIO0:  [gpio, strap, button, boot_high, pull_up_external]
+  GPIO1:  [gpio, uart_tx, serial_tx]
+  GPIO2:  [gpio, strap, builtin_led, boot_high, pull_up_external]
+  GPIO3:  [gpio, uart_rx, serial_rx]
+  GPIO4:  [gpio, i2c_sda]
+  GPIO5:  [gpio, i2c_scl]
+  GPIO12: [gpio]
+  GPIO13: [gpio]
+  GPIO14: [gpio]
+  GPIO15: [gpio, strap, boot_low, pull_down_external]
+  GPIO16: [gpio, no_pwm, no_i2c, no_interrupt]
+
+# KiCad symbol mapping. ESP8285 shares the ESP-12 family footprint;
+# the SMD module form factor is what actually solders onto plug PCBs.
+kicad:
+  symbol_lib: RF_Module
+  symbol: ESP-12E
+  value: ESP8285

--- a/wirestudio/library/components/cse7766.yaml
+++ b/wirestudio/library/components/cse7766.yaml
@@ -1,0 +1,58 @@
+id: cse7766
+name: Chipsea CSE7766 AC power meter (UART, 4800 baud, EVEN parity)
+category: sensor
+use_cases: [power_metering, ac_voltage, ac_current, energy, smart_plug]
+aliases: ["sonoff_pow", "athom_v2", "v9821", "bl0937_uart"]
+
+electrical:
+  vcc_min: 3.3
+  vcc_max: 5.0
+  current_ma_typical: 5
+  current_ma_peak: 15
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    # The CSE7766 sends AC measurements one-way at 4800 8E1; the MCU only
+    # listens. So the module's TX -> MCU RX. There is no MCU-to-module
+    # data path on this chip.
+    - {role: TX, kind: uart_tx, voltage: 3.3}
+  passives:
+    # The chip itself is on the high-voltage side via current shunt + voltage
+    # divider; the only LV decoupling our library cares about is on VCC.
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [uart]
+  yaml_template: |
+    sensor:
+      - platform: cse7766
+        uart_id: {{ bus.id }}
+        current:
+          name: "{{ label }} Current"
+        voltage:
+          name: "{{ label }} Voltage"
+        power:
+          name: "{{ label }} Power"
+        energy:
+          name: "{{ label }} Energy"
+        apparent_power:
+          name: "{{ label }} Apparent Power"
+        power_factor:
+          name: "{{ label }} Power Factor"
+
+params_schema: {}
+
+notes: |
+  AC power-metering IC inside Athom / Sonoff smart plugs (v2 / c3 era) and
+  the V9821-clone modules. Streams measurements one-way over UART at
+  4800 8E1; bind the host UART to those pins + parity. The chip pushes
+  values on its own cadence -- there's no `update_interval`, the sub-
+  sensors update whenever a fresh frame lands. The chip is on the mains
+  side -- *do not poke at the high-voltage pads if the plug is plugged
+  in.*
+# KiCad symbol mapping. CSE7766 isn't in stock KiCad libs; use a generic
+# 4-pin header for the LV side breakout.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  value: CSE7766

--- a/wirestudio/library/components/esp32_rmt_led_strip.yaml
+++ b/wirestudio/library/components/esp32_rmt_led_strip.yaml
@@ -1,0 +1,59 @@
+id: esp32_rmt_led_strip
+name: ESP32 RMT-driven addressable LED strip (WS2812 / SK6812)
+category: light
+use_cases: [indicator, status_led, ambient, matrix, pixel_strip]
+aliases: ["esp32_rmt", "ws2812_rmt", "sk6812_rmt", "neopixel_rmt"]
+
+electrical:
+  vcc_min: 3.5
+  vcc_max: 5.3
+  current_ma_typical: 20
+  current_ma_peak: 60
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - {role: DIN, kind: digital_in, voltage: 5.0}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: []
+  yaml_template: |
+    light:
+      - platform: esp32_rmt_led_strip
+        rgb_order: {{ params.rgb_order | default('GRB') }}
+        pin: {{ pins.DIN | tojson }}
+        num_leds: {{ params.num_leds | default(1) }}
+        chipset: {{ params.chipset | default('WS2812') }}
+        name: "{{ label }}"
+        id: {{ id }}
+
+params_schema:
+  rgb_order:
+    type: string
+    enum: ["RGB", "RBG", "GRB", "GBR", "BRG", "BGR"]
+    default: "GRB"
+  num_leds:
+    type: integer
+    default: 1
+    minimum: 1
+  chipset:
+    type: string
+    enum: ["WS2812", "SK6812", "WS2811", "SM16703", "SM16704"]
+    default: "WS2812"
+
+notes: |
+  ESP32-only LED-strip driver that uses the chip's RMT peripheral for
+  precise WS2812 / SK6812 timing without bit-banging. Strictly preferred
+  over the bit-banged `ws2812b` (neopixelbus) component on ESP32 / S2 / S3
+  / C3 hardware -- it doesn't disable interrupts, doesn't fight WiFi, and
+  hits frame rates the bit-banger can't. Same electrical envelope as
+  ws2812b: budget ~60mA per LED at full white, add a 300-500ohm series
+  resistor on DIN and a 1000uF bulk cap across VCC/GND for strips >8 LEDs.
+# KiCad symbol mapping. Matches ws2812b -- the silicon is identical;
+# only the host driver changes.
+kicad:
+  symbol_lib: LED
+  symbol: WS2812B
+  pin_map:
+    VCC: VDD

--- a/wirestudio/library/components/hlw8012.yaml
+++ b/wirestudio/library/components/hlw8012.yaml
@@ -1,0 +1,79 @@
+id: hlw8012
+name: HLW8012 / BL0937 AC power meter (3-pin pulse output)
+category: sensor
+use_cases: [power_metering, ac_voltage, ac_current, energy, smart_plug]
+aliases: ["bl0937", "athom_v1"]
+
+electrical:
+  vcc_min: 4.5
+  vcc_max: 5.5
+  current_ma_typical: 5
+  current_ma_peak: 15
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    # HLW8012 / BL0937 multiplex voltage + current measurements through
+    # two pulse-frequency outputs (CF, CF1) and one selector input (SEL).
+    # The MCU drives SEL to switch CF1 between voltage and current modes,
+    # and reads pulse rates on CF + CF1 -- no UART, no I2C.
+    - {role: SEL, kind: digital_in,  voltage: 3.3}
+    - {role: CF,  kind: digital_out, voltage: 3.3}
+    - {role: CF1, kind: digital_out, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: []
+  yaml_template: |
+    sensor:
+      - platform: hlw8012
+        sel_pin:
+          number: {{ pins.SEL | tojson }}
+          inverted: true
+        cf_pin: {{ pins.CF | tojson }}
+        cf1_pin: {{ pins.CF1 | tojson }}
+        update_interval: {{ params.update_interval | default('30s') }}
+        model: {{ params.model | default('HLW8012') }}
+        current_resistor: {{ params.current_resistor | default('0.001 ohm') | tojson }}
+        voltage_divider: {{ params.voltage_divider | default(2351) }}
+        current:
+          name: "{{ label }} Current"
+        voltage:
+          name: "{{ label }} Voltage"
+        power:
+          name: "{{ label }} Power"
+        energy:
+          name: "{{ label }} Energy"
+
+params_schema:
+  update_interval:
+    type: string
+    default: "30s"
+  model:
+    type: string
+    enum: ["HLW8012", "BL0937", "CSE7759"]
+    default: "HLW8012"
+    description: "BL0937 is the cost-down clone in older Athom plugs; CSE7759 is the same chip rebadged."
+  current_resistor:
+    type: string
+    default: "0.001 ohm"
+    description: "Shunt resistor on the current path. Most plug PCBs use 1 milliohm; check the silkscreen."
+  voltage_divider:
+    type: number
+    default: 2351
+    description: "Resistor-divider ratio on the voltage path. 2351 is the Athom/Sonoff stock value; tweak after measuring against a known reference."
+
+notes: |
+  AC power-metering IC in older Athom v1 / Sonoff POW R1 / Smartape
+  power-strip generations -- predates the cse7766 UART chip. Three GPIOs
+  (SEL, CF, CF1) instead of UART. Calibration is per-board: the
+  current_resistor + voltage_divider params reflect the Athom/Sonoff
+  stock values; cross-check against a known reference if absolute
+  accuracy matters. *Do not poke at the high-voltage pads while the plug
+  is plugged in.*
+# KiCad symbol mapping. HLW8012/BL0937 isn't in stock KiCad libs; use a
+# generic 5-pin header for the LV side breakout (VCC, GND, SEL, CF, CF1).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x05
+  value: HLW8012

--- a/wirestudio/model.py
+++ b/wirestudio/model.py
@@ -56,6 +56,9 @@ class Bus(_Strict):
     # 1-wire data pin. Single-wire bus, so the bus carries one pin field
     # rather than the multi-pin sets the synchronous buses use.
     pin: Optional[str] = None
+    # UART parity. ESPHome's cse7766 requires EVEN; most other UART
+    # peripherals are happy with NONE (the default if omitted).
+    parity: Optional[Literal["NONE", "EVEN", "ODD"]] = None
 
 
 class RailTarget(_Strict):


### PR DESCRIPTION
## Why

Demand-driven library expansion seeded by surveying [`jesserockz/esphome-configs`](https://github.com/jesserockz/esphome-configs) — Jesse Rocks's collection of personal ESPHome device configs. Picked the 3 highest-frequency components his configs use that we don't yet have, plus the board they all run on:

| New | Used by | Why |
|---|---|---|
| `cse7766` | Athom v2/c3 + Sonoff Basic R3+ smart plugs (5+ configs) | Modern UART power meter — replaces HLW8012 in nearly every plug since ~2022 |
| `hlw8012` | Athom v1 + Sonoff POW R1 (2 configs) | Older 3-pin pulse-output AC meter; pairs with cse7766 for full plug coverage |
| `esp32_rmt_led_strip` | desk-display matrix + localdeck (2+ configs) | ESP32 RMT-driven WS2812 / SK6812. Strictly preferred over the bit-banged `ws2812b` on ESP32 / S2 / S3 / C3 — doesn't disable interrupts, doesn't fight WiFi |
| `esp8285-1m` board | Every smart plug (Athom / Sonoff / Kogan / Smartape) | The actual SoC inside cheap smart plugs — distinct from `esp01_1m` which is an ESP-01S module |

Following the rule from CONTRIBUTING.md: *your component is supported only when an example using it round-trips through `esphome config`.*

## What

### Library entries (4 new)
- `wirestudio/library/components/cse7766.yaml`
- `wirestudio/library/components/hlw8012.yaml`
- `wirestudio/library/components/esp32_rmt_led_strip.yaml`
- `wirestudio/library/boards/esp8285-1m.yaml`

### Generator updates
- `wirestudio/model.py`: new `Bus.parity` optional field (`NONE` / `EVEN` / `ODD`). The cse7766 ESPHome component validates that its UART has `parity: EVEN` set; without this the gate rejects.
- `wirestudio/generate/yaml_gen.py`: emits `parity: <value>` in the uart block when set, omits otherwise. Pre-existing UART buses unchanged.

### Examples (3 new)
- `wirestudio/examples/smart-plug.json` — ESP8285 + cse7766 + relay + button. Logger `baud_rate: 0` because GPIO3 (RX) is owned by the cse7766 4800-baud stream.
- `wirestudio/examples/smart-plug-v1.json` — ESP8285 + hlw8012 + relay + button. No UART (3 GPIO pulse interface). Calibration params (`current_resistor`, `voltage_divider`) default to Athom v1 / Sonoff POW R1 stock values.
- `wirestudio/examples/desk-matrix.json` — ESP32-DevKitC + 64-LED WS2812 matrix on the RMT peripheral. Includes the 1000uF bulk cap + 330ohm series-resistor pattern recommended for any strip >8 LEDs.

### Goldens
Six files (`yaml` + `txt` for each new example) under `tests/golden/`.

### README
- New `esp8285-1m` board entry under Boards
- New "Power metering" component group with cse7766 + hlw8012
- `esp32_rmt_led_strip` alongside `ws2812b` under Light/audio
- Three new rows in the Examples table

## Verified locally

- `python -m pytest`: **299/299 pass**
- `python -m ruff check .`: clean
- `python scripts/check_examples.py` against ESPHome **2025.12.7** (in venv): **20/20 examples PASS, exit 0** (the 17 pre-existing examples + the 3 new)

Two real schema-validation gotchas the gate caught and I fixed before pushing:
- `cse7766` doesn't accept `update_interval` — it's a streaming sensor; values land per-frame. Removed from the template.
- `esp32_rmt_led_strip`'s `rmt_channel` parameter was dropped in newer ESPHome (it auto-assigns now). Removed from the template + params_schema.

## Out of scope (deferred)

The survey flagged these but each needs more setup than a one-shot example:
- `tuya` MCU bridge — whole vendor class (switches/sensors/numbers/selects/climate/fan all hang off it)
- `modbus_controller` + `sdm_meter` pair — RS485 + a MAX485 transceiver
- `bl0906` — 6-channel energy meter
- `nextion` HMI display

Each is a candidate for batch 3.

## Test plan

- [x] `python -m pytest`
- [x] `python -m ruff check .`
- [x] `python scripts/check_examples.py` against ESPHome 2025.12.7
- [ ] CI `esphome-config` round-trip on this PR
- [ ] CI `build` (multi-arch image)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_