### PR TITLE
Ruff cleanup: clear 21 lint errors left by PR #19

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from wirestudio.agent.session import SessionStore, FileSessionStore, new_session_id
+from wirestudio.agent.session import FileSessionStore, new_session_id
 from wirestudio.agent.tools import execute_tool
 from wirestudio.api.app import create_app
 from wirestudio.library import default_library

--- a/tests/test_designs.py
+++ b/tests/test_designs.py
@@ -11,9 +11,9 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from wirestudio.agent.session import SessionStore, FileSessionStore
+from wirestudio.agent.session import FileSessionStore
 from wirestudio.api.app import create_app
-from wirestudio.designs.store import DesignStore, FileDesignStore, sanitize_id
+from wirestudio.designs.store import FileDesignStore, sanitize_id
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES_DIR = REPO_ROOT / "wirestudio" / "examples"

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -6,9 +6,6 @@ spinning up the addon.
 """
 from __future__ import annotations
 
-import pytest
-pytestmark = pytest.mark.anyio
-
 import json
 from pathlib import Path
 
@@ -16,10 +13,12 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
-from wirestudio.agent.session import SessionStore, FileSessionStore
+from wirestudio.agent.session import FileSessionStore
 from wirestudio.api.app import create_app
-from wirestudio.designs.store import DesignStore, FileDesignStore
+from wirestudio.designs.store import FileDesignStore
 from wirestudio.fleet.client import FleetClient, FleetUnavailable, _validate_filename
+
+pytestmark = pytest.mark.anyio
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES_DIR = REPO_ROOT / "wirestudio" / "examples"

--- a/tests/test_recommend.py
+++ b/tests/test_recommend.py
@@ -233,7 +233,7 @@ def test_recommend_tool_rejects_bad_args(lib):
 
 @pytest.fixture
 def client(tmp_path) -> TestClient:
-    from wirestudio.agent.session import SessionStore, FileSessionStore
+    from wirestudio.agent.session import FileSessionStore
     return TestClient(create_app(sessions=FileSessionStore(root=tmp_path)))
 
 

--- a/wirestudio/agent/session.py
+++ b/wirestudio/agent/session.py
@@ -11,7 +11,7 @@ import json
 import secrets
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Protocol
 
 SESSIONS_DIR_ENV_DEFAULT = Path(__file__).resolve().parent.parent.parent / "sessions"
 
@@ -19,8 +19,6 @@ SESSIONS_DIR_ENV_DEFAULT = Path(__file__).resolve().parent.parent.parent / "sess
 def new_session_id() -> str:
     return secrets.token_urlsafe(8)
 
-
-from typing import Optional, Protocol
 
 class SessionStore(Protocol):
     def exists(self, session_id: str) -> bool: ...

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import json
-import time
 import asyncio
+import json
 from pathlib import Path
 from typing import Optional
 

--- a/wirestudio/designs/__init__.py
+++ b/wirestudio/designs/__init__.py
@@ -8,4 +8,4 @@ conversation history, never carries design state).
 
 from wirestudio.designs.store import DesignStore, FileDesignStore, SavedDesignSummary
 
-__all__ = ["DesignStore", "SavedDesignSummary"]
+__all__ = ["DesignStore", "FileDesignStore", "SavedDesignSummary"]

--- a/wirestudio/designs/store.py
+++ b/wirestudio/designs/store.py
@@ -13,7 +13,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Protocol
 
 DESIGNS_DIR_DEFAULT = Path(__file__).resolve().parent.parent.parent / "designs"
 
@@ -50,8 +50,6 @@ class SavedDesignSummary:
     saved_at: str
     component_count: int
 
-
-from typing import Optional, Protocol
 
 class DesignStore(Protocol):
     def exists(self, design_id: str) -> bool: ...


### PR DESCRIPTION
## Summary
- Resolves all 21 ruff errors that PR #19 left on \`main\`. Since no CI workflow runs ruff (only the opt-in pre-commit hook does), these have been silent since #19 merged.
- 8 F401 unused imports + 11 E402 import-below-statement + 2 F811 Optional-redefined.
- Zero behavior change. Pure import-block tidying.

## Specific edits
- **\`wirestudio/designs/store.py\` + \`wirestudio/agent/session.py\`**: consolidate the duplicate \`from typing import Optional, Protocol\` imports into the existing top-of-file typing block. The duplicate appeared in PR #19 because the Protocol definitions were added in a fresh block below module-level code, triggering both F811 (Optional redefined) and E402 (import below dataclass / module-level statement).
- **\`wirestudio/designs/__init__.py\`**: add \`FileDesignStore\` to \`__all__\`. The class is intentionally re-exported (it's the file-backed implementation users instantiate), so adding to \`__all__\` is the right answer rather than dropping the import.
- **\`wirestudio/api/app.py\`**: drop unused \`import time\` (residue from the streaming refactor; actual time-keeping moved into the per-step helpers).
- **\`tests/test_fleet.py\`**: move \`pytestmark = pytest.mark.anyio\` below all imports. The 9 E402 errors here all chained from this single line being above \`import json\`.
- **\`tests/test_agent.py\` / \`test_designs.py\` / \`test_fleet.py\` / \`test_recommend.py\`**: drop unused \`SessionStore\` / \`DesignStore\` Protocol imports — they were only used as type aliases that no call site referenced.

## Verification
- \`ruff check wirestudio tests\` → **All checks passed**
- \`pytest -q\` → **299/299 pass**

## Test plan
- [x] Ruff clean
- [x] Pytest green
- [ ] (not run here, but unaffected) \`scripts/check_examples.py\` — no example or library file touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)