### PR TITLE
WebUI: basic / advanced mode toggle in the header

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import { CapabilityPickerDialog } from "./components/CapabilityPickerDialog";
 import { EnclosureDialog } from "./components/EnclosureDialog";
 import { SchematicDialog } from "./components/SchematicDialog";
 import { useDebouncedValue } from "./lib/debounce";
+import { useAdvancedMode } from "./lib/uiMode";
 import {
   addComponent,
   isDirty,
@@ -55,6 +56,11 @@ export default function App() {
    *  before push-to-fleet. Default permissive so the user isn't blocked
    *  while editing. */
   const [strictMode, setStrictMode] = useState<boolean>(false);
+  /** Advanced mode reveals the schematic / enclosure / push-to-fleet /
+   *  agent surfaces. Default basic so the front door is the verified-tier
+   *  flow (board + components + buses + YAML preview). Persists to
+   *  localStorage. */
+  const [advancedMode, setAdvancedMode] = useAdvancedMode();
 
   const [boardData, setBoardData] = useState<unknown | null>(null);
 
@@ -373,13 +379,15 @@ export default function App() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <button
-            onClick={() => setShowAgent(true)}
-            className="rounded bg-blue-500/15 px-2 py-1 text-xs text-blue-100 ring-1 ring-blue-400/40 hover:bg-blue-500/25"
-            title="Open the design agent"
-          >
-            Agent
-          </button>
+          {advancedMode && (
+            <button
+              onClick={() => setShowAgent(true)}
+              className="rounded bg-blue-500/15 px-2 py-1 text-xs text-blue-100 ring-1 ring-blue-400/40 hover:bg-blue-500/25"
+              title="Open the design agent"
+            >
+              Agent
+            </button>
+          )}
           <button
             onClick={() => setShowNewDialog(true)}
             className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-900"
@@ -423,6 +431,22 @@ export default function App() {
             />
             strict
           </label>
+          <label
+            className={`flex cursor-pointer items-center gap-1 rounded border px-2 py-1 text-xs transition-colors ${
+              advancedMode
+                ? "border-violet-600/50 bg-violet-900/20 text-violet-100"
+                : "border-zinc-800 text-zinc-300 hover:bg-zinc-900"
+            }`}
+            title="Advanced mode reveals the Agent, Schematic (KiCad), Enclosure, and Push-to-fleet surfaces. Persists across sessions."
+          >
+            <input
+              type="checkbox"
+              checked={advancedMode}
+              onChange={(e) => setAdvancedMode(e.target.checked)}
+              className="h-3 w-3"
+            />
+            advanced
+          </label>
           <button
             onClick={() => setShowUsbDialog(true)}
             className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-900"
@@ -438,30 +462,34 @@ export default function App() {
           >
             Add by function
           </button>
-          <button
-            disabled={!design}
-            onClick={() => setShowSchematicDialog(true)}
-            className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 enabled:hover:bg-zinc-900 disabled:opacity-40"
-            title="Download a SKiDL Python script that produces a .kicad_sch when run locally"
-          >
-            Schematic
-          </button>
-          <button
-            disabled={!design}
-            onClick={() => setShowEnclosureDialog(true)}
-            className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 enabled:hover:bg-zinc-900 disabled:opacity-40"
-            title="Generate a parametric .scad shell or search community-uploaded models"
-          >
-            Enclosure
-          </button>
-          <button
-            disabled={!design}
-            onClick={() => setShowFleetDialog(true)}
-            className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 enabled:hover:bg-zinc-900 disabled:opacity-40"
-            title="Push the rendered YAML to distributed-esphome"
-          >
-            Push to fleet
-          </button>
+          {advancedMode && (
+            <>
+              <button
+                disabled={!design}
+                onClick={() => setShowSchematicDialog(true)}
+                className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 enabled:hover:bg-zinc-900 disabled:opacity-40"
+                title="Download a SKiDL Python script that produces a .kicad_sch when run locally"
+              >
+                Schematic
+              </button>
+              <button
+                disabled={!design}
+                onClick={() => setShowEnclosureDialog(true)}
+                className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 enabled:hover:bg-zinc-900 disabled:opacity-40"
+                title="Generate a parametric .scad shell or search community-uploaded models"
+              >
+                Enclosure
+              </button>
+              <button
+                disabled={!design}
+                onClick={() => setShowFleetDialog(true)}
+                className="rounded border border-zinc-800 px-2 py-1 text-xs text-zinc-300 enabled:hover:bg-zinc-900 disabled:opacity-40"
+                title="Push the rendered YAML to distributed-esphome"
+              >
+                Push to fleet
+              </button>
+            </>
+          )}
           <button
             disabled={!dirty}
             onClick={handleReset}

--- a/web/src/lib/uiMode.test.ts
+++ b/web/src/lib/uiMode.test.ts
@@ -1,0 +1,40 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAdvancedMode } from "./uiMode";
+
+const KEY = "wirestudio:ui:advanced";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("useAdvancedMode", () => {
+  it("defaults to false when nothing is stored", () => {
+    const { result } = renderHook(() => useAdvancedMode());
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("hydrates from localStorage", () => {
+    window.localStorage.setItem(KEY, "1");
+    const { result } = renderHook(() => useAdvancedMode());
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("persists changes to localStorage", () => {
+    const { result } = renderHook(() => useAdvancedMode());
+    act(() => result.current[1](true));
+    expect(window.localStorage.getItem(KEY)).toBe("1");
+    act(() => result.current[1](false));
+    expect(window.localStorage.getItem(KEY)).toBe("0");
+  });
+
+  it("treats any non-1 stored value as basic mode", () => {
+    window.localStorage.setItem(KEY, "yes");
+    const { result } = renderHook(() => useAdvancedMode());
+    expect(result.current[0]).toBe(false);
+  });
+});

--- a/web/src/lib/uiMode.ts
+++ b/web/src/lib/uiMode.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "wirestudio:ui:advanced";
+
+function readInitial(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function useAdvancedMode(): [boolean, (next: boolean) => void] {
+  const [advanced, setAdvanced] = useState<boolean>(readInitial);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, advanced ? "1" : "0");
+    } catch {
+      // Quota / private browsing -- in-memory state still works for this session.
+    }
+  }, [advanced]);
+
+  return [advanced, setAdvanced];
+}


### PR DESCRIPTION
## Summary
- Default UI now shows only the **verified-tier surface**: board picker, components, buses, YAML preview, plus the existing Save / Solve pins / Connect device / Add by function / Reset / Download JSON controls. The four surfaces that were the "AI slop" front-door risk — **Agent**, **Schematic** (KiCad), **Enclosure**, **Push to fleet** — hide behind a new `advanced` toggle in the header.
- Toggle persists to `localStorage` under `wirestudio:ui:advanced`, so a preference survives reloads / new sessions.
- Implements the WebUI-streamline item that's been queued in `START.md` since the 2026-05-06 session.

## What changed
- New `web/src/lib/uiMode.ts` — `useAdvancedMode()` hook with localStorage persistence, defaults to `false`. Quota / private-browsing failures fall through silently (in-memory state still works for the session).
- New `web/src/lib/uiMode.test.ts` — 4 vitest cases covering default, hydrate, persist (round-trip), and malformed-stored-value paths.
- `web/src/App.tsx` — wraps the four advanced buttons in `{advancedMode && (...)}`, adds the labeled checkbox toggle next to the existing `strict` toggle. Visual style matches strict's amber ring (violet when advanced is on).

## Verification
- `npm test -- --run` → **129/129 vitest pass** (was 125; +4 from the new test file)
- `npx tsc --noEmit` → clean
- `npm run build` → clean (300 kB main bundle, no growth)
- **Live UI verified through Chrome MCP** at the actual dev server:
  - Default state: 7 header buttons + 2 toggles, four advanced buttons absent, localStorage = `0`.
  - Toggle on: Agent appears at the start, Schematic / Enclosure / Push to fleet appear in the middle (between "Add by function" and "Reset"), localStorage flips to `1`.
  - Page reload: state hydrates correctly, advanced buttons stay visible.
  - Toggle off: advanced buttons hide, localStorage flips back to `0`.

## Out of scope (deferred)
- Doesn't gate the strict-mode toggle. Strict is useful in basic too (catches issues during render even without push-to-fleet).
- Doesn't gate `Connect device` (WebSerial USB bootstrap). It's part of the verified-tier "pick a board from a real chip" flow.
- No URL-param override (`?advanced=1`) — pure localStorage. Easy to add later if a deep-link surface needs it.

## Side note
Vitest needs `jsdom` to run (already declared in `web/package.json` but absent from `node_modules` on a fresh clone). `npm install` after pulling this branch populates it; no tracked file change here.

## Test plan
- [x] vitest green (129/129)
- [x] tsc clean
- [x] Vite build clean
- [x] Live Chrome verification of toggle / hide / show / reload / round-trip
- [ ] Sanity-check on a fresh clone after merge: `npm install && npm test -- --run` should be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)