### PR TITLE
agent: strip SDK parser metadata from assistant blocks before history append

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -279,3 +279,77 @@ def test_session_store_rejects_traversal_directly(tmp_path):
     store = FileSessionStore(root=tmp_path)
     with pytest.raises(ValueError):
         store.path("../passwd")
+
+
+# ---------------------------------------------------------------------------
+# Assistant block sanitizer
+# ---------------------------------------------------------------------------
+# Real bug from a multi-turn agent session: after ~10 turns the next API call
+# 400'd with `messages.N.content.M.text.parsed_output: Extra inputs are not
+# permitted`. Cause: the SDK's message-stream parser attaches `parsed_output`
+# (and potentially other helpers) to TextBlock instances; feeding the raw
+# model_dump() back as history poisons the conversation. _serialize_assistant_block
+# whitelists only the API-accepted keys per block type.
+
+class _FakeTextBlock:
+    type = "text"
+    def __init__(self, text: str, **extras):
+        self.text = text
+        for k, v in extras.items():
+            setattr(self, k, v)
+    def model_dump(self):
+        return {"type": self.type, "text": self.text, **{
+            k: v for k, v in self.__dict__.items() if k != "text"
+        }}
+
+
+class _FakeToolUseBlock:
+    type = "tool_use"
+    def __init__(self, id_: str, name: str, input_: dict, **extras):
+        self.id = id_
+        self.name = name
+        self.input = input_
+        for k, v in extras.items():
+            setattr(self, k, v)
+
+
+def test_serialize_text_block_drops_parser_extras():
+    from wirestudio.agent.agent import _serialize_assistant_block
+    block = _FakeTextBlock("hello", parsed_output={"foo": "bar"}, citations=[])
+    out = _serialize_assistant_block(block)
+    assert out == {"type": "text", "text": "hello"}
+    assert "parsed_output" not in out
+    assert "citations" not in out
+
+
+def test_serialize_tool_use_block_keeps_only_input_fields():
+    from wirestudio.agent.agent import _serialize_assistant_block
+    block = _FakeToolUseBlock(
+        "tu_01", "search_components", {"query": "motion"},
+        cache_creation_input_tokens=42,  # SDK-attached usage hint
+    )
+    out = _serialize_assistant_block(block)
+    assert out == {
+        "type": "tool_use",
+        "id": "tu_01",
+        "name": "search_components",
+        "input": {"query": "motion"},
+    }
+    assert "cache_creation_input_tokens" not in out
+
+
+def test_serialize_unknown_block_falls_back_to_model_dump():
+    """Future SDK block types (thinking, server_tool_use, ...) round-trip
+    via model_dump until we add an explicit branch. Better than dropping
+    them silently."""
+    from wirestudio.agent.agent import _serialize_assistant_block
+
+    class _Future:
+        type = "thinking"
+        def __init__(self):
+            self.thought = "..."
+        def model_dump(self):
+            return {"type": self.type, "thought": self.thought}
+
+    out = _serialize_assistant_block(_Future())
+    assert out == {"type": "thinking", "thought": "..."}

--- a/wirestudio/agent/agent.py
+++ b/wirestudio/agent/agent.py
@@ -127,6 +127,33 @@ def _process_tool_calls(response, working_design: dict, library: Library, tool_c
     return tool_results, events
 
 
+def _serialize_assistant_block(block: object) -> dict:
+    """Strip SDK-side parser metadata from a content block before feeding
+    it back as conversation history.
+
+    `Message.content[*].model_dump()` includes fields the SDK attaches
+    while parsing the streamed response (e.g. `parsed_output` on text
+    blocks under structured-output paths). The Anthropic API rejects
+    those extras on input -- a multi-turn agent loop fails on the next
+    request with `messages.N.content.M.text.parsed_output: Extra inputs
+    are not permitted`. So we hand-pick only the fields the API
+    documents as input-valid for each block type.
+    """
+    btype = getattr(block, "type", None)
+    if btype == "text":
+        return {"type": "text", "text": getattr(block, "text", "")}
+    if btype == "tool_use":
+        return {
+            "type": "tool_use",
+            "id": getattr(block, "id", None),
+            "name": getattr(block, "name", None),
+            "input": getattr(block, "input", {}),
+        }
+    # Defensive: future block kinds (e.g. thinking, server_tool_use) get
+    # dumped as-is. Add explicit branches when we start using them.
+    return block.model_dump() if hasattr(block, "model_dump") else dict(block)  # type: ignore[arg-type]
+
+
 def stream_turn_events(
     *,
     design: dict,
@@ -194,7 +221,7 @@ def stream_turn_events(
             if response.stop_reason != "tool_use":
                 break
 
-            messages.append({"role": "assistant", "content": [b.model_dump() for b in response.content]})
+            messages.append({"role": "assistant", "content": [_serialize_assistant_block(b) for b in response.content]})
             tool_results, tool_events = _process_tool_calls(response, working_design, library_instance, tool_calls_log)
             for event in tool_events:
                 yield event


### PR DESCRIPTION
## Summary
- Real bug found by a multi-turn user session: after ~10 turns the next Anthropic API call 400'd with `messages.N.content.M.text.parsed_output: Extra inputs are not permitted`. Conversation was unrecoverable.
- Fix: sanitize assistant content blocks to only the API-input-valid keys before appending to history. Whitelist per block type rather than `model_dump()` everything.
- Manually verified end-to-end against a live Anthropic API: a previously-failing multi-turn garage-door session now completes.

## Why
`Message.content[*].model_dump()` carries SDK-side parser metadata (`parsed_output` on `TextBlock` under structured-output paths, plus other usage hints) that the Anthropic API rejects on input. The agent loop fed `model_dump()` straight back as conversation history, so once a tainted block landed in `messages[]` the next request died.

## Why existing tests didn't catch it
`tests/test_agent.py` mocks the Anthropic call entirely — the round-trip back into the API was never exercised against the real schema. This is exactly the failure mode the queued "agent failure-mode tests" item in `START.md` is supposed to harden against (real API rejects, network errors, mid-stream disconnects).

## What changed
- `wirestudio/agent/agent.py`: new `_serialize_assistant_block(block)` whitelist:
  - `text` → `{type, text}`
  - `tool_use` → `{type, id, name, input}`
  - unknown future block kinds (thinking, server_tool_use, ...) fall back to `model_dump()` so we don't silently drop them; add an explicit branch when those start being used.
  - Call site at agent.py:197 swapped from `b.model_dump()` to `_serialize_assistant_block(b)`.
- `tests/test_agent.py`: 3 new unit tests that pin the sanitizer:
  - text block drops `parsed_output` + `citations`
  - tool_use block drops `cache_creation_input_tokens`
  - unknown block type falls back to `model_dump`

## Test plan
- [x] `pytest -q tests/test_agent.py` → 27/27 pass (was 24; +3 new)
- [x] Full `pytest -q` → 302/302 pass
- [x] `ruff check wirestudio/agent/agent.py tests/test_agent.py` → clean
- [x] Live multi-turn agent session against real Anthropic API: previously-failing garage-door flow (search → add 5 components → solve_pins → validate → render → 5 set_connection calls → next turn) now completes without 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)