### PR TITLE
agent: cost tuning + parsed_output regression fix + MCP pivot roadmap

### DIFF
--- a/START.md
+++ b/START.md
@@ -170,18 +170,73 @@ reason to publish to PyPI.
 
 **Next up candidates (current ordering, 2026-05-09):**
 
-1. Library batch 3 from the jesserockz survey: tuya MCU bridge
-   (vendor class — switches/sensors/numbers/selects/climate/fan all
-   hang off it), modbus_controller + sdm_meter (RS485 + MAX485
-   transceiver), bl0906 (6-channel energy meter), nextion HMI
-   display. Same format as #12 / #17. This is now the obvious
-   continuation: the compile gate is proven, so library expansion
-   is end-to-end verified by default.
-2. WebUI basic/advanced mode toggle (verified-tier surface by default;
-   Schematic / Enclosure / Push-to-fleet / Agent behind Advanced).
-3. Component-coverage matrix script — walk goldens, emit a checkbox
-   table of which library entries have a passing example.
-4. **Gemini plan tail (open items from PR #19's review doc):**
+(Items 1–3 from the previous list shipped: library batch 3 in PR
+#20, WebUI basic/advanced toggle in PR #22, coverage matrix in PR
+#23. Ruff cleanup shipped in PR #21. PR #24 fixed a real
+multi-turn agent regression — `_serialize_assistant_block`
+sanitizes SDK parser metadata before history append. Live UI
+testing surfaced two strategic items below.)
+
+1. **Agent cost tuning.** Multi-turn agent sessions burn through
+   API credits faster than expected on `claude-opus-4-7`. Tackle
+   in priority of impact:
+   1. **Configurable model tier.** Default to `claude-sonnet-4-6`
+      (5× cheaper input/output than Opus) via env var
+      `WIRESTUDIO_AGENT_MODEL`. Opus stays as an opt-in. Agent
+      work here is tool-routing + dict editing, not frontier
+      reasoning — Sonnet is sufficient.
+   2. **Verify prompt caching is hitting.** The library JSON has
+      `cache_control: ephemeral` at `agent.py:172` but
+      `cache_read_input_tokens` hasn't been confirmed in usage.
+      Also add a cache breakpoint on `SYSTEM_INSTRUCTIONS` (it's
+      stable across turns, currently uncached).
+   3. **Slim the system payload.** Today every system prompt
+      carries the full library YAML for 56 components + 14
+      boards (~30–50 KB). Emit a compact index by default
+      (id + category + use_cases + aliases); add a
+      `library_detail(id)` tool the agent calls when it needs
+      the full sheet for a specific component.
+   4. **Lower `max_iterations`.** Currently 12. Most design
+      edits take 3–5 tool calls; cap at 8.
+   5. **Compact `tool_result` payloads.** `search_components`
+      returns full library cards; trim to id + category +
+      score. Saves repeat-trip tokens.
+
+   Combined estimate: 5–10× cheaper per turn with no real
+   capability loss. Items 1.1 + 1.2 are this session's PR.
+
+2. **MCP pivot (placeholder — bigger architectural call).**
+   Expose the agent tool surface (`wirestudio/agent/tools.py` —
+   11 tools) as an MCP server. Users with a Claude Code or
+   Claude Desktop subscription drive the studio from their host
+   client; wirestudio pays nothing for LLM tokens. Subscription
+   economics for the user, decoupling for us. The HTTP API
+   already provides design persistence + render — MCP is mostly
+   plumbing.
+
+   Open questions to settle before scoping the work:
+   - **Two surfaces or one?** Keep the embedded `/agent/turn`
+     endpoint for users with their own API key, plus add MCP?
+     Or drop the embedded path and lean on MCP only? More code
+     vs. simpler ownership.
+   - **Tool-call boundary.** Each MCP tool is stateless;
+     wirestudio's tools today mutate a design dict in memory.
+     Either tools take + return the design dict each call (fat
+     payload), or they reference a server-side design id and
+     mutate via the existing `/designs/{id}` endpoints
+     (stateful, racy under concurrent agents).
+   - **Render visibility.** The web UI's value-add is the live
+     YAML / ASCII / pinout pane. If the user is driving from
+     Claude Code, do they ever open the UI? If not, the
+     studio's UI surface shrinks. If yes, MCP needs a "design
+     id" the UI can subscribe to so edits show up live.
+   - **Auth model.** Today the agent endpoints rate-limit by
+     IP; an MCP server reachable on the host needs a different
+     story (loopback-only, token, both?).
+
+   Not blocked, just need to decide before pouring code in.
+
+3. **Gemini plan tail (open items from PR #19's review doc):**
    - SQLite-backed `DesignStore` + `SessionStore` implementations
      (Protocol abstractions are in; alternative backend isn't).
    - `Field(description="…")` on `wirestudio.api.schemas` so
@@ -193,13 +248,16 @@ reason to publish to PyPI.
      `wirestudio/agent`, `wirestudio/fleet`).
    - Agent failure-mode tests: Anthropic 429 / connection error /
      mid-stream disconnect coverage in `tests/test_agent.py`.
-   - Ruff cleanup: PR #19 left 21 lint errors (unused
-     `SessionStore` / `DesignStore` imports in tests, E402
-     import-order on `tests/test_fleet.py`'s `pytestmark` line).
-     CI doesn't run ruff; the opt-in pre-commit hook does. Cheap
-     `ruff --fix` + manual E402 reorder.
+     PR #24's `parsed_output` regression would have been caught
+     by a "real-API-rejects-extras" test in this group.
    - (Decided against:) global `@app.exception_handler` — see PR #19
      rationale; helper-function approach is the chosen pattern.
+
+4. **Library coverage gap follow-ups.** PR #23's matrix surfaced
+   25 components and 6 boards without a bundled example. Each is
+   a small example PR in the #12 / #17 mold. Useful steady-state
+   work between substantive items.
+
 5. 1.0 — KiCad PCB layout (reuse the schematic's netlist;
    Freerouting; Gerber + JLCPCB CPL/BOM).
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -279,3 +279,77 @@ def test_session_store_rejects_traversal_directly(tmp_path):
     store = FileSessionStore(root=tmp_path)
     with pytest.raises(ValueError):
         store.path("../passwd")
+
+
+# ---------------------------------------------------------------------------
+# Assistant block sanitizer
+# ---------------------------------------------------------------------------
+# Real bug from a multi-turn agent session: after ~10 turns the next API call
+# 400'd with `messages.N.content.M.text.parsed_output: Extra inputs are not
+# permitted`. Cause: the SDK's message-stream parser attaches `parsed_output`
+# (and potentially other helpers) to TextBlock instances; feeding the raw
+# model_dump() back as history poisons the conversation. _serialize_assistant_block
+# whitelists only the API-accepted keys per block type.
+
+class _FakeTextBlock:
+    type = "text"
+    def __init__(self, text: str, **extras):
+        self.text = text
+        for k, v in extras.items():
+            setattr(self, k, v)
+    def model_dump(self):
+        return {"type": self.type, "text": self.text, **{
+            k: v for k, v in self.__dict__.items() if k != "text"
+        }}
+
+
+class _FakeToolUseBlock:
+    type = "tool_use"
+    def __init__(self, id_: str, name: str, input_: dict, **extras):
+        self.id = id_
+        self.name = name
+        self.input = input_
+        for k, v in extras.items():
+            setattr(self, k, v)
+
+
+def test_serialize_text_block_drops_parser_extras():
+    from wirestudio.agent.agent import _serialize_assistant_block
+    block = _FakeTextBlock("hello", parsed_output={"foo": "bar"}, citations=[])
+    out = _serialize_assistant_block(block)
+    assert out == {"type": "text", "text": "hello"}
+    assert "parsed_output" not in out
+    assert "citations" not in out
+
+
+def test_serialize_tool_use_block_keeps_only_input_fields():
+    from wirestudio.agent.agent import _serialize_assistant_block
+    block = _FakeToolUseBlock(
+        "tu_01", "search_components", {"query": "motion"},
+        cache_creation_input_tokens=42,  # SDK-attached usage hint
+    )
+    out = _serialize_assistant_block(block)
+    assert out == {
+        "type": "tool_use",
+        "id": "tu_01",
+        "name": "search_components",
+        "input": {"query": "motion"},
+    }
+    assert "cache_creation_input_tokens" not in out
+
+
+def test_serialize_unknown_block_falls_back_to_model_dump():
+    """Future SDK block types (thinking, server_tool_use, ...) round-trip
+    via model_dump until we add an explicit branch. Better than dropping
+    them silently."""
+    from wirestudio.agent.agent import _serialize_assistant_block
+
+    class _Future:
+        type = "thinking"
+        def __init__(self):
+            self.thought = "..."
+        def model_dump(self):
+            return {"type": self.type, "thought": self.thought}
+
+    out = _serialize_assistant_block(_Future())
+    assert out == {"type": "thinking", "thought": "..."}

--- a/web/src/components/AgentSidebar.tsx
+++ b/web/src/components/AgentSidebar.tsx
@@ -16,6 +16,10 @@ interface ChatMessage {
   pendingToolCalls?: PendingToolCall[];  // populated mid-stream
   streaming?: boolean;
   isError?: boolean;
+  /** Populated on turn_complete -- shown as a small footer per assistant
+   *  message so cache-hit + model choice are visible at a glance. */
+  usage?: Record<string, number>;
+  model?: string;
 }
 
 interface Props {
@@ -93,6 +97,8 @@ export function AgentSidebar({ open, design, onClose, onDesignReplaced }: Props)
             toolCalls: event.tool_calls,
             pendingToolCalls: undefined,
             streaming: false,
+            usage: event.usage,
+            model: event.model,
           }));
         } else if (event.type === "error") {
           appendToLastAssistant((m) => ({
@@ -292,7 +298,39 @@ function Bubble({ message }: { message: ChatMessage }) {
             </ul>
           </details>
         )}
+
+        {message.usage && !message.streaming && (
+          <UsageFooter usage={message.usage} model={message.model} />
+        )}
       </div>
+    </div>
+  );
+}
+
+function UsageFooter({ usage, model }: { usage: Record<string, number>; model?: string }) {
+  const inTok = usage.input_tokens ?? 0;
+  const outTok = usage.output_tokens ?? 0;
+  const cacheRead = usage.cache_read_input_tokens ?? 0;
+  const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+  // Cache hit ratio against the input total (read + write + uncached input).
+  // A high read share is the win: ephemeral cache returns a ~90% read discount.
+  const totalInput = inTok + cacheRead + cacheWrite;
+  const hitPct = totalInput > 0 ? Math.round((cacheRead / totalInput) * 100) : 0;
+  return (
+    <div className="mt-2 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-zinc-500">
+      {model && <span title="model that handled this turn">{model}</span>}
+      <span title="uncached input tokens">in {inTok}</span>
+      <span title="output tokens">out {outTok}</span>
+      {(cacheRead > 0 || cacheWrite > 0) && (
+        <span
+          className={cacheRead > 0 ? "text-emerald-400/80" : "text-amber-400/80"}
+          title={cacheRead > 0
+            ? `${cacheRead} cached input tokens read (${hitPct}% of input). ~90% cheaper than uncached input.`
+            : `${cacheWrite} input tokens written to cache. Subsequent turns within ~5min will read from this for cheap.`}
+        >
+          cache {cacheRead > 0 ? `${hitPct}% hit` : "warmed"}
+        </span>
+      )}
     </div>
   );
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -202,6 +202,7 @@ export type AgentStreamEvent =
       tool_calls: AgentToolCall[];
       stop_reason: string;
       usage: Record<string, number>;
+      model?: string;
     }
   | { type: "error"; message: string };
 

--- a/wirestudio/agent/agent.py
+++ b/wirestudio/agent/agent.py
@@ -20,6 +20,17 @@ except ImportError:  # pragma: no cover - exercised in deployment, not tests
     _ANTHROPIC_INSTALLED = False
 
 
+# Default agent model. Sonnet handles tool-routing + design-dict editing
+# fine and is ~5x cheaper than Opus. Override via WIRESTUDIO_AGENT_MODEL
+# (e.g., set to claude-opus-4-7 for the long-tail ambiguous prompts where
+# Opus's reasoning shows up). Per-call override still wins over the env.
+DEFAULT_AGENT_MODEL = "claude-sonnet-4-6"
+
+
+def _resolve_model(explicit: Optional[str] = None) -> str:
+    return explicit or os.environ.get("WIRESTUDIO_AGENT_MODEL") or DEFAULT_AGENT_MODEL
+
+
 SYSTEM_INSTRUCTIONS = """\
 You are a helper inside wirestudio, a tool that turns a `design.json` \
 document into ESPHome YAML + an ASCII wiring diagram + a BOM.
@@ -58,6 +69,7 @@ class TurnResult:
     tool_calls: list[dict]
     stop_reason: str
     usage: dict
+    model: str = ""
 
 
 def _build_library_context(library: Library) -> str:
@@ -127,6 +139,33 @@ def _process_tool_calls(response, working_design: dict, library: Library, tool_c
     return tool_results, events
 
 
+def _serialize_assistant_block(block: object) -> dict:
+    """Strip SDK-side parser metadata from a content block before feeding
+    it back as conversation history.
+
+    `Message.content[*].model_dump()` includes fields the SDK attaches
+    while parsing the streamed response (e.g. `parsed_output` on text
+    blocks under structured-output paths). The Anthropic API rejects
+    those extras on input -- a multi-turn agent loop fails on the next
+    request with `messages.N.content.M.text.parsed_output: Extra inputs
+    are not permitted`. So we hand-pick only the fields the API
+    documents as input-valid for each block type.
+    """
+    btype = getattr(block, "type", None)
+    if btype == "text":
+        return {"type": "text", "text": getattr(block, "text", "")}
+    if btype == "tool_use":
+        return {
+            "type": "tool_use",
+            "id": getattr(block, "id", None),
+            "name": getattr(block, "name", None),
+            "input": getattr(block, "input", {}),
+        }
+    # Defensive: future block kinds (e.g. thinking, server_tool_use) get
+    # dumped as-is. Add explicit branches when we start using them.
+    return block.model_dump() if hasattr(block, "model_dump") else dict(block)  # type: ignore[arg-type]
+
+
 def stream_turn_events(
     *,
     design: dict,
@@ -134,16 +173,21 @@ def stream_turn_events(
     session_id: Optional[str] = None,
     library: Optional[Library] = None,
     sessions: Optional[SessionStore] = None,
-    model: str = "claude-opus-4-7",
+    model: Optional[str] = None,
     max_iterations: int = 12,
 ) -> Iterator[dict]:
-    """Run a single user turn and yield events as they happen."""
+    """Run a single user turn and yield events as they happen.
+
+    `model` defaults to `WIRESTUDIO_AGENT_MODEL` env var, falling back to
+    `DEFAULT_AGENT_MODEL` (Sonnet). Pass an explicit string to override
+    per-call (e.g., the agent UI could expose a model picker)."""
     available, reason = is_available()
     if not available:
         yield {"type": "error", "message": reason or "agent unavailable"}
         return
 
     library_instance = library or default_library()
+    resolved_model = _resolve_model(model)
 
     sid, sessions_store, working_design, messages, library_block = _initialize_turn(
         design, user_message, session_id, sessions, library_instance
@@ -164,11 +208,15 @@ def stream_turn_events(
     try:
         for _ in range(max_iterations):
             with client.messages.stream(
-                model=model,
+                model=resolved_model,
                 max_tokens=4096,
                 thinking={"type": "adaptive"},
+                # Two cache breakpoints: SYSTEM_INSTRUCTIONS is small but stable
+                # across every turn -> always a hit after the first, ~90% read
+                # discount. library_block is ~30-50KB stable JSON -> the big
+                # win. Anthropic caches at each breakpoint that has cache_control.
                 system=[
-                    {"type": "text", "text": SYSTEM_INSTRUCTIONS},
+                    {"type": "text", "text": SYSTEM_INSTRUCTIONS, "cache_control": {"type": "ephemeral"}},
                     {"type": "text", "text": library_block, "cache_control": {"type": "ephemeral"}},
                 ],
                 tools=TOOL_SCHEMAS,
@@ -194,7 +242,7 @@ def stream_turn_events(
             if response.stop_reason != "tool_use":
                 break
 
-            messages.append({"role": "assistant", "content": [b.model_dump() for b in response.content]})
+            messages.append({"role": "assistant", "content": [_serialize_assistant_block(b) for b in response.content]})
             tool_results, tool_events = _process_tool_calls(response, working_design, library_instance, tool_calls_log)
             for event in tool_events:
                 yield event
@@ -219,6 +267,7 @@ def stream_turn_events(
         "tool_calls": tool_calls_log,
         "stop_reason": stop_reason,
         "usage": accumulated_usage,
+        "model": resolved_model,
     }
 
 
@@ -230,7 +279,7 @@ def run_turn(
     session_id: Optional[str] = None,
     library: Optional[Library] = None,
     sessions: Optional[SessionStore] = None,
-    model: str = "claude-opus-4-7",
+    model: Optional[str] = None,
     max_iterations: int = 12,
 ) -> TurnResult:
     """Non-streaming wrapper. Consumes stream_turn_events and collapses
@@ -260,4 +309,5 @@ def run_turn(
         tool_calls=final["tool_calls"],
         stop_reason=final["stop_reason"],
         usage=final["usage"],
+        model=final.get("model", ""),
     )


### PR DESCRIPTION
## Summary

Three changes that the live UI testing session surfaced together. **Supersedes #24** — that PR's sanitizer fix is included here as commit-1's contents.

### 1. Multi-turn regression fix (was #24)
Real bug: after ~10 turns the next API call 400'd with \`messages.N.content.M.text.parsed_output: Extra inputs are not permitted\`. Cause: \`Message.content[*].model_dump()\` round-trips SDK parser metadata that the Anthropic API rejects on input. New \`_serialize_assistant_block\` whitelists only API-input-valid fields per block type. Three unit tests pin the shape.

### 2. Agent cost tuning, round 1
**Default model: \`claude-opus-4-7\` → \`claude-sonnet-4-6\`.** Sonnet handles the agent's tool-routing + design-dict editing work fine and is ~5× cheaper. Override per-deploy via \`WIRESTUDIO_AGENT_MODEL\` env var; per-call via \`model=\` kwarg. Opus stays as opt-in.

**Cache breakpoint added on \`SYSTEM_INSTRUCTIONS\`.** Was uncached; the library JSON below it had \`cache_control: ephemeral\` already. Both blocks now write to and read from the ephemeral cache, so subsequent turns within ~5 min hit ~10% of input price for the system payload.

**Cache hit visibility in the agent sidebar.** New \`UsageFooter\` component renders \`model · in N out N · cache N% hit\` (or \`cache warmed\` on the first turn) per assistant message. Reads the existing \`usage\` payload that already flows through \`turn_complete\`. Makes "is caching working?" answerable at a glance instead of by reading server logs.

### 3. \`START.md\` roadmap update
- Retire shipped items #1-3 from the Next-up list (PRs #20 / #22 / #23 + the ruff cleanup PR #21 all merged).
- Add **Agent cost tuning** as a 5-item sub-roadmap; this PR ships 1.1 + 1.2. The remaining tuning steps (compact library payload via \`library_detail(id)\` tool, lower \`max_iterations\` from 12 → 8, slim \`tool_result\` payloads) are queued.
- Add **MCP pivot placeholder** with notes — exposing the agent tool surface as an MCP server so users with a Claude Code / Claude Desktop subscription drive the studio without per-token billing. Open questions documented (two surfaces vs. one, stateful vs. fat-payload tool calls, render-visibility coupling, auth model). Architectural call; not blocked but wants a decision before scoping.

## Verification
- [x] \`pytest -q\` → 302/302 pass
- [x] \`npm test -- --run\` → 129/129 pass
- [x] \`ruff check\` clean
- [x] \`tsc --noEmit\` clean
- [x] Live multi-turn agent session against real Anthropic API: previously-failing garage-door flow now completes through the full tool loop; sidebar footer shows \`claude-sonnet-4-6 · in 234 out 156 · cache 87% hit\` on the second turn

## What to do with #24
Close it as superseded — its commits (the sanitizer + the 3 sanitizer tests) are included here verbatim via cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)