### PR TITLE
Library batch 3: modbus + sdm_meter + bl0906 + nextion + tuya MCU bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ it without a proxy.
 | [`smart-plug.json`](wirestudio/examples/smart-plug.json) | ESP8285 1MB | Athom-style smart plug — relay + button + CSE7766 AC power metering over UART 4800 8E1 |
 | [`smart-plug-v1.json`](wirestudio/examples/smart-plug-v1.json) | ESP8285 1MB | Older Athom v1 / Sonoff POW R1 plug — same topology with the HLW8012 / BL0937 3-pin pulse meter |
 | [`desk-matrix.json`](wirestudio/examples/desk-matrix.json) | ESP32-DevKitC | 8x8 WS2812 matrix driven by the ESP32 RMT peripheral (no bit-banging) |
+| [`rs485-energy.json`](wirestudio/examples/rs485-energy.json) | ESP32-DevKitC-V4 | Eastron SDM230 single-phase energy meter via Modbus RTU (UART2 + MAX485 transceiver, GPIO5 drives DE+RE) |
+| [`bl0906-mainmeter.json`](wirestudio/examples/bl0906-mainmeter.json) | ESP32-DevKitC-V4 | BL0906 6-channel CT-clamp energy monitor over UART2 (Athom EM6-style whole-home sub-metering) |
+| [`nextion-thermostat.json`](wirestudio/examples/nextion-thermostat.json) | ESP32-DevKitC-V4 | Nextion HMI thermostat panel — display on UART2 + SHT3xD temp/humidity on default I2C |
+| [`tuya-smart-plug.json`](wirestudio/examples/tuya-smart-plug.json) | ESP8285 1MB | Tuya-MCU smart plug — relay (DP 1) + power (DP 17) + energy (DP 18) over UART 9600; logger off UART0 |
 
 Generated artifacts for each are pinned as goldens in
 [`tests/golden/`](tests/golden/).
@@ -372,6 +376,14 @@ _Light / audio / camera:_
 _Power metering:_
 - `cse7766` — Chipsea AC voltage / current / power / energy over UART 4800 8E1 (Athom v2/c3 + Sonoff plugs)
 - `hlw8012` — HLW8012 / BL0937 / CSE7759 AC power meter via 3-pin pulse interface (older Athom v1 + Sonoff POW R1)
+- `bl0906` — Belling 6-channel AC energy meter over UART 19200 (Athom EM6 / whole-home sub-metering)
+- `modbus` + `sdm_meter` — Modbus RTU bus (RS485 via MAX485 transceiver) + Eastron SDM120/220/230/630 single/three-phase DIN-rail meter
+
+_Vendor bridges:_
+- `tuya` + `tuya_switch` + `tuya_sensor` — Tuya MCU UART bridge plus per-datapoint switch and sensor platforms (smart plugs / switches / climate gadgets that ship with an ESP8266-class radio talking to a separate Tuya MCU)
+
+_Displays (HMI):_
+- `nextion` — Nextion HMI smart display over UART 9600 (T/K/P series; .tft uploaded separately via Nextion Editor)
 
 _Location:_
 - `uart_gps` — generic UART GPS module (NEO-6M / NEO-8M)

--- a/START.md
+++ b/START.md
@@ -17,6 +17,56 @@ committed and pushed. To pick up where we left off:
 4. `pip install -e .[dev] && cd web && npm install` to get a working
    tree; `python -m pytest -q` and `cd web && npm test` should be green.
 
+**Last shipped (2026-05-09 session).** Architectural pass off the
+back of a Jules-authored review.
+
+- **PR #18 — `Gemini refinements.md`.** External review doc (Jules)
+  flagging async IO, separation-of-concerns, state-management
+  abstraction, agent-streaming readability, CORS/rate-limit gaps,
+  and a five-step bite-size PR plan. Doc only; no code.
+- **PR #19 — Gemini plan, items 1–3 + 5 implemented.**
+  - `_validate_design` helper in `wirestudio/api/app.py` (chosen over
+    a global `@app.exception_handler` deliberately — Gemini's
+    proposal #1's "global handler" variant was rejected as too
+    broad: a top-level `ValueError` handler swallows internal bugs
+    along with route-input failures).
+  - `wirestudio/api/app.py` endpoints migrated to `async def`;
+    `wirestudio/fleet/client.py` rewritten on `httpx.AsyncClient`.
+  - `slowapi` rate limiting on `/agent/turn` + `/agent/stream`;
+    CORS origins now read from `WIRESTUDIO_ALLOWED_ORIGINS`
+    (comma-separated) with the localhost defaults preserved when
+    unset.
+  - `typing.Protocol` interfaces extracted: `DesignStore` in
+    `wirestudio/designs/store.py`, `SessionStore` in
+    `wirestudio/agent/session.py`. **No SQLite implementation
+    yet** — Protocol shipped, alternative backend deferred.
+  - `stream_turn_events` in `wirestudio/agent/agent.py` decomposed
+    into smaller helpers; `run_turn` is now a thin collapsing
+    wrapper over the streaming generator.
+
+**Confirmed already-shipped (corrects an earlier stale "Next up"
+block).** Both 0.5 follow-ons that were queued in the
+2026-05-06 doc are in fact in `main`:
+
+- `POST /agent/stream` SSE endpoint (`wirestudio/api/app.py:709`)
+  yields `tool_use_start` / `tool_result` / `text_delta` /
+  `turn_complete` events from `stream_turn_events`.
+- `recommend` agent tool (`wirestudio/agent/tools.py:193`) plus
+  the deterministic ranker at `wirestudio/recommend/recommender.py`
+  and the `POST /library/recommend` HTTP surface
+  (`app.py:511`).
+
+**`esphome compile` smoke gate is in fact green.** The earlier
+session log called it "never observed." Untrue: the nightly ran
+successfully on 2026-05-07 and 2026-05-08, and a manual
+`workflow_dispatch` on 2026-05-09 (run 25589055836) compiled
+`garage-motion` in 4m17s on warm cache. PlatformIO + ESPHome
+2025.12.7 toolchain + our codegen all hold up. Workflow itself
+emits a Node 20 deprecation warning — not urgent (deadline
+2026-09-16) but worth bumping `actions/checkout@v4` /
+`actions/setup-python@v5` / `actions/cache@v4` next time someone
+touches a workflow file.
+
 **Last shipped (2026-05-06 session).** Wide cluster of work; the
 through-line is "make the studio honest about what's verified" + a
 focused first library expansion. Recent merges to `main`:
@@ -118,15 +168,40 @@ reason to publish to PyPI.
   reveals Schematic / Enclosure / Push-to-fleet / Agent. Reduces
   "AI slop" front-door optics. Not started.
 
-**Next up candidates:**
+**Next up candidates (current ordering, 2026-05-09):**
 
-- Library batch 3 from the survey list above (probably the most
-  obvious continuation — same format as #12 / #17).
-- WebUI basic/advanced mode toggle.
-- A real `esphome compile` smoke run + fix anything that surfaces.
-- Component-coverage matrix script.
-- 1.0 — KiCad PCB layout (reuse the schematic's netlist;
-  Freerouting; Gerber + JLCPCB CPL/BOM).
+1. Library batch 3 from the jesserockz survey: tuya MCU bridge
+   (vendor class — switches/sensors/numbers/selects/climate/fan all
+   hang off it), modbus_controller + sdm_meter (RS485 + MAX485
+   transceiver), bl0906 (6-channel energy meter), nextion HMI
+   display. Same format as #12 / #17. This is now the obvious
+   continuation: the compile gate is proven, so library expansion
+   is end-to-end verified by default.
+2. WebUI basic/advanced mode toggle (verified-tier surface by default;
+   Schematic / Enclosure / Push-to-fleet / Agent behind Advanced).
+3. Component-coverage matrix script — walk goldens, emit a checkbox
+   table of which library entries have a passing example.
+4. **Gemini plan tail (open items from PR #19's review doc):**
+   - SQLite-backed `DesignStore` + `SessionStore` implementations
+     (Protocol abstractions are in; alternative backend isn't).
+   - `Field(description="…")` on `wirestudio.api.schemas` so
+     `/docs` (Swagger UI) is self-documenting without reading
+     source.
+   - Split `docs/DEVELOPMENT.md` out of `README.md` (dev onboarding
+     vs. user-facing pitch).
+   - `print` → `logging` cleanup (audit `wirestudio/api`,
+     `wirestudio/agent`, `wirestudio/fleet`).
+   - Agent failure-mode tests: Anthropic 429 / connection error /
+     mid-stream disconnect coverage in `tests/test_agent.py`.
+   - Ruff cleanup: PR #19 left 21 lint errors (unused
+     `SessionStore` / `DesignStore` imports in tests, E402
+     import-order on `tests/test_fleet.py`'s `pytestmark` line).
+     CI doesn't run ruff; the opt-in pre-commit hook does. Cheap
+     `ruff --fix` + manual E402 reorder.
+   - (Decided against:) global `@app.exception_handler` — see PR #19
+     rationale; helper-function approach is the chosen pattern.
+5. 1.0 — KiCad PCB layout (reuse the schematic's netlist;
+   Freerouting; Gerber + JLCPCB CPL/BOM).
 
 
 **0.9 v2 -- library mapping expansion shipped.** The remaining 20
@@ -874,58 +949,6 @@ The UI-first ordering means 0.5's agent and 0.6's solver each have a
 visible place to land. If the agent lands first (alternative ordering),
 it ships as a CLI/tool-only surface and we re-skin it later — strictly
 worse for the headline feature.
-
-### Next up (queued, not started)
-
-Two small follow-ons to 0.5's agent layer, agreed in the last session:
-
-1. **Streaming agent responses.** Swap `POST /agent/turn` for an SSE
-   variant that emits events as they happen:
-   `tool_use_start { tool, input }`, `tool_result { tool, is_error }`,
-   `text_delta { text }`, then a final `turn_complete { design, usage }`
-   carrying the updated design state. Frontend reads the stream and
-   updates the chat + tool-call UI live; the design swap happens once
-   on the final event so the live YAML/ASCII doesn't churn mid-turn.
-   Improves perceived latency a lot — currently a 4-tool turn looks
-   like a 5-second blank stare.
-
-   Implementation sketch: keep `/agent/turn` for backward-compat,
-   add `POST /agent/stream` (or upgrade `/agent/turn` to also accept
-   `Accept: text/event-stream`). Reuse the manual agentic loop in
-   `wirestudio/agent/agent.py`; just yield events instead of accumulating.
-   Anthropic SDK supports `client.messages.stream(...)` with
-   `get_final_message()` — the per-tool-call dispatch stays the same.
-
-2. **Recommendation mode.** New `recommend(query)` agent tool that
-   takes a capability query (*"motion detection on a battery-powered
-   ESP32"*, *"weather station outdoors"*) and returns ranked component
-   candidates with electrical trade-offs. Pairs naturally with the
-   solver: pick a candidate, add it, solve. Shape:
-
-   ```python
-   {
-       "name": "recommend",
-       "description": "...",
-       "input_schema": {
-           "type": "object",
-           "properties": {
-               "capability": {"type": "string"},
-               "constraints": {"type": "object"},  # power, indoor/outdoor, etc.
-           },
-       },
-   }
-   ```
-
-   The tool implementation is a small ranking function over
-   `library.list_components()`: filter by `use_cases` + `aliases`
-   matching the query; rank by current draw, voltage compatibility,
-   and presence in existing examples (a proxy for "battle-tested").
-
-   v1 should NOT call out to an LLM internally — keep the recommender
-   deterministic and fast. The agent then narrates the options.
-
-Both fit comfortably in one PR. Streaming first (it's the bigger UX
-win); recommend second.
 
 ## Studio web UI (0.3)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,14 @@ dependencies = [
     "fastapi>=0.110",
     "uvicorn[standard]>=0.27",
     "anthropic>=0.40",
+    "httpx>=0.27",
+    "slowapi>=0.1.9",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
     "ruff>=0.4",
-    "httpx>=0.27",
 ]
 
 [project.scripts]

--- a/tests/golden/bl0906-mainmeter.txt
+++ b/tests/golden/bl0906-mainmeter.txt
@@ -1,0 +1,23 @@
++------------------------------------------------------------------------+
+|  ESP32-DevKitC-V4  ---  bl0906-mainmeter                               |
++------------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                   |
+|                                                                        |
+|  em6  [BL0906 6-channel AC energy meter (UART, 19200 baud)]  -- Mains  |
+|    VCC   -> rail 3V3                                                   |
+|    GND   -> rail GND                                                   |
+|    TX    -> em6_uart (GPIO16)                                          |
+|    RX    -> em6_uart (GPIO17)                                          |
+|                                                                        |
+|  Passives:                                                             |
+|    c1: 100nF capacitor, em6.VCC  <->  GND   (decoupling bl0906)        |
+|                                                                        |
+|  BOM:                                                                  |
+|    - ESP32-DevKitC-V4                                                  |
+|    - BL0906 6-channel AC energy meter (UART, 19200 baud)  (em6)        |
+|    - 1x 100nF capacitor                                                |
+|                                                                        |
+|  Power: ~8mA typical, ~20mA peak (budget 500mA)  OK                    |
+|                                                                        |
+|  Warnings: none                                                        |
++------------------------------------------------------------------------+

--- a/tests/golden/bl0906-mainmeter.yaml
+++ b/tests/golden/bl0906-mainmeter.yaml
@@ -1,0 +1,75 @@
+esphome:
+  name: bl0906-mainmeter
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+captive_portal: {}
+uart:
+- id: em6_uart
+  rx_pin: GPIO16
+  tx_pin: GPIO17
+  baud_rate: 19200
+sensor:
+- platform: bl0906
+  uart_id: em6_uart
+  update_interval: 30s
+  voltage:
+    name: Mains Voltage
+  frequency:
+    name: Mains Frequency
+  total_power:
+    name: Mains Total Power
+  total_energy:
+    name: Mains Total Energy
+  channel_1:
+    current:
+      name: Mains Ch1 Current
+    power:
+      name: Mains Ch1 Power
+    energy:
+      name: Mains Ch1 Energy
+  channel_2:
+    current:
+      name: Mains Ch2 Current
+    power:
+      name: Mains Ch2 Power
+    energy:
+      name: Mains Ch2 Energy
+  channel_3:
+    current:
+      name: Mains Ch3 Current
+    power:
+      name: Mains Ch3 Power
+    energy:
+      name: Mains Ch3 Energy
+  channel_4:
+    current:
+      name: Mains Ch4 Current
+    power:
+      name: Mains Ch4 Power
+    energy:
+      name: Mains Ch4 Energy
+  channel_5:
+    current:
+      name: Mains Ch5 Current
+    power:
+      name: Mains Ch5 Power
+    energy:
+      name: Mains Ch5 Energy
+  channel_6:
+    current:
+      name: Mains Ch6 Current
+    power:
+      name: Mains Ch6 Power
+    energy:
+      name: Mains Ch6 Energy

--- a/tests/golden/nextion-thermostat.txt
+++ b/tests/golden/nextion-thermostat.txt
@@ -1,0 +1,36 @@
++----------------------------------------------------------------------------------------------------------------+
+|  ESP32-DevKitC-V4  ---  nextion-thermostat                                                                     |
++----------------------------------------------------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                                                           |
+|                                                                                                                |
+|  screen  [Nextion HMI display (UART, 9600 baud default)]  -- Thermostat                                        |
+|    VCC   -> rail 5V                                                                                            |
+|    GND   -> rail GND                                                                                           |
+|    TX    -> nextion_uart (GPIO16)                                                                              |
+|    RX    -> nextion_uart (GPIO17)                                                                              |
+|                                                                                                                |
+|  th  [Sensirion SHT3x / SHT4x temperature + humidity (I2C)]  -- Room                                           |
+|    VCC   -> rail 3V3                                                                                           |
+|    GND   -> rail GND                                                                                           |
+|    SDA   -> i2c0 (GPIO21)                                                                                      |
+|    SCL   -> i2c0 (GPIO22)                                                                                      |
+|                                                                                                                |
+|  Passives:                                                                                                     |
+|    c1: 100uF capacitor, screen.VCC  <->  GND   (bulk decoupling nextion backlight inrush)                      |
+|    c2: 100nF capacitor, screen.VCC  <->  GND   (decoupling nextion logic)                                      |
+|    c3: 100nF capacitor, th.VCC  <->  GND   (decoupling sht3xd)                                                 |
+|                                                                                                                |
+|  BOM:                                                                                                          |
+|    - ESP32-DevKitC-V4                                                                                          |
+|    - Nextion HMI display (UART, 9600 baud default)  (screen)                                                   |
+|    - Sensirion SHT3x / SHT4x temperature + humidity (I2C)  (th)                                                |
+|    - 1x 100uF capacitor                                                                                        |
+|    - 2x 100nF capacitor                                                                                        |
+|                                                                                                                |
+|  Power: ~90mA typical, ~251mA peak (budget 800mA)  OK                                                          |
+|                                                                                                                |
+|  Warnings:                                                                                                     |
+|    [info] nextion_5v_supply: The Nextion's VCC rides the board's 5V rail (USB) -- a Nextion at full backlight  |
+|                              pulls 200-250mA. Check your USB supply margin or feed the display from a          |
+|                              separate 5V brick if you're also driving WS2812 strips off the same regulator.    |
++----------------------------------------------------------------------------------------------------------------+

--- a/tests/golden/nextion-thermostat.yaml
+++ b/tests/golden/nextion-thermostat.yaml
@@ -1,0 +1,41 @@
+esphome:
+  name: nextion-thermostat
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+captive_portal: {}
+i2c:
+- id: i2c0
+  sda: GPIO21
+  scl: GPIO22
+  frequency: 100kHz
+uart:
+- id: nextion_uart
+  rx_pin: GPIO16
+  tx_pin: GPIO17
+  baud_rate: 9600
+display:
+- platform: nextion
+  id: screen
+  uart_id: nextion_uart
+  update_interval: 10s
+  brightness: 60%
+sensor:
+- platform: sht3xd
+  i2c_id: i2c0
+  address: '0x44'
+  update_interval: 60s
+  temperature:
+    name: Room Temperature
+  humidity:
+    name: Room Humidity

--- a/tests/golden/rs485-energy.txt
+++ b/tests/golden/rs485-energy.txt
@@ -1,0 +1,22 @@
++------------------------------------------------------------------------------------------------------------------------+
+|  ESP32-DevKitC-V4  ---  rs485-energy                                                                                   |
++------------------------------------------------------------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                                                                   |
+|                                                                                                                        |
+|  rs485_bus  [Modbus RTU bus protocol (RS485-over-UART)]  -- RS485 modbus                                               |
+|    UART  -> modbus_uart (uart)                                                                                         |
+|    FLOW  -> GPIO5                                                                                                      |
+|                                                                                                                        |
+|  meter  [Eastron SDM single/three-phase energy meter (Modbus RTU over RS485)]  -- Mains                                |
+|                                                                                                                        |
+|  BOM:                                                                                                                  |
+|    - ESP32-DevKitC-V4                                                                                                  |
+|    - Modbus RTU bus protocol (RS485-over-UART)  (rs485_bus)                                                            |
+|    - Eastron SDM single/three-phase energy meter (Modbus RTU over RS485)  (meter)                                      |
+|                                                                                                                        |
+|  Power: ~0mA typical, ~0mA peak (budget 500mA)  OK                                                                     |
+|                                                                                                                        |
+|  Warnings:                                                                                                             |
+|    [info] rs485_transceiver_required: Wire UART RX/TX through a MAX485 (or equivalent) transceiver: A/B to the SDM230  |
+|                                       terminals 9/10, RO/DI to GPIO16/GPIO17, DE+RE tied together to GPIO5.            |
++------------------------------------------------------------------------------------------------------------------------+

--- a/tests/golden/rs485-energy.yaml
+++ b/tests/golden/rs485-energy.yaml
@@ -1,0 +1,44 @@
+esphome:
+  name: rs485-energy
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+captive_portal: {}
+uart:
+- id: modbus_uart
+  rx_pin: GPIO16
+  tx_pin: GPIO17
+  baud_rate: 9600
+modbus:
+  id: rs485_bus
+  uart_id: modbus_uart
+  flow_control_pin: GPIO5
+  send_wait_time: 200ms
+sensor:
+- platform: sdm_meter
+  modbus_id: rs485_bus
+  address: 1
+  update_interval: 30s
+  phase_a:
+    voltage:
+      name: Mains Phase A Voltage
+    current:
+      name: Mains Phase A Current
+    active_power:
+      name: Mains Phase A Power
+  frequency:
+    name: Mains Frequency
+  import_active_energy:
+    name: Mains Total Import Energy
+  export_active_energy:
+    name: Mains Total Export Energy

--- a/tests/golden/tuya-smart-plug.txt
+++ b/tests/golden/tuya-smart-plug.txt
@@ -1,0 +1,27 @@
++-----------------------------------------------------------------------------------------------------------------+
+|  Generic ESP8285 1MB module (Athom / Sonoff Basic R3 / Tuya plug)  ---  tuya-smart-plug                         |
++-----------------------------------------------------------------------------------------------------------------+
+|  Rails: MAINS, 5V, 3V3, GND                                                                                     |
+|                                                                                                                 |
+|  tuya_mcu  [Tuya MCU bridge (UART, 9600 baud)]  -- Tuya bridge                                                  |
+|    UART  -> tuya_uart (uart)                                                                                    |
+|                                                                                                                 |
+|  relay  [Tuya datapoint switch]  -- Plug relay                                                                  |
+|                                                                                                                 |
+|  watts  [Tuya datapoint sensor]  -- Plug power                                                                  |
+|                                                                                                                 |
+|  kwh  [Tuya datapoint sensor]  -- Plug energy                                                                   |
+|                                                                                                                 |
+|  BOM:                                                                                                           |
+|    - Generic ESP8285 1MB module (Athom / Sonoff Basic R3 / Tuya plug)                                           |
+|    - Tuya MCU bridge (UART, 9600 baud)  (tuya_mcu)                                                              |
+|    - Tuya datapoint switch  (relay)                                                                             |
+|    - Tuya datapoint sensor  (watts)                                                                             |
+|    - Tuya datapoint sensor  (kwh)                                                                               |
+|                                                                                                                 |
+|  Power: ~0mA typical, ~0mA peak (budget 200mA)  OK                                                              |
+|                                                                                                                 |
+|  Warnings:                                                                                                      |
+|    [warn] logger_baud_collision: Disable the ESPHome serial logger (or move it off UART0) -- the Tuya MCU owns  |
+|                                  the 9600-baud UART0 bus.                                                       |
++-----------------------------------------------------------------------------------------------------------------+

--- a/tests/golden/tuya-smart-plug.yaml
+++ b/tests/golden/tuya-smart-plug.yaml
@@ -1,0 +1,48 @@
+esphome:
+  name: tuya-smart-plug
+esp8266:
+  board: esp8285
+logger:
+  baud_rate: 0
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+captive_portal: {}
+uart:
+- id: tuya_uart
+  rx_pin: GPIO3
+  tx_pin: GPIO1
+  baud_rate: 9600
+tuya:
+  id: tuya_mcu
+  uart_id: tuya_uart
+switch:
+- platform: tuya
+  id: relay
+  name: Plug relay
+  tuya_id: tuya_mcu
+  switch_datapoint: 1
+  restore_mode: RESTORE_DEFAULT_OFF
+sensor:
+- platform: tuya
+  id: watts
+  name: Plug power
+  tuya_id: tuya_mcu
+  sensor_datapoint: 17
+  unit_of_measurement: W
+  filters:
+  - multiply: 0.1
+- platform: tuya
+  id: kwh
+  name: Plug energy
+  tuya_id: tuya_mcu
+  sensor_datapoint: 18
+  unit_of_measurement: kWh
+  accuracy_decimals: 2
+  filters:
+  - multiply: 0.01

--- a/wirestudio/examples/bl0906-mainmeter.json
+++ b/wirestudio/examples/bl0906-mainmeter.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "0.1",
+  "id": "bl0906-mainmeter",
+  "name": "BL0906 6-channel mains energy monitor",
+  "description": "ESP32-DevKitC-V4 reading a BL0906 6-channel energy meter (Athom EM6-style) over UART2. Six CT clamps land on channels 1-6; the chip aggregates total power and total energy across all of them.",
+  "created_at": "2026-05-09T00:00:00Z",
+  "updated_at": "2026-05-09T00:00:00Z",
+
+  "board": {
+    "library_id": "esp32-devkitc-v4",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117-3v3",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "publish per-channel current/power/energy from six 2000:1 CT clamps" },
+    { "id": "r2", "kind": "capability", "text": "publish global voltage / frequency / total power / total energy" }
+  ],
+
+  "components": [
+    {
+      "id": "em6",
+      "library_id": "bl0906",
+      "label": "Mains",
+      "params": { "update_interval": "30s" }
+    }
+  ],
+
+  "buses": [
+    { "id": "em6_uart", "type": "uart", "rx": "GPIO16", "tx": "GPIO17", "baud_rate": 19200 }
+  ],
+
+  "connections": [
+    { "component_id": "em6", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "em6", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "em6", "pin_role": "TX",  "target": { "kind": "bus",  "bus_id": "em6_uart" } },
+    { "component_id": "em6", "pin_role": "RX",  "target": { "kind": "bus",  "bus_id": "em6_uart" } }
+  ],
+
+  "passives": [
+    { "id": "c1", "kind": "capacitor", "value": "100nF",
+      "between": ["em6.VCC", "GND"], "purpose": "decoupling bl0906" }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "captive_portal": {}
+  },
+
+  "fleet": {
+    "device_name": "bl0906-mainmeter",
+    "tags": ["energy", "bl0906", "ct-clamp"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/examples/nextion-thermostat.json
+++ b/wirestudio/examples/nextion-thermostat.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": "0.1",
+  "id": "nextion-thermostat",
+  "name": "Nextion HMI thermostat panel",
+  "description": "ESP32-DevKitC-V4 with a Nextion HMI display on UART2 (GPIO16/GPIO17 @ 9600 baud) and an SHT3xD temp/humidity sensor on the board's default I2C. The Nextion's GUI is uploaded separately via the Nextion Editor; this design just feeds it sensor values.",
+  "created_at": "2026-05-09T00:00:00Z",
+  "updated_at": "2026-05-09T00:00:00Z",
+
+  "board": {
+    "library_id": "esp32-devkitc-v4",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117-3v3",
+    "budget_ma": 800
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "drive a Nextion 2.4\"-3.5\" HMI display over UART for thermostat UI" },
+    { "id": "r2", "kind": "capability", "text": "publish room temperature + humidity from an SHT3xD" }
+  ],
+
+  "components": [
+    {
+      "id": "screen",
+      "library_id": "nextion",
+      "label": "Thermostat",
+      "params": { "brightness": "60%", "update_interval": "10s" }
+    },
+    {
+      "id": "th",
+      "library_id": "sht3xd",
+      "label": "Room",
+      "params": {}
+    }
+  ],
+
+  "buses": [
+    { "id": "i2c0",         "type": "i2c",  "sda": "GPIO21", "scl": "GPIO22", "frequency_hz": 100000 },
+    { "id": "nextion_uart", "type": "uart", "rx": "GPIO16", "tx": "GPIO17", "baud_rate": 9600 }
+  ],
+
+  "connections": [
+    { "component_id": "screen", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "screen", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "screen", "pin_role": "TX",  "target": { "kind": "bus",  "bus_id": "nextion_uart" } },
+    { "component_id": "screen", "pin_role": "RX",  "target": { "kind": "bus",  "bus_id": "nextion_uart" } },
+
+    { "component_id": "th", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "th", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "th", "pin_role": "SDA", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+    { "component_id": "th", "pin_role": "SCL", "target": { "kind": "bus",  "bus_id": "i2c0" } }
+  ],
+
+  "passives": [
+    { "id": "c1", "kind": "capacitor", "value": "100uF",
+      "between": ["screen.VCC", "GND"], "purpose": "bulk decoupling nextion backlight inrush" },
+    { "id": "c2", "kind": "capacitor", "value": "100nF",
+      "between": ["screen.VCC", "GND"], "purpose": "decoupling nextion logic" },
+    { "id": "c3", "kind": "capacitor", "value": "100nF",
+      "between": ["th.VCC", "GND"], "purpose": "decoupling sht3xd" }
+  ],
+
+  "warnings": [
+    { "level": "info", "code": "nextion_5v_supply",
+      "text": "The Nextion's VCC rides the board's 5V rail (USB) -- a Nextion at full backlight pulls 200-250mA. Check your USB supply margin or feed the display from a separate 5V brick if you're also driving WS2812 strips off the same regulator." }
+  ],
+
+  "esphome_extras": {
+    "captive_portal": {}
+  },
+
+  "fleet": {
+    "device_name": "nextion-thermostat",
+    "tags": ["display", "thermostat", "nextion"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/examples/rs485-energy.json
+++ b/wirestudio/examples/rs485-energy.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "0.1",
+  "id": "rs485-energy",
+  "name": "Eastron SDM230 single-phase energy meter via RS485",
+  "description": "ESP32-DevKitC-V4 reading an Eastron SDM230 energy meter over Modbus RTU. UART2 (GPIO16/GPIO17) drives a MAX485 transceiver; GPIO5 toggles the transceiver's combined DE+RE direction pin. The studio's modbus component owns the protocol layer, sdm_meter rides on top.",
+  "created_at": "2026-05-09T00:00:00Z",
+  "updated_at": "2026-05-09T00:00:00Z",
+
+  "board": {
+    "library_id": "esp32-devkitc-v4",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117-3v3",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "publish per-phase voltage / current / power and total import/export energy from an SDM230" },
+    { "id": "r2", "kind": "constraint",  "text": "RS485 is half-duplex through a MAX485; flow_control_pin must drive DE+RE in lockstep" }
+  ],
+
+  "components": [
+    {
+      "id": "rs485_bus",
+      "library_id": "modbus",
+      "label": "RS485 modbus",
+      "params": { "send_wait_time": "200ms" }
+    },
+    {
+      "id": "meter",
+      "library_id": "sdm_meter",
+      "label": "Mains",
+      "params": { "address": 1, "update_interval": "30s" }
+    }
+  ],
+
+  "buses": [
+    { "id": "modbus_uart", "type": "uart", "rx": "GPIO16", "tx": "GPIO17", "baud_rate": 9600 }
+  ],
+
+  "connections": [
+    { "component_id": "rs485_bus", "pin_role": "UART", "target": { "kind": "bus",  "bus_id": "modbus_uart" } },
+    { "component_id": "rs485_bus", "pin_role": "FLOW", "target": { "kind": "gpio", "pin": "GPIO5" } },
+    { "component_id": "meter",     "pin_role": "HUB",  "target": { "kind": "component", "component_id": "rs485_bus" } }
+  ],
+
+  "passives": [],
+
+  "warnings": [
+    { "level": "info", "code": "rs485_transceiver_required",
+      "text": "Wire UART RX/TX through a MAX485 (or equivalent) transceiver: A/B to the SDM230 terminals 9/10, RO/DI to GPIO16/GPIO17, DE+RE tied together to GPIO5." }
+  ],
+
+  "esphome_extras": {
+    "captive_portal": {}
+  },
+
+  "fleet": {
+    "device_name": "rs485-energy",
+    "tags": ["energy", "rs485", "sdm230"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/examples/tuya-smart-plug.json
+++ b/wirestudio/examples/tuya-smart-plug.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "0.1",
+  "id": "tuya-smart-plug",
+  "name": "Tuya MCU smart plug (relay + energy DPs)",
+  "description": "ESP8285 1MB module (the typical Tuya plug radio side) talking to its onboard Tuya MCU over UART0. The MCU owns the relay + the metering chip; ESPHome reaches them through datapoints: DP 1 toggles the relay, DP 17 streams instantaneous power, DP 18 streams cumulative energy.",
+  "created_at": "2026-05-09T00:00:00Z",
+  "updated_at": "2026-05-09T00:00:00Z",
+
+  "board": {
+    "library_id": "esp8285-1m",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "ac-mains",
+    "rail_voltage_v": 230.0,
+    "regulator": "onboard-acdc-3v3",
+    "budget_ma": 200
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "drive the load relay via Tuya DP 1 with HA-controllable state" },
+    { "id": "r2", "kind": "capability", "text": "publish current power (DP 17) and cumulative energy (DP 18)" },
+    { "id": "r3", "kind": "constraint",  "text": "ESPHome logger must NOT use UART0 -- the Tuya MCU owns the bus" }
+  ],
+
+  "components": [
+    {
+      "id": "tuya_mcu",
+      "library_id": "tuya",
+      "label": "Tuya bridge",
+      "params": {}
+    },
+    {
+      "id": "relay",
+      "library_id": "tuya_switch",
+      "label": "Plug relay",
+      "params": { "switch_datapoint": 1, "restore_mode": "RESTORE_DEFAULT_OFF" }
+    },
+    {
+      "id": "watts",
+      "library_id": "tuya_sensor",
+      "label": "Plug power",
+      "params": {
+        "sensor_datapoint": 17,
+        "unit_of_measurement": "W",
+        "filters": [{"multiply": 0.1}]
+      }
+    },
+    {
+      "id": "kwh",
+      "library_id": "tuya_sensor",
+      "label": "Plug energy",
+      "params": {
+        "sensor_datapoint": 18,
+        "unit_of_measurement": "kWh",
+        "accuracy_decimals": 2,
+        "filters": [{"multiply": 0.01}]
+      }
+    }
+  ],
+
+  "buses": [
+    { "id": "tuya_uart", "type": "uart", "rx": "GPIO3", "tx": "GPIO1", "baud_rate": 9600 }
+  ],
+
+  "connections": [
+    { "component_id": "tuya_mcu", "pin_role": "UART", "target": { "kind": "bus", "bus_id": "tuya_uart" } },
+
+    { "component_id": "relay", "pin_role": "HUB", "target": { "kind": "component", "component_id": "tuya_mcu" } },
+    { "component_id": "watts", "pin_role": "HUB", "target": { "kind": "component", "component_id": "tuya_mcu" } },
+    { "component_id": "kwh",   "pin_role": "HUB", "target": { "kind": "component", "component_id": "tuya_mcu" } }
+  ],
+
+  "passives": [],
+
+  "warnings": [
+    { "level": "warn", "code": "logger_baud_collision",
+      "text": "Disable the ESPHome serial logger (or move it off UART0) -- the Tuya MCU owns the 9600-baud UART0 bus." }
+  ],
+
+  "esphome_extras": {
+    "captive_portal": {},
+    "logger": { "baud_rate": 0 }
+  },
+
+  "fleet": {
+    "device_name": "tuya-smart-plug",
+    "tags": ["plug", "tuya", "power"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/library/components/bl0906.yaml
+++ b/wirestudio/library/components/bl0906.yaml
@@ -1,0 +1,97 @@
+id: bl0906
+name: BL0906 6-channel AC energy meter (UART, 19200 baud)
+category: sensor
+use_cases: [power_metering, ac_voltage, ac_current, energy, sub_metering, multi_channel]
+aliases: ["athom_em6", "bl0906_em6"]
+
+electrical:
+  vcc_min: 3.3
+  vcc_max: 3.6
+  current_ma_typical: 8
+  current_ma_peak: 20
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - {role: TX, kind: uart_tx, voltage: 3.3}
+    - {role: RX, kind: uart_rx, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [uart]
+  yaml_template: |
+    sensor:
+      - platform: bl0906
+        uart_id: {{ bus.id }}
+        update_interval: {{ params.update_interval | default('60s') }}
+        voltage:
+          name: "{{ label }} Voltage"
+        frequency:
+          name: "{{ label }} Frequency"
+        total_power:
+          name: "{{ label }} Total Power"
+        total_energy:
+          name: "{{ label }} Total Energy"
+        channel_1:
+          current:
+            name: "{{ label }} Ch1 Current"
+          power:
+            name: "{{ label }} Ch1 Power"
+          energy:
+            name: "{{ label }} Ch1 Energy"
+        channel_2:
+          current:
+            name: "{{ label }} Ch2 Current"
+          power:
+            name: "{{ label }} Ch2 Power"
+          energy:
+            name: "{{ label }} Ch2 Energy"
+        channel_3:
+          current:
+            name: "{{ label }} Ch3 Current"
+          power:
+            name: "{{ label }} Ch3 Power"
+          energy:
+            name: "{{ label }} Ch3 Energy"
+        channel_4:
+          current:
+            name: "{{ label }} Ch4 Current"
+          power:
+            name: "{{ label }} Ch4 Power"
+          energy:
+            name: "{{ label }} Ch4 Energy"
+        channel_5:
+          current:
+            name: "{{ label }} Ch5 Current"
+          power:
+            name: "{{ label }} Ch5 Power"
+          energy:
+            name: "{{ label }} Ch5 Energy"
+        channel_6:
+          current:
+            name: "{{ label }} Ch6 Current"
+          power:
+            name: "{{ label }} Ch6 Power"
+          energy:
+            name: "{{ label }} Ch6 Energy"
+
+params_schema:
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  BL0906 is the 6-channel sibling of BL0937 (3-pin pulse), used in the
+  Athom EM6 whole-home energy monitor. Talks UART at 19200 8N1 -- bind
+  a UART bus to those pins. ESP32-class MCU recommended (UART2 or
+  UART1 free; UART0 stays available for the ESPHome logger). Each of
+  the six current-transformer channels (CT clamp ratio 2000:1 in stock
+  Athom hardware) yields current/power/energy; the chip aggregates
+  total_power/total_energy across all six. The voltage / frequency
+  sensors are global (single AC service feeding the meter).
+# KiCad symbol mapping. BL0906 isn't in stock KiCad libs; use a generic
+# 4-pin header for the LV side breakout (VCC, GND, TX, RX).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  value: BL0906

--- a/wirestudio/library/components/modbus.yaml
+++ b/wirestudio/library/components/modbus.yaml
@@ -1,0 +1,62 @@
+id: modbus
+name: Modbus RTU bus protocol (RS485-over-UART)
+category: bus
+use_cases: [rs485, modbus_rtu, energy_meter, hvac, inverter]
+aliases: ["modbus_rtu", "rs485_bus"]
+
+electrical:
+  vcc_min: 0.0
+  vcc_max: 0.0
+  current_ma_typical: 0
+  current_ma_peak: 0
+  pins:
+    # Optional GPIO that drives a MAX485 (or equivalent) RS485
+    # transceiver's combined DE+RE direction pin. Bind only when
+    # half-duplex RS485 is wired through such a transceiver; for
+    # full-duplex RS232/TTL modbus stacks, leave it unbound.
+    - {role: FLOW, kind: digital_out, voltage: 3.3}
+  passives: []
+
+esphome:
+  required_components: [uart]
+  yaml_template: |
+    modbus:
+      id: {{ id }}
+      uart_id: {{ bus.id }}
+    {%- if pins.FLOW is defined %}
+      flow_control_pin: {{ pins.FLOW | tojson }}
+    {%- endif %}
+    {%- if params.send_wait_time is defined %}
+      send_wait_time: {{ params.send_wait_time }}
+    {%- endif %}
+    {%- if params.role is defined %}
+      role: {{ params.role }}
+    {%- endif %}
+
+params_schema:
+  send_wait_time:
+    type: string
+    description: "Minimum gap between modbus requests, e.g. '200ms'. Some slaves need 100-500ms to settle between transactions."
+  role:
+    type: string
+    enum: [client, server]
+    default: client
+    description: "client = master (the studio reads), server = slave (the studio answers). Almost everyone wants client."
+
+notes: |
+  The bare modbus protocol layer that downstream platforms (sdm_meter,
+  modbus_controller, dl_bus, etc.) ride on. Pair with a UART configured
+  for the slave's baud rate (commonly 9600 for SDM230 / 2400 for SDM120
+  / 19200 for many inverters; check the device datasheet) and a MAX485
+  transceiver if the bus is electrically RS485. The transceiver's
+  DE+RE direction pin ties to the FLOW pin; ESPHome toggles it on each
+  TX. UART parity is per-slave -- most modbus stacks run NONE 8N1, but
+  a handful (SMA inverters, some HVAC gateways) need EVEN.
+# KiCad symbol mapping. Modbus is a logical layer with no part number;
+# the FLOW connection is to a real transceiver IC the user adds
+# separately. 1-pin header keeps the schematic honest about the wiring
+# point without inventing a part.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x01
+  value: Modbus hub

--- a/wirestudio/library/components/nextion.yaml
+++ b/wirestudio/library/components/nextion.yaml
@@ -1,0 +1,73 @@
+id: nextion
+name: Nextion HMI display (UART, 9600 baud default)
+category: display
+use_cases: [hmi, touchscreen, gui, thermostat_ui, control_panel]
+aliases: ["nextion_basic", "nextion_enhanced", "nextion_intelligent"]
+
+electrical:
+  vcc_min: 4.5
+  vcc_max: 5.5
+  current_ma_typical: 90
+  current_ma_peak: 250
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    # Display TX -> MCU RX, MCU TX -> Display RX. Bidirectional UART.
+    - {role: TX, kind: uart_tx, voltage: 3.3}
+    - {role: RX, kind: uart_rx, voltage: 3.3}
+  passives:
+    # Backlight + display logic together pull spikes well above 100mA at
+    # power-on; bulk decoupling on VCC keeps the rail clean.
+    - {kind: capacitor, value: "100uF", between: [VCC, GND], purpose: bulk decoupling}
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [uart]
+  yaml_template: |
+    display:
+      - platform: nextion
+        id: {{ id }}
+        uart_id: {{ bus.id }}
+        update_interval: {{ params.update_interval | default('5s') }}
+    {%- if params.brightness is defined %}
+        brightness: {{ params.brightness }}
+    {%- endif %}
+    {%- if params.tft_url is defined %}
+        tft_url: "{{ params.tft_url }}"
+    {%- endif %}
+    {%- if params.lambda is defined %}
+        lambda: |-
+          {{ params.lambda | indent(10) }}
+    {%- endif %}
+
+params_schema:
+  update_interval:
+    type: string
+    default: "5s"
+    description: "How often the lambda runs. Most updates should ride dedicated nextion sensor/switch components instead -- use a long interval (60s+) when there's no lambda."
+  brightness:
+    type: string
+    description: "Backlight at boot, e.g. '60%'. Omit to keep the display's stored brightness."
+  tft_url:
+    type: string
+    description: "HTTP(S) URL to a .tft file the display upgrades from on demand. Leave unset unless you're bundling firmware updates."
+  lambda:
+    type: string
+    description: "C++ rendering body. Prefer dedicated nextion components over driving everything from the lambda -- it runs every update_interval and serial-blasts the display."
+
+notes: |
+  Nextion is a serial-driven smart display: the screen runs its own GUI
+  uploaded from Nextion Editor (.HMI -> .tft), and the MCU sends
+  text/value updates over UART. Default baud is 9600 (raise to 115200
+  in Nextion Editor's program.s if you need faster updates). Use a
+  hardware UART -- software UART will glitch on long strings. The
+  display draws ~80mA idle and spikes to ~250mA on touch + backlight
+  full -- size the regulator accordingly. ESPHome 2025.12.x supports
+  Nextion Basic (T-series) and Enhanced/Intelligent (K/P-series); the
+  schema is the same.
+# KiCad symbol mapping. Nextion ships a 4-pin JST connector (5V, GND,
+# TX, RX) that matches a generic 4-pin header.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  value: Nextion HMI

--- a/wirestudio/library/components/sdm_meter.yaml
+++ b/wirestudio/library/components/sdm_meter.yaml
@@ -1,0 +1,82 @@
+id: sdm_meter
+name: Eastron SDM single/three-phase energy meter (Modbus RTU over RS485)
+category: sensor
+use_cases: [power_metering, ac_voltage, ac_current, energy, sub_metering, three_phase]
+aliases: ["sdm120", "sdm120m", "sdm220", "sdm230", "sdm630"]
+
+electrical:
+  current_ma_typical: 0
+  current_ma_peak: 0
+  pins:
+    - role: HUB
+      kind: hub_ref
+      parent_library_id: modbus
+  passives: []
+
+esphome:
+  required_components: []
+  yaml_template: |
+    sensor:
+      - platform: sdm_meter
+        modbus_id: {{ parent.id }}
+        address: {{ params.address | default(1) }}
+        update_interval: {{ params.update_interval | default('60s') }}
+        phase_a:
+          voltage:
+            name: "{{ label }} Phase A Voltage"
+          current:
+            name: "{{ label }} Phase A Current"
+          active_power:
+            name: "{{ label }} Phase A Power"
+    {%- if params.three_phase is defined and params.three_phase %}
+        phase_b:
+          voltage:
+            name: "{{ label }} Phase B Voltage"
+          current:
+            name: "{{ label }} Phase B Current"
+          active_power:
+            name: "{{ label }} Phase B Power"
+        phase_c:
+          voltage:
+            name: "{{ label }} Phase C Voltage"
+          current:
+            name: "{{ label }} Phase C Current"
+          active_power:
+            name: "{{ label }} Phase C Power"
+    {%- endif %}
+        frequency:
+          name: "{{ label }} Frequency"
+        import_active_energy:
+          name: "{{ label }} Total Import Energy"
+        export_active_energy:
+          name: "{{ label }} Total Export Energy"
+
+params_schema:
+  address:
+    type: number
+    default: 1
+    description: "Modbus slave address. SDM meters ship as 0x01 from the factory; change via the front-panel menu if you have multiple meters on one bus."
+  update_interval:
+    type: string
+    default: "60s"
+  three_phase:
+    type: boolean
+    default: false
+    description: "Set true for SDM630 / SDM72 (three-phase models). SDM120/SDM220/SDM230 are single-phase, leave false."
+
+notes: |
+  Eastron SDM-series DIN-rail energy meters speak Modbus RTU over an
+  RS485 bus. Wire through a MAX485-class transceiver: A/B to the
+  meter, RO/DI to the MCU UART RX/TX, DE+RE tied together to a GPIO
+  bound to the modbus FLOW pin. Baud rates: SDM120 default is 2400;
+  SDM230 / SDM630 default is 9600 -- check the meter's display menu,
+  most modern installs use 9600. The meter also exposes a wider
+  register set (reactive power, power factor, phase angle, etc.); add
+  per-phase blocks downstream of phase_a as needed.
+# KiCad symbol mapping. The SDM is a DIN-rail meter, not a board-level
+# part; render a generic 4-pin terminal block (A, B, GND, optional shield)
+# for the RS485 connection.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  value: SDM meter

--- a/wirestudio/library/components/tuya.yaml
+++ b/wirestudio/library/components/tuya.yaml
@@ -1,0 +1,66 @@
+id: tuya
+name: Tuya MCU bridge (UART, 9600 baud)
+category: bus
+use_cases: [tuya, tuya_mcu, smart_plug, smart_switch, climate_controller, fan_controller]
+aliases: ["tuya_mcu", "tuya_serial"]
+
+electrical:
+  vcc_min: 0.0
+  vcc_max: 0.0
+  current_ma_typical: 0
+  current_ma_peak: 0
+  # tuya is a serial protocol layer -- the physical wiring is the
+  # host UART (TX/RX) on the radio module side; the Tuya MCU is on
+  # the other side of the link with its own VCC/GND. The hub itself
+  # owns no pins; downstream tuya_switch / tuya_sensor entries hub-
+  # link via parent.id.
+  pins: []
+  passives: []
+
+esphome:
+  required_components: [uart]
+  yaml_template: |
+    tuya:
+      id: {{ id }}
+      uart_id: {{ bus.id }}
+    {%- if params.time_id is defined %}
+      time_id: {{ params.time_id }}
+    {%- endif %}
+    {%- if params.status_pin is defined %}
+      status_pin: {{ params.status_pin | tojson }}
+    {%- endif %}
+    {%- if params.ignore_mcu_update_on_datapoints is defined %}
+      ignore_mcu_update_on_datapoints: {{ params.ignore_mcu_update_on_datapoints | tojson }}
+    {%- endif %}
+
+params_schema:
+  time_id:
+    type: string
+    description: "ID of a time component (sntp / homeassistant). Tuya MCUs that show the time on their own panel pull it via this link."
+  status_pin:
+    type: string
+    description: "GPIO the Tuya MCU monitors for WiFi-connected status. Wired internally on most Tuya devices -- check the teardown / scopeprobe before guessing."
+  ignore_mcu_update_on_datapoints:
+    type: array
+    description: "List of integer DP ids the host should not echo back to the MCU. Used to break feedback loops on devices where the MCU pushes its own state changes spuriously."
+
+notes: |
+  Tuya / Smart Life devices ship as a radio module (ESP8266/ESP8285/BK7231
+  -- the BK chips are not flashable to ESPHome) glued to a Tuya MCU
+  that owns the relays / sensors / motor / display. The MCU and the
+  radio talk a documented serial protocol over a single UART (9600 8N1).
+  ESPHome's tuya hub speaks that protocol; downstream tuya_switch /
+  tuya_sensor / tuya_number / tuya_select entries each address one
+  datapoint (DP) on the MCU. Find DP ids by sniffing the MCU traffic
+  with the tuya-cloudcutter tools or by reading
+  https://github.com/ct-Open-Source/tuya-convert/wiki and the device's
+  community tuya-local entries. Common patterns: DP 1 = main switch,
+  DP 17 = current power, DP 18 = total energy, DP 24 = temperature.
+# KiCad symbol mapping. Tuya is a logical hub -- the user already has
+# a board entry for the radio module. Render a 1-pin header so the
+# schematic shows where downstream tuya_switch / tuya_sensor children
+# attach without inventing a duplicate part.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x01
+  value: Tuya MCU

--- a/wirestudio/library/components/tuya_sensor.yaml
+++ b/wirestudio/library/components/tuya_sensor.yaml
@@ -1,0 +1,60 @@
+id: tuya_sensor
+name: Tuya datapoint sensor
+category: sensor
+use_cases: [tuya_sensor, smart_plug_metering, tuya_temperature, tuya_humidity, tuya_kwh]
+aliases: ["tuya_dp_sensor"]
+
+electrical:
+  current_ma_typical: 0
+  current_ma_peak: 0
+  pins:
+    - role: HUB
+      kind: hub_ref
+      parent_library_id: tuya
+  passives: []
+
+esphome:
+  required_components: []
+  yaml_template: |
+    sensor:
+      - platform: tuya
+        id: {{ id }}
+        name: "{{ label }}"
+        tuya_id: {{ parent.id }}
+        sensor_datapoint: {{ params.sensor_datapoint | default(17) }}
+    {%- if params.unit_of_measurement is defined %}
+        unit_of_measurement: "{{ params.unit_of_measurement }}"
+    {%- endif %}
+    {%- if params.accuracy_decimals is defined %}
+        accuracy_decimals: {{ params.accuracy_decimals }}
+    {%- endif %}
+    {%- if params.filters is defined %}
+        filters: {{ params.filters | tojson }}
+    {%- endif %}
+
+params_schema:
+  sensor_datapoint:
+    type: number
+    default: 17
+    description: "Integer DP id on the Tuya MCU that emits this reading. Common metering plugs: 17 = current power (dW), 18 = current (mA), 19 = voltage (dV), 22 = total energy (Wh)."
+  unit_of_measurement:
+    type: string
+    description: "e.g. 'W', 'kWh', '°C'. Apply with `filters: [multiply: 0.1]` if the MCU reports decidegrees / dW."
+  accuracy_decimals:
+    type: number
+    description: "Decimal places ESPHome rounds to. Most metering DPs report integers in tenths/hundredths -- pair with a multiply filter."
+  filters:
+    type: array
+    description: "Standard ESPHome sensor filters. `[{multiply: 0.1}]` is common for dW -> W or 0.1°C -> °C scaling on Tuya metering DPs."
+
+notes: |
+  One numeric datapoint on a Tuya MCU. Sits as a child of a tuya hub.
+  Most Tuya plugs/switches expose metering on DPs 17-22 with
+  fixed-point integer encoding (dW, dA, dV, deci-kWh) -- attach a
+  `[{multiply: 0.1}]` filter to get human units. For boolean DPs
+  (e.g. occupancy / smoke / door-open) use a tuya binary_sensor
+  variant rather than wedging this entry into bool mode.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x01
+  value: Tuya sensor DP

--- a/wirestudio/library/components/tuya_switch.yaml
+++ b/wirestudio/library/components/tuya_switch.yaml
@@ -1,0 +1,53 @@
+id: tuya_switch
+name: Tuya datapoint switch
+category: switch
+use_cases: [tuya_switch, smart_plug_relay, smart_switch_button, tuya_relay]
+aliases: ["tuya_relay", "tuya_dp_switch"]
+
+electrical:
+  current_ma_typical: 0
+  current_ma_peak: 0
+  pins:
+    - role: HUB
+      kind: hub_ref
+      parent_library_id: tuya
+  passives: []
+
+esphome:
+  required_components: []
+  yaml_template: |
+    switch:
+      - platform: tuya
+        id: {{ id }}
+        name: "{{ label }}"
+        tuya_id: {{ parent.id }}
+        switch_datapoint: {{ params.switch_datapoint | default(1) }}
+    {%- if params.icon is defined %}
+        icon: "{{ params.icon }}"
+    {%- endif %}
+    {%- if params.restore_mode is defined %}
+        restore_mode: {{ params.restore_mode }}
+    {%- endif %}
+
+params_schema:
+  switch_datapoint:
+    type: number
+    default: 1
+    description: "Integer DP id on the Tuya MCU that toggles this switch. DP 1 is the main relay on most plugs / switches; multi-gang switches use DP 1..4."
+  icon:
+    type: string
+  restore_mode:
+    type: string
+    enum: [RESTORE_DEFAULT_OFF, RESTORE_DEFAULT_ON, ALWAYS_OFF, ALWAYS_ON, RESTORE_INVERTED_DEFAULT_OFF, RESTORE_INVERTED_DEFAULT_ON, DISABLED]
+
+notes: |
+  One toggleable datapoint on a Tuya MCU. Sits as a child of a tuya
+  hub -- add a tuya component first, then point this switch at it via
+  the HUB connection. The MCU handles the actual relay / triac drive;
+  ESPHome just sends DP set commands and listens for echoes. For
+  current/power/energy readings on the same plug, add tuya_sensor
+  instances pointed at the metering DPs (commonly 17, 18, 19).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x01
+  value: Tuya switch DP


### PR DESCRIPTION
## Summary
- Seven new library entries: `modbus` + `sdm_meter`, `bl0906`, `nextion`, and the Tuya MCU vendor bridge (`tuya` + `tuya_switch` + `tuya_sensor`).
- Four new examples that all pass `esphome config` against the pinned ESPHome 2025.12.7 gate: `rs485-energy`, `bl0906-mainmeter`, `nextion-thermostat`, `tuya-smart-plug`.
- Two side-deliverables: load-bearing `pyproject.toml` fix (PR #19 imported `slowapi` + `httpx.AsyncClient` at runtime without declaring them as deps), and the 2026-05-09 session log refresh in `START.md` (smoke gate confirmed green, stale 0.5 follow-ons retired, batch 3 promoted to head of Next-up).

## Component shapes

- **`modbus` + `sdm_meter`** — modbus is a UART-bound hub with optional `flow_control_pin` for MAX485 DE+RE direction control. sdm_meter is its first hub-child via the existing `kind: component` connection pattern (same shape as `ads1115_channel <- ads1115`). Default rendering covers single-phase (SDM120/220/230); flip `three_phase: true` for SDM630.
- **`bl0906`** — Belling 6-channel UART energy meter (Athom EM6-style whole-home monitor). Single component, all 6 current/power/energy channels + global voltage/frequency/total sensors. ESP32-class only (UART2 free; UART0 stays for the logger).
- **`nextion`** — HMI smart display over UART. Default 9600 baud, raise via Nextion Editor's `program.s` if needed. Param-heavy: `brightness`, `update_interval`, optional `tft_url` + `lambda`.
- **`tuya` vendor bridge** — modeled in the ads1115 + ads1115_channel mold. `tuya` is the UART hub to the Tuya MCU (which owns relays / metering / motors). `tuya_switch` and `tuya_sensor` each address one MCU datapoint (DP). The smart-plug example shows DP 1 (relay), DP 17 (instantaneous power, dW * 0.1 = W), DP 18 (cumulative energy, deci-kWh * 0.01 = kWh).

## Bug surfaced + fixed mid-batch
ESPHome 2025.12.7 doesn't accept `datapoint_type:` on `sensor.tuya` — the upstream docs are ahead of the pinned release. Dropped the field from `tuya_sensor`'s template + the smart-plug example before locking the goldens.

## pyproject.toml side-fix
PR #19 imports `slowapi` and uses `httpx.AsyncClient` at runtime but never declared either in dependencies; `pip install -e .` produced a runtime-broken install. CI didn't catch this because no workflow runs pytest, only `esphome config`. Promoted both to main dependencies.

## State after this batch
- 56 components × 14 boards × **24 examples** (was 49 × 14 × 20)
- 299/299 pytest pass
- **24/24 examples pass `esphome config`** against ESPHome 2025.12.7
- ruff still has 21 pre-existing errors from PR #19 — out of scope here, separate cleanup PR will follow

## Test plan
- [x] `python -m pytest -q` → 299/299 pass
- [x] `python scripts/check_examples.py` (every example) → 24/24 pass
- [x] `python scripts/check_examples.py <new-example>` for each of the four new ones individually
- [x] Manual review of all four generated YAMLs against the ESPHome docs schema
- [ ] Nightly `esphome compile` workflow run after merge (gate validated independently on 2026-05-07/08/09)

🤖 Generated with [Claude Code](https://claude.com/claude-code)