### PR TITLE
mcp: phase 1.1 — server skeleton over Streamable HTTP

### DIFF
--- a/START.md
+++ b/START.md
@@ -238,11 +238,18 @@ testing surfaced two strategic items below.)
 
    ### Phase 1: wirestudio MCP server (the actual scope)
 
-   1. **MCP server skeleton** — `wirestudio/mcp/server.py`
-      wrapping the 11 tools in `wirestudio/agent/tools.py`. Same
-      Python, different protocol shim. Day-1 deliverable. Tools
-      expose only the design-editing surface; generators stay
-      callable via HTTP API + CLI as before.
+   1. **MCP server skeleton — shipped (PR #27, 2026-05-10).**
+      `wirestudio/mcp/server.py` wraps all 12 tools from
+      `wirestudio/agent/tools.py` as FastMCP tools; mounted into
+      the existing FastAPI app at `/mcp` over Streamable HTTP.
+      Bearer-token auth (`WIRESTUDIO_MCP_TOKEN` env var or
+      auto-generated to `~/.config/wirestudio/mcp-token` mode
+      0600). Mutating tools take `design_id` and persist back to
+      the design store; read-only library tools skip storage.
+      `WIRESTUDIO_MCP_ENABLED=false` short-circuits the wiring
+      for envs that don't need it. `docs/MCP.md` covers config +
+      env-var precedence; a polished walkthrough lands with the
+      Phase 1.5 docs sweep.
    2. **`design-changed` SSE channel** on the HTTP API. Browser
       tabs subscribe per design id; any write to that design
       (from MCP, HTTP, or CLI) triggers the same channel and the
@@ -255,14 +262,15 @@ testing surfaced two strategic items below.)
    4. **`set_active_design(id)` tool + UI plumbing.** Browser
       cookies the active id; MCP tools default to it. So the
       user's "add a BME280 to this design" prompt resolves
-      against whatever the browser tab is showing.
-   5. **MCP docs.** `docs/MCP.md` with the
-      `claude_desktop_config.json` snippet and a one-screen
-      walkthrough.
+      against whatever the browser tab is showing. Until this
+      lands, every design-bound MCP tool needs an explicit
+      `design_id` and the design must already exist in the
+      store (created via the web UI's save flow).
+   5. **MCP docs.** Polished walkthrough on top of the
+      Phase 1.1 `docs/MCP.md` skeleton — end-to-end "click here,
+      paste this, ask Claude to do that" flow.
 
-   ~2-3 PRs of work total. The first is genuinely small because
-   `tools.py` is already a clean function surface — MCP is
-   mostly bindings.
+   Remaining 1.2-1.5 are the next 2-3 PRs.
 
    ### Phase 2: knowledge importers (bigger payoff than KiCAD-MCP)
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,91 @@
+# MCP server (Phase 1.1 skeleton)
+
+Wirestudio exposes its design-editing tool surface over the
+[Model Context Protocol](https://modelcontextprotocol.io). Point a host
+LLM client (Claude Desktop, Claude Code) at the daemon and the model
+drives the studio without burning your Anthropic credits.
+
+This page covers the day-1 skeleton. Phase 1.2-1.5 (live design-changed
+SSE channel, MCP resources, set_active_design tool, polished walkthrough)
+land in follow-on PRs.
+
+## Endpoint
+
+`POST /mcp` on the wirestudio HTTP API. Streamable HTTP transport, mounted
+into the same FastAPI app as `/library/*`, `/design/*`, etc.
+
+## Auth
+
+Bearer token, always required. Resolution order:
+
+1. `WIRESTUDIO_MCP_TOKEN` env var.
+2. Persisted file at `~/.config/wirestudio/mcp-token` (override path with
+   `WIRESTUDIO_MCP_TOKEN_PATH`).
+3. Auto-generated on first start, persisted with mode 0600. Logged at
+   INFO so an operator can copy the value: `Generated MCP token; copy
+   it from /home/<user>/.config/wirestudio/mcp-token`.
+
+## Claude Desktop config
+
+`claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "wirestudio": {
+      "url": "http://localhost:8765/mcp",
+      "headers": { "Authorization": "Bearer <paste-token-here>" }
+    }
+  }
+}
+```
+
+For a remote homelab deployment, swap the URL for
+`https://wirestudio.your.domain/mcp`.
+
+## DNS-rebinding allowlist
+
+The `mcp` SDK ships with a DNS-rebinding mitigation that defaults to
+loopback hostnames. To run wirestudio behind a real hostname, set:
+
+```
+WIRESTUDIO_MCP_ALLOWED_HOSTS=wirestudio.example.com:443,wirestudio.example.com
+```
+
+## Tools (Phase 1.1)
+
+Same 12 tools the embedded `/agent/turn` flow uses. Mutating tools take
+a `design_id` argument and operate on the persisted design at
+`designs/<id>.json`:
+
+| Tool | Mutates | Notes |
+|------|---------|-------|
+| `search_components` | no | library lookup |
+| `list_boards` | no | library lookup |
+| `recommend` | no | ranked capability search |
+| `render` | no | YAML + ASCII for a stored design |
+| `validate` | no | schema + library check |
+| `set_board` | yes | replace `design.board` |
+| `add_component` | yes | append a component |
+| `remove_component` | yes | drop component + originating connections |
+| `set_param` | yes | per-instance param set/delete |
+| `set_connection` | yes | retarget a single connection |
+| `add_bus` | yes | append a bus |
+| `solve_pins` | yes | auto-assign unbound connections |
+
+`design_id` defaults will land in Phase 1.4 (`set_active_design` tool +
+browser cookie); until then, every design-bound tool needs an explicit
+`design_id` and the design must already exist on disk (create one via
+the web UI's save flow first).
+
+## Disable
+
+`WIRESTUDIO_MCP_ENABLED=false` skips MCP wiring entirely (e.g. for the
+`esphome-config` CI run, where the server's lifespan would add startup
+latency for nothing).
+
+## Upgrade path
+
+OAuth 2.1 (the MCP spec's multi-user auth flow) is deferred. Right shape
+for SaaS-grade hosted MCPs; wrong shape for a single-operator homelab.
+Revisit if/when wirestudio grows multi-user.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "anthropic>=0.40",
     "httpx>=0.27",
     "slowapi>=0.1.9",
+    "mcp>=1.27",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -1,0 +1,100 @@
+"""Tests for the MCP bearer-token middleware + token resolution helper."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from wirestudio.mcp.auth import (
+    DEFAULT_TOKEN_PATH,
+    BearerTokenMiddleware,
+    resolve_token,
+)
+
+
+pytestmark = pytest.mark.anyio
+
+
+def _ok(_request):
+    return JSONResponse({"ok": True})
+
+
+def _build_app(token: str) -> Starlette:
+    app = Starlette(routes=[Route("/probe", _ok)])
+    app.add_middleware(BearerTokenMiddleware, token=token)
+    return app
+
+
+async def test_middleware_rejects_missing_header():
+    app = _build_app("secret-token")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/probe")
+    assert r.status_code == 401
+    assert r.headers["www-authenticate"].startswith("Bearer")
+
+
+async def test_middleware_rejects_wrong_token():
+    app = _build_app("right")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/probe", headers={"Authorization": "Bearer wrong"})
+    assert r.status_code == 401
+
+
+async def test_middleware_accepts_correct_token():
+    app = _build_app("right")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/probe", headers={"Authorization": "Bearer right"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+
+async def test_middleware_rejects_non_bearer_scheme():
+    app = _build_app("right")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/probe", headers={"Authorization": "Basic right"})
+    assert r.status_code == 401
+
+
+def test_resolve_token_env_wins(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("WIRESTUDIO_MCP_TOKEN", "from-env")
+    file_path = tmp_path / "mcp-token"
+    file_path.write_text("from-file")
+    assert resolve_token(token_path=file_path) == "from-env"
+    # Env-var path doesn't read or touch the file.
+    assert file_path.read_text() == "from-file"
+
+
+def test_resolve_token_reads_persisted_file(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("WIRESTUDIO_MCP_TOKEN", raising=False)
+    file_path = tmp_path / "mcp-token"
+    file_path.write_text("persisted")
+    assert resolve_token(token_path=file_path) == "persisted"
+
+
+def test_resolve_token_generates_and_persists(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("WIRESTUDIO_MCP_TOKEN", raising=False)
+    file_path = tmp_path / "nested" / "mcp-token"
+    assert not file_path.exists()
+    token = resolve_token(token_path=file_path)
+    assert token
+    assert file_path.read_text() == token
+    # 0600 because the file holds an auth secret.
+    mode = file_path.stat().st_mode & 0o777
+    assert mode == 0o600
+    # Subsequent calls return the same value.
+    assert resolve_token(token_path=file_path) == token
+
+
+def test_default_token_path_is_under_user_config():
+    # Anchored to ~/.config/wirestudio so operators know where to look
+    # without grepping the source.
+    assert DEFAULT_TOKEN_PATH.name == "mcp-token"
+    assert "wirestudio" in DEFAULT_TOKEN_PATH.parts

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,187 @@
+"""Tests for the MCP server wrapper around the agent tool surface."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from wirestudio.designs.store import FileDesignStore
+from wirestudio.library import default_library
+from wirestudio.mcp.server import build_mcp_server
+
+
+pytestmark = pytest.mark.anyio
+
+
+EXPECTED_TOOLS = {
+    "search_components",
+    "list_boards",
+    "recommend",
+    "render",
+    "validate",
+    "set_board",
+    "add_component",
+    "remove_component",
+    "set_param",
+    "set_connection",
+    "add_bus",
+    "solve_pins",
+}
+
+
+def _seed_design(store: FileDesignStore, design_id: str = "test-bench") -> str:
+    design = {
+        "schema_version": "0.1",
+        "id": design_id,
+        "name": "Test Bench",
+        "board": {"library_id": "esp32-devkitc-v4", "mcu": "esp32", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [],
+        "buses": [],
+        "connections": [],
+    }
+    store.save(design, design_id=design_id)
+    return design_id
+
+
+def _content_to_dict(content: list[Any]) -> dict:
+    """Decode the first TextContent payload as JSON."""
+    assert content, "expected at least one content block"
+    text = getattr(content[0], "text", None)
+    assert isinstance(text, str)
+    return json.loads(text)
+
+
+@pytest.fixture
+def mcp_server(tmp_path: Path):
+    store = FileDesignStore(root=tmp_path / "designs")
+    server = build_mcp_server(default_library(), store)
+    return server, store
+
+
+async def test_all_expected_tools_registered(mcp_server):
+    server, _ = mcp_server
+    tools = await server.list_tools()
+    names = {t.name for t in tools}
+    assert names == EXPECTED_TOOLS
+
+
+async def test_tool_input_schemas_include_design_id_for_mutating_tools(mcp_server):
+    server, _ = mcp_server
+    tools = {t.name: t for t in await server.list_tools()}
+    for name in {"set_board", "add_component", "remove_component", "set_param",
+                 "set_connection", "add_bus", "solve_pins", "render", "validate"}:
+        schema = tools[name].inputSchema
+        assert "design_id" in schema.get("properties", {}), f"{name} missing design_id"
+
+
+async def test_search_components_finds_bme280(mcp_server):
+    server, _ = mcp_server
+    out = await server.call_tool("search_components", {"query": "bme280"})
+    payload = _content_to_dict(out)
+    assert payload["total"] >= 1
+    ids = [m["library_id"] for m in payload["matches"]]
+    assert "bme280" in ids
+
+
+async def test_list_boards_returns_known_board(mcp_server):
+    server, _ = mcp_server
+    out = await server.call_tool("list_boards", {})
+    payload = _content_to_dict(out)
+    ids = {b["library_id"] for b in payload["boards"]}
+    assert "esp32-devkitc-v4" in ids
+
+
+async def test_add_component_persists_to_store(mcp_server):
+    server, store = mcp_server
+    design_id = _seed_design(store)
+
+    out = await server.call_tool(
+        "add_component",
+        {"design_id": design_id, "library_id": "bme280"},
+    )
+    payload = _content_to_dict(out)
+    assert payload["ok"] is True
+
+    # The mutation must have been written back to the store -- otherwise
+    # the next tool call (or the browser) sees a stale design.
+    saved = store.load(design_id)
+    assert len(saved["components"]) == 1
+    assert saved["components"][0]["library_id"] == "bme280"
+    assert saved["components"][0]["id"] == payload["instance_id"]
+
+
+async def test_validate_against_stored_design(mcp_server):
+    server, store = mcp_server
+    design_id = _seed_design(store)
+    out = await server.call_tool("validate", {"design_id": design_id})
+    payload = _content_to_dict(out)
+    assert payload["ok"] is True
+    assert payload["design_id"] == design_id
+
+
+async def test_render_against_stored_design(mcp_server):
+    server, store = mcp_server
+    design_id = _seed_design(store)
+    out = await server.call_tool("render", {"design_id": design_id})
+    payload = _content_to_dict(out)
+    assert payload["ok"] is True
+    assert "yaml" in payload
+    assert "ascii" in payload
+
+
+async def test_remove_component_persists(mcp_server):
+    server, store = mcp_server
+    design_id = _seed_design(store)
+    add = _content_to_dict(
+        await server.call_tool(
+            "add_component", {"design_id": design_id, "library_id": "bme280"}
+        )
+    )
+    instance_id = add["instance_id"]
+
+    out = await server.call_tool(
+        "remove_component",
+        {"design_id": design_id, "instance_id": instance_id},
+    )
+    assert _content_to_dict(out)["ok"] is True
+    assert store.load(design_id)["components"] == []
+
+
+async def test_unknown_design_id_surfaces_as_tool_error(mcp_server):
+    server, _ = mcp_server
+    # Unknown design_id triggers FileNotFoundError in the store. FastMCP's
+    # contract is that tool exceptions become an isError-flagged result;
+    # call_tool itself raises ToolError so the model can recover instead
+    # of seeing a black-hole response.
+    with pytest.raises(Exception):
+        await server.call_tool(
+            "validate", {"design_id": "no-such-design"}
+        )
+
+
+async def test_mounted_mcp_route_requires_token(monkeypatch, tmp_path: Path):
+    # End-to-end: build the FastAPI app with MCP mounted, hit /mcp without
+    # a token, expect 401. We also confirm the route is mounted at all
+    # (a 404 would indicate the mount path was wrong).
+    monkeypatch.setenv("WIRESTUDIO_MCP_TOKEN", "test-secret")
+    monkeypatch.setenv("DESIGNS_DIR", str(tmp_path / "designs"))
+    monkeypatch.setenv("SESSIONS_DIR", str(tmp_path / "sessions"))
+
+    from wirestudio.api.app import create_app
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    # Lifespan needs to run for the MCP session manager. httpx.ASGITransport
+    # handles startup/shutdown around the request, but we use lifespan="on"
+    # via the lifespan manager pattern.
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+            headers={"Accept": "application/json, text/event-stream"},
+        )
+    assert r.status_code == 401, r.text

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 from typing import Optional
 
@@ -14,6 +15,8 @@ from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 import os
 from pydantic import ValidationError
+
+from wirestudio.mcp import BearerTokenMiddleware, build_mcp_server, resolve_token
 
 from wirestudio import __version__
 from wirestudio.agent.agent import is_available as agent_available, run_turn, stream_turn_events
@@ -144,6 +147,20 @@ def create_app(
     limiter = Limiter(key_func=get_remote_address)
 
 
+    mcp_enabled = os.environ.get("WIRESTUDIO_MCP_ENABLED", "true").lower() != "false"
+    mcp_server = build_mcp_server(lib, designs_store) if mcp_enabled else None
+
+    @asynccontextmanager
+    async def lifespan(_: FastAPI):
+        # FastMCP's session_manager wraps the streamable_http_app; without
+        # entering its run() context the /mcp endpoint 500s with "Task group
+        # is not initialized." AsyncExitStack lets us no-op when MCP is
+        # disabled without a duplicate yield branch.
+        async with AsyncExitStack() as stack:
+            if mcp_server is not None:
+                await stack.enter_async_context(mcp_server.session_manager.run())
+            yield
+
     # `docs_url=None` disables FastAPI's built-in /docs so we can serve our
     # own that points Swagger UI at /api/openapi.json -- which works whether
     # the page is reached directly (browser at :8765/docs) or via the
@@ -158,6 +175,7 @@ def create_app(
             "Pure layer over `wirestudio.generate`; no server-side state."
         ),
         docs_url=None,
+        lifespan=lifespan,
     )
 
     app.state.limiter = limiter
@@ -750,6 +768,24 @@ def create_app(
             session_id=session_id,
             messages=[AgentSessionMessage(**m) for m in messages],
         )
+
+    if mcp_server is not None:
+        # Streamable HTTP transport. mcp_server.streamable_http_app() registers
+        # `/mcp` on its own Starlette app; we wrap it in BearerTokenMiddleware
+        # and mount at root so the path stays `/mcp`. Mounting at `/mcp` would
+        # land the inner route at `/mcp/mcp`, which is wrong.
+        allowed_hosts = os.environ.get("WIRESTUDIO_MCP_ALLOWED_HOSTS")
+        if allowed_hosts:
+            mcp_server.settings.transport_security.allowed_hosts = [
+                h.strip() for h in allowed_hosts.split(",") if h.strip()
+            ]
+        token_path_env = os.environ.get("WIRESTUDIO_MCP_TOKEN_PATH")
+        token = resolve_token(
+            token_path=Path(token_path_env) if token_path_env else None,
+        )
+        mcp_app = mcp_server.streamable_http_app()
+        mcp_app.add_middleware(BearerTokenMiddleware, token=token)
+        app.mount("/", mcp_app)
 
     return app
 

--- a/wirestudio/mcp/__init__.py
+++ b/wirestudio/mcp/__init__.py
@@ -1,0 +1,20 @@
+"""MCP (Model Context Protocol) server for wirestudio.
+
+Exposes the agent's design-editing tool surface (`wirestudio/agent/tools.py`)
+as MCP tools so a host LLM client (Claude Desktop, Claude Code) can drive
+the studio without burning the user's Anthropic credits. The server mounts
+into the existing FastAPI app at `/mcp` over the Streamable HTTP transport.
+"""
+from wirestudio.mcp.auth import (
+    DEFAULT_TOKEN_PATH,
+    BearerTokenMiddleware,
+    resolve_token,
+)
+from wirestudio.mcp.server import build_mcp_server
+
+__all__ = [
+    "BearerTokenMiddleware",
+    "DEFAULT_TOKEN_PATH",
+    "build_mcp_server",
+    "resolve_token",
+]

--- a/wirestudio/mcp/auth.py
+++ b/wirestudio/mcp/auth.py
@@ -1,0 +1,96 @@
+"""Bearer-token auth for the MCP HTTP endpoint.
+
+Resolution precedence: env var `WIRESTUDIO_MCP_TOKEN` > persisted file
+(`~/.config/wirestudio/mcp-token`, mode 0600) > newly generated token
+(persisted to the same file). Tokens are 32 raw bytes encoded with
+`secrets.token_urlsafe`.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from pathlib import Path
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TOKEN_PATH = Path(os.path.expanduser("~/.config/wirestudio/mcp-token"))
+ENV_VAR = "WIRESTUDIO_MCP_TOKEN"
+
+
+def resolve_token(
+    *,
+    env_var: str = ENV_VAR,
+    token_path: Path | None = None,
+) -> str:
+    """Return the MCP bearer token, generating + persisting one on first call.
+
+    The env var wins if set (operators using k8s Secrets / sops set this and
+    the token-file path is ignored). Otherwise the persisted file is read.
+    Otherwise a fresh token is generated, persisted with mode 0600, and the
+    path is logged at INFO so the operator knows where to copy it from.
+    """
+    env_token = os.environ.get(env_var)
+    if env_token:
+        return env_token.strip()
+
+    path = token_path or DEFAULT_TOKEN_PATH
+    if path.exists():
+        return path.read_text().strip()
+
+    token = secrets.token_urlsafe(32)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(token)
+    path.chmod(0o600)
+    logger.info("Generated MCP token; copy it from %s", path)
+    return token
+
+
+class BearerTokenMiddleware:
+    """ASGI middleware that 401s any HTTP request without a matching bearer token.
+
+    Compares the `Authorization: Bearer <token>` header against the configured
+    token using `secrets.compare_digest` so a malicious client can't use timing
+    to brute-force the token. Non-HTTP scopes (lifespan, websocket) pass
+    through untouched.
+    """
+
+    def __init__(self, app: ASGIApp, *, token: str) -> None:
+        self.app = app
+        self._token = token
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers") or [])
+        auth = headers.get(b"authorization", b"").decode("latin-1", errors="ignore")
+        prefix = "Bearer "
+        if not auth.startswith(prefix) or not secrets.compare_digest(
+            auth[len(prefix):], self._token
+        ):
+            await _send_401(send)
+            return
+        await self.app(scope, receive, send)
+
+
+async def _send_401(send: Send) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 401,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"www-authenticate", b'Bearer realm="wirestudio-mcp"'),
+            ],
+        }
+    )
+    await send(
+        {
+            "type": "http.response.body",
+            "body": b'{"error":"missing or invalid bearer token"}',
+        }
+    )

--- a/wirestudio/mcp/server.py
+++ b/wirestudio/mcp/server.py
@@ -1,0 +1,287 @@
+"""MCP server wrapping the agent's tool surface.
+
+Each tool here is a thin shim over a function in `wirestudio/agent/tools.py`.
+Mutating tools take a `design_id` argument, load the design from the store,
+call the underlying handler (which mutates the dict in place), and persist
+the result back. Read-only library tools skip the store entirely.
+
+The server is a `FastMCP` instance. The caller is responsible for mounting
+its `streamable_http_app()` into the parent FastAPI app and arranging
+`session_manager.run()` in the parent's lifespan.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from wirestudio.agent.tools import (
+    _run_add_bus,
+    _run_add_component,
+    _run_list_boards,
+    _run_recommend,
+    _run_remove_component,
+    _run_render,
+    _run_search_components,
+    _run_set_board,
+    _run_set_connection,
+    _run_set_param,
+    _run_solve_pins,
+    _run_validate,
+)
+from wirestudio.designs.store import DesignStore
+from wirestudio.library import Library
+
+
+def build_mcp_server(
+    library: Library,
+    designs: DesignStore,
+    *,
+    name: str = "wirestudio",
+) -> FastMCP:
+    """Build a FastMCP server with all wirestudio tools registered."""
+    mcp = FastMCP(name=name)
+    _register_library_tools(mcp, library)
+    _register_design_tools(mcp, library, designs)
+    return mcp
+
+
+def _register_library_tools(mcp: FastMCP, library: Library) -> None:
+    @mcp.tool(
+        name="search_components",
+        description=(
+            "Fuzzy-search the component library by name, category, use_case, "
+            "or alias. Returns up to 10 matches with library_id, name, "
+            "category, and required ESPHome integrations. Use this before "
+            "calling add_component so you never invent a library_id."
+        ),
+    )
+    def search_components(query: str) -> dict:
+        return _run_search_components({}, library, query=query)
+
+    @mcp.tool(
+        name="list_boards",
+        description=(
+            "List every board in the library with its mcu, chip_variant, "
+            "framework, and platformio_board."
+        ),
+    )
+    def list_boards() -> dict:
+        return _run_list_boards({}, library)
+
+    @mcp.tool(
+        name="recommend",
+        description=(
+            "Rank library components against a free-text capability query "
+            "(e.g. 'motion detection', 'temperature humidity'). Returns up "
+            "to `limit` candidates with their electrical metadata, an "
+            "in-examples count, and a one-line rationale per pick. "
+            "Read-only -- doesn't add anything to a design. Optionally "
+            "pass constraints (voltage, max_current_ma_peak, required_bus, "
+            "excluded_categories) to filter before ranking."
+        ),
+    )
+    def recommend(
+        query: str,
+        limit: int = 10,
+        constraints: Optional[dict] = None,
+    ) -> dict:
+        return _run_recommend(
+            {}, library, query=query, limit=limit, constraints=constraints
+        )
+
+
+def _register_design_tools(
+    mcp: FastMCP, library: Library, designs: DesignStore
+) -> None:
+    def _load(design_id: str) -> dict:
+        return designs.load(design_id)
+
+    def _save(design_id: str, design: dict) -> None:
+        designs.save(design, design_id=design_id)
+
+    @mcp.tool(
+        name="render",
+        description=(
+            "Render the named design to ESPHome YAML + ASCII diagram. "
+            "Returns both as strings. Read-only."
+        ),
+    )
+    def render(design_id: str) -> dict:
+        return _run_render(_load(design_id), library)
+
+    @mcp.tool(
+        name="validate",
+        description=(
+            "Validate the named design against the JSON schema and library. "
+            "Returns ok=true plus a summary, or ok=false with the failing "
+            "field path + message. Read-only."
+        ),
+    )
+    def validate(design_id: str) -> dict:
+        return _run_validate(_load(design_id), library)
+
+    @mcp.tool(
+        name="set_board",
+        description=(
+            "Replace the design's board. Looks up the library board by id "
+            "and updates `design.board.{library_id, mcu, framework}`. Does "
+            "NOT translate existing pin references."
+        ),
+    )
+    def set_board(design_id: str, library_id: str) -> dict:
+        design = _load(design_id)
+        result = _run_set_board(design, library, library_id=library_id)
+        _save(design_id, design)
+        return result
+
+    @mcp.tool(
+        name="add_component",
+        description=(
+            "Add a component instance to the design. Auto-generates a "
+            "unique instance_id (or use `instance_id_hint`), sets `label` "
+            "(default = library component name), copies any provided "
+            "`params`. Returns the new instance_id."
+        ),
+    )
+    def add_component(
+        design_id: str,
+        library_id: str,
+        label: Optional[str] = None,
+        instance_id_hint: Optional[str] = None,
+        params: Optional[dict] = None,
+    ) -> dict:
+        design = _load(design_id)
+        result = _run_add_component(
+            design,
+            library,
+            library_id=library_id,
+            label=label,
+            instance_id_hint=instance_id_hint,
+            params=params,
+        )
+        _save(design_id, design)
+        return result
+
+    @mcp.tool(
+        name="remove_component",
+        description=(
+            "Remove a component instance and all connections originating "
+            "from it. Connections that target it via expander_id are left "
+            "as orphans."
+        ),
+    )
+    def remove_component(design_id: str, instance_id: str) -> dict:
+        design = _load(design_id)
+        result = _run_remove_component(design, library, instance_id=instance_id)
+        _save(design_id, design)
+        return result
+
+    @mcp.tool(
+        name="set_param",
+        description=(
+            "Set a single param on a component instance. Pass `value: null` "
+            "to delete the param entirely."
+        ),
+    )
+    def set_param(
+        design_id: str,
+        instance_id: str,
+        key: str,
+        value: Any = None,
+    ) -> dict:
+        design = _load(design_id)
+        result = _run_set_param(
+            design, library, instance_id=instance_id, key=key, value=value
+        )
+        _save(design_id, design)
+        return result
+
+    @mcp.tool(
+        name="set_connection",
+        description=(
+            "Set the target of a single connection identified by "
+            "component_id + pin_role. The `target` shape mirrors the "
+            "design.json schema: rail, gpio, bus, or expander_pin."
+        ),
+    )
+    def set_connection(
+        design_id: str,
+        component_id: str,
+        pin_role: str,
+        target: dict,
+    ) -> dict:
+        design = _load(design_id)
+        result = _run_set_connection(
+            design,
+            library,
+            component_id=component_id,
+            pin_role=pin_role,
+            target=target,
+        )
+        _save(design_id, design)
+        return result
+
+    @mcp.tool(
+        name="add_bus",
+        description=(
+            "Add a bus to the design. `type` must be one of i2c / spi / "
+            "uart / 1wire / i2s. Other fields depend on type: i2c needs "
+            "sda + scl, spi needs clk + miso? + mosi?, uart needs rx + tx "
+            "+ baud_rate, i2s needs lrclk + bclk."
+        ),
+    )
+    def add_bus(
+        design_id: str,
+        id: str,
+        type: str,
+        sda: Optional[str] = None,
+        scl: Optional[str] = None,
+        frequency_hz: Optional[int] = None,
+        miso: Optional[str] = None,
+        mosi: Optional[str] = None,
+        clk: Optional[str] = None,
+        cs: Optional[str] = None,
+        rx: Optional[str] = None,
+        tx: Optional[str] = None,
+        baud_rate: Optional[int] = None,
+        lrclk: Optional[str] = None,
+        bclk: Optional[str] = None,
+    ) -> dict:
+        design = _load(design_id)
+        fields = {
+            "id": id,
+            "type": type,
+            "sda": sda,
+            "scl": scl,
+            "frequency_hz": frequency_hz,
+            "miso": miso,
+            "mosi": mosi,
+            "clk": clk,
+            "cs": cs,
+            "rx": rx,
+            "tx": tx,
+            "baud_rate": baud_rate,
+            "lrclk": lrclk,
+            "bclk": bclk,
+        }
+        result = _run_add_bus(
+            design, library, **{k: v for k, v in fields.items() if v is not None}
+        )
+        _save(design_id, design)
+        return result
+
+    @mcp.tool(
+        name="solve_pins",
+        description=(
+            "Auto-assign every unbound connection. Doesn't reassign "
+            "already-bound pins. Returns the count of assignments made, "
+            "any unresolved connections, and any conflict / current-budget "
+            "warnings the solver detected. Mutates the design."
+        ),
+    )
+    def solve_pins(design_id: str) -> dict:
+        design = _load(design_id)
+        result = _run_solve_pins(design, library)
+        _save(design_id, design)
+        return result


### PR DESCRIPTION
## Summary

- Wraps the 12 tools in `wirestudio/agent/tools.py` as MCP tools (`wirestudio/mcp/server.py`) and mounts FastMCP's Streamable HTTP app at `/mcp` on the existing FastAPI app — same Python, different protocol shim. Mutating tools take `design_id`, load via the design store, mutate, persist back. Read-only library tools skip storage.
- Bearer-token auth on `/mcp`. Resolution order: `WIRESTUDIO_MCP_TOKEN` env var > persisted file at `~/.config/wirestudio/mcp-token` (mode 0600) > newly generated + persisted (logged at INFO so the operator knows where to copy it from). `WIRESTUDIO_MCP_ENABLED=false` short-circuits the wiring entirely. `WIRESTUDIO_MCP_ALLOWED_HOSTS` overrides the SDK's default loopback-only DNS-rebinding mitigation for hostname-based deployments.
- Implements the transport + auth decisions locked in PR #26.

Phase 1.2 (`design-changed` SSE channel), 1.3 (MCP resources), 1.4 (`set_active_design` tool + browser cookie), and 1.5 (polished docs walkthrough) remain in the queue. Until 1.4 ships, every design-bound MCP tool needs an explicit `design_id` and the design must already exist in the store (created via the web UI's save flow).

## Test plan

- [x] `pytest -q` — 320 pass (302 + 18 new across `tests/test_mcp_auth.py` and `tests/test_mcp_server.py`)
- [x] `ruff check wirestudio/ tests/` — clean
- [x] Manual smoke against uvicorn:
  - `/health` → 200
  - `POST /mcp` no auth → 401 + `WWW-Authenticate: Bearer`
  - `POST /mcp` with valid token + initialize payload → 200 + standard MCP `initialize` response with session id
- [ ] Real Claude Desktop / Claude Code round-trip to call a tool against a real saved design (recommended manual verification before merge — paste the auto-generated token + URL into `claude_desktop_config.json` and ask Claude to "list the boards in wirestudio")

🤖 Generated with [Claude Code](https://claude.com/claude-code)