### PR TITLE
mcp: phase 1.2 — design-changed SSE channel

### DIFF
--- a/START.md
+++ b/START.md
@@ -250,11 +250,20 @@ testing surfaced two strategic items below.)
       for envs that don't need it. `docs/MCP.md` covers config +
       env-var precedence; a polished walkthrough lands with the
       Phase 1.5 docs sweep.
-   2. **`design-changed` SSE channel** on the HTTP API. Browser
-      tabs subscribe per design id; any write to that design
-      (from MCP, HTTP, or CLI) triggers the same channel and the
-      browser re-fetches + re-renders. Closes the
-      "drive-from-chat, see-it-in-the-browser" loop.
+   2. **`design-changed` SSE channel — shipped (PR #29, 2026-05-10).**
+      `wirestudio/designs/events.py` ships an in-process
+      `DesignEventBus` (per-design `asyncio.Queue` fan-out) plus an
+      `EventEmittingDesignStore` wrapper that publishes a
+      `saved` / `deleted` event after every successful write. All
+      callers -- MCP tool surface, HTTP `POST /designs`, future CLI
+      -- get the broadcast for free because they all go through
+      the wrapped store. New `GET /designs/{id}/events` SSE
+      endpoint streams to subscribed browser tabs (15s heartbeat,
+      hello frame on connect). `App.tsx` opens an `EventSource`
+      per active saved design and re-fetches on `saved`,
+      clears state on `deleted`. Skips refresh while the user has
+      unsaved local edits so an MCP write doesn't blow away the
+      buffer they're typing into.
    3. **MCP resources** — `library://components`,
       `library://boards`, `design://{id}/yaml`,
       `design://{id}/ascii`. Read-only views the LLM can pull

--- a/tests/test_design_events.py
+++ b/tests/test_design_events.py
@@ -1,0 +1,139 @@
+"""Tests for the design-changed pub/sub: bus + store wrapper.
+
+The HTTP-level SSE endpoint is exercised by manual smoke tests against
+uvicorn rather than httpx.ASGITransport -- in-process streaming through
+ASGITransport has historically had buffering / lifespan-handshake quirks
+that make a long-running SSE handler unreliable to assert against, and
+the SSE endpoint itself is thin glue over the bus.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from wirestudio.designs.events import (
+    DesignEvent,
+    DesignEventBus,
+    EventEmittingDesignStore,
+)
+from wirestudio.designs.store import FileDesignStore
+
+
+pytestmark = pytest.mark.anyio
+
+
+# ---------------------------------------------------------------------------
+# DesignEventBus
+# ---------------------------------------------------------------------------
+
+
+async def test_bus_publish_to_one_subscriber():
+    bus = DesignEventBus()
+    q = bus.subscribe("garage")
+    bus.publish(DesignEvent(kind="saved", design_id="garage"))
+    event = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert event.kind == "saved"
+    assert event.design_id == "garage"
+
+
+async def test_bus_filters_by_design_id():
+    bus = DesignEventBus()
+    qa = bus.subscribe("a")
+    qb = bus.subscribe("b")
+    bus.publish(DesignEvent(kind="saved", design_id="a"))
+    bus.publish(DesignEvent(kind="deleted", design_id="b"))
+
+    ea = await asyncio.wait_for(qa.get(), timeout=1.0)
+    eb = await asyncio.wait_for(qb.get(), timeout=1.0)
+    assert ea.kind == "saved" and ea.design_id == "a"
+    assert eb.kind == "deleted" and eb.design_id == "b"
+    assert qa.empty() and qb.empty()
+
+
+async def test_bus_fans_out_to_multiple_subscribers():
+    bus = DesignEventBus()
+    q1 = bus.subscribe("d")
+    q2 = bus.subscribe("d")
+    bus.publish(DesignEvent(kind="saved", design_id="d"))
+
+    e1 = await asyncio.wait_for(q1.get(), timeout=1.0)
+    e2 = await asyncio.wait_for(q2.get(), timeout=1.0)
+    assert e1.design_id == "d"
+    assert e2.design_id == "d"
+
+
+async def test_bus_unsubscribe_stops_delivery():
+    bus = DesignEventBus()
+    q = bus.subscribe("d")
+    bus.unsubscribe("d", q)
+    assert bus.subscriber_count("d") == 0
+    bus.publish(DesignEvent(kind="saved", design_id="d"))
+    # Nothing in the queue -- the unsubscribe took effect.
+    assert q.empty()
+
+
+async def test_bus_unsubscribe_unknown_id_is_noop():
+    bus = DesignEventBus()
+    bus.unsubscribe("never-subscribed", asyncio.Queue())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# EventEmittingDesignStore
+# ---------------------------------------------------------------------------
+
+
+def _seed_design(design_id: str = "test-bench") -> dict:
+    return {
+        "schema_version": "0.1",
+        "id": design_id,
+        "name": "Test Bench",
+        "board": {"library_id": "esp32-devkitc-v4", "mcu": "esp32", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [],
+        "buses": [],
+        "connections": [],
+    }
+
+
+async def test_store_save_publishes_event(tmp_path: Path):
+    bus = DesignEventBus()
+    store = EventEmittingDesignStore(FileDesignStore(root=tmp_path), bus)
+    q = bus.subscribe("test-bench")
+
+    store.save(_seed_design())
+
+    event = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert event.kind == "saved"
+    assert event.design_id == "test-bench"
+
+
+async def test_store_delete_publishes_event_only_when_removed(tmp_path: Path):
+    bus = DesignEventBus()
+    store = EventEmittingDesignStore(FileDesignStore(root=tmp_path), bus)
+    store.save(_seed_design("real-design"))
+
+    q = bus.subscribe("real-design")
+    assert store.delete("real-design") is True
+    event = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert event.kind == "deleted"
+
+    # Deleting an unknown id returns False and must not publish.
+    q2 = bus.subscribe("ghost")
+    assert store.delete("ghost") is False
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(q2.get(), timeout=0.1)
+
+
+def test_store_reads_delegate(tmp_path: Path):
+    bus = DesignEventBus()
+    inner = FileDesignStore(root=tmp_path)
+    inner.save(_seed_design("d1"))
+    store = EventEmittingDesignStore(inner, bus)
+    assert store.exists("d1") is True
+    assert store.exists("missing") is False
+    assert store.load("d1")["id"] == "d1"
+    assert [s.id for s in store.list()] == ["d1"]
+
+

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api, ApiError } from "./api/client";
 import type {
   BoardSummary,
@@ -142,6 +142,61 @@ export default function App() {
     })();
     return () => { cancelled = true; };
   }, [selectedExample]);
+
+  // Refs so the SSE handler can read the latest design/originalDesign
+  // without re-creating the EventSource on every keystroke. Using state
+  // in the handler's closure would freeze whatever was current at the
+  // time the effect ran.
+  const designRef = useRef<Design | null>(design);
+  const originalDesignRef = useRef<Design | null>(originalDesign);
+  useEffect(() => { designRef.current = design; }, [design]);
+  useEffect(() => { originalDesignRef.current = originalDesign; }, [originalDesign]);
+
+  // Subscribe to design-changed events for the active saved design. Any
+  // write from the MCP tool surface (or another tab, or the CLI) fires a
+  // `saved` event we react to by re-fetching. If the user has unsaved
+  // local edits we skip the refresh -- silently overwriting them would
+  // be hostile. `deleted` always wins because the design is gone.
+  useEffect(() => {
+    if (!selectedSaved) return;
+    if (typeof EventSource === "undefined") return;
+    const id = selectedSaved;
+    const url = `/api/designs/${encodeURIComponent(id)}/events`;
+    const es = new EventSource(url);
+    console.log("[wirestudio] SSE opening", url);
+    es.addEventListener("open", () => console.log("[wirestudio] SSE open", url));
+    es.addEventListener("error", (e) => console.warn("[wirestudio] SSE error", url, e));
+    es.addEventListener("hello", (ev) =>
+      console.log("[wirestudio] SSE hello", (ev as MessageEvent).data),
+    );
+    es.addEventListener("saved", (ev) => {
+      const dirty = isDirty(originalDesignRef.current, designRef.current);
+      console.log("[wirestudio] SSE saved", { dirty, data: (ev as MessageEvent).data });
+      if (dirty) return;
+      (async () => {
+        try {
+          const d = await api.getSavedDesign(id);
+          setOriginalDesign(d);
+          setDesign(d);
+          void refreshSavedDesigns();
+          console.log("[wirestudio] SSE saved -> design refreshed");
+        } catch (err) {
+          console.warn("[wirestudio] SSE saved -> refresh failed", err);
+        }
+      })();
+    });
+    es.addEventListener("deleted", (ev) => {
+      console.log("[wirestudio] SSE deleted", (ev as MessageEvent).data);
+      setSelectedSaved(null);
+      setOriginalDesign(null);
+      setDesign(null);
+      void refreshSavedDesigns();
+    });
+    return () => {
+      console.log("[wirestudio] SSE closing", url);
+      es.close();
+    };
+  }, [selectedSaved]);
 
   // Cache the full library board for the design's `board.library_id`.
   // ConnectionForm needs rails + GPIO capabilities; refetching per inspector

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -49,6 +49,7 @@ from wirestudio.api.schemas import (
     UseCaseEntry,
     ValidateResponse,
 )
+from wirestudio.designs.events import DesignEventBus, EventEmittingDesignStore
 from wirestudio.fleet.client import FleetClient, FleetUnavailable
 from wirestudio.csp.compatibility import check_pin_compatibility
 from wirestudio.csp.pin_solver import solve_pins as run_solve_pins
@@ -132,6 +133,7 @@ def create_app(
     sessions: Optional[SessionStore] = None,
     designs: Optional[DesignStore] = None,
     fleet_client_factory=None,
+    event_bus: Optional[DesignEventBus] = None,
 ) -> FastAPI:
     import os as _os
     lib = library or default_library()
@@ -139,7 +141,12 @@ def create_app(
     # the stores at a /data volume without the caller plumbing args
     # through. Falls back to the package-local default in dev.
     sessions_store = sessions or FileSessionStore(root=_os.environ.get("SESSIONS_DIR") or None)
-    designs_store = designs or FileDesignStore(root=_os.environ.get("DESIGNS_DIR") or None)
+    inner_designs = designs or FileDesignStore(root=_os.environ.get("DESIGNS_DIR") or None)
+    bus = event_bus or DesignEventBus()
+    # Every write goes through the wrapper so MCP tools, HTTP endpoints,
+    # and any future CLI all fan out to subscribed browser tabs without
+    # the caller knowing about the bus.
+    designs_store = EventEmittingDesignStore(inner_designs, bus)
     # Tests substitute a factory that returns a FleetClient bound to an
     # httpx.MockTransport so we never hit the network in CI.
     make_fleet: callable = fleet_client_factory or (lambda: FleetClient())
@@ -499,6 +506,59 @@ def create_app(
         if not removed:
             raise HTTPException(status_code=404, detail=f"no saved design with id {design_id!r}")
         return {"deleted": True, "id": design_id}
+
+    @app.get("/designs/{design_id}/events", tags=["designs"])
+    async def design_events(design_id: str, request: Request):
+        """SSE stream of writes to one design.
+
+        Browser tabs open this once per displayed design; any save or
+        delete from MCP / HTTP / CLI emits a `saved` or `deleted` event
+        the client uses to re-fetch + re-render. Also emits a `: ping`
+        comment every 15s to keep intermediate proxies (nginx, vite-dev,
+        Cloudflare) from killing an idle connection.
+
+        The endpoint doesn't validate that `design_id` exists -- a tab
+        opening this stream for a not-yet-saved design is a legitimate
+        race where the next save will be the first event the client
+        ever sees.
+        """
+        queue = bus.subscribe(design_id)
+
+        async def event_source():
+            try:
+                # Replay the current saved-at timestamp on connect so a
+                # late-joining tab can reconcile against its own state
+                # without an explicit fetch race.
+                if designs_store.exists(design_id):
+                    summary = next(
+                        (s for s in designs_store.list() if s.id == design_id),
+                        None,
+                    )
+                    if summary is not None:
+                        yield (
+                            "event: hello\n"
+                            f"data: {json.dumps({'design_id': design_id, 'saved_at': summary.saved_at})}\n\n"
+                        )
+                while True:
+                    if await request.is_disconnected():
+                        return
+                    try:
+                        event = await asyncio.wait_for(queue.get(), timeout=15.0)
+                    except asyncio.TimeoutError:
+                        yield ": ping\n\n"
+                        continue
+                    yield (
+                        f"event: {event.kind}\n"
+                        f"data: {json.dumps(event.to_dict())}\n\n"
+                    )
+            finally:
+                bus.unsubscribe(design_id, queue)
+
+        return StreamingResponse(
+            event_source(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
 
     @app.get("/library/use_cases", response_model=list[UseCaseEntry], tags=["library"])
     def list_use_cases() -> list[UseCaseEntry]:

--- a/wirestudio/designs/events.py
+++ b/wirestudio/designs/events.py
@@ -1,0 +1,108 @@
+"""In-process pub/sub for design-store mutations.
+
+Wirestudio writes a design from three places now: the HTTP `POST /designs`
+endpoint, the MCP tool surface, and the future CLI. A browser tab showing
+the same design needs to see those writes without polling. The cheapest
+shape that works is a per-design `asyncio.Queue` fan-out: the design store
+publishes an event after each write, and a Server-Sent-Events endpoint
+subscribes per request.
+
+The bus lives inside the FastAPI app's process. There is no cross-process
+broadcast -- if you ever run multiple wirestudio replicas behind a load
+balancer you'll need to swap this for a redis pubsub or similar, but a
+single-operator homelab deployment doesn't.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Literal, Optional
+
+from wirestudio.designs.store import DesignStore, SavedDesignSummary
+
+
+EventKind = Literal["saved", "deleted"]
+
+
+@dataclass
+class DesignEvent:
+    kind: EventKind
+    design_id: str
+    at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict:
+        return {"kind": self.kind, "design_id": self.design_id, "at": self.at}
+
+
+class DesignEventBus:
+    """Per-design subscriber set with non-blocking publish.
+
+    Subscribers register via `subscribe(design_id)` and get back an
+    `asyncio.Queue` they can `await queue.get()` on. Publishers call
+    `publish(event)` from sync code; the bus iterates the queue set for
+    that id and puts the event with `put_nowait`. An unbounded queue
+    means a slow consumer can grow memory until they disconnect, which
+    is acceptable for a single-operator UI; a public deployment would
+    want a maxsize + drop policy.
+    """
+
+    def __init__(self) -> None:
+        self._subs: dict[str, set[asyncio.Queue[DesignEvent]]] = {}
+
+    def subscribe(self, design_id: str) -> asyncio.Queue[DesignEvent]:
+        q: asyncio.Queue[DesignEvent] = asyncio.Queue()
+        self._subs.setdefault(design_id, set()).add(q)
+        return q
+
+    def unsubscribe(self, design_id: str, queue: asyncio.Queue[DesignEvent]) -> None:
+        subs = self._subs.get(design_id)
+        if subs is None:
+            return
+        subs.discard(queue)
+        if not subs:
+            self._subs.pop(design_id, None)
+
+    def publish(self, event: DesignEvent) -> None:
+        for q in list(self._subs.get(event.design_id, ())):
+            q.put_nowait(event)
+
+    def subscriber_count(self, design_id: str) -> int:
+        return len(self._subs.get(design_id, ()))
+
+
+class EventEmittingDesignStore:
+    """DesignStore wrapper that publishes a DesignEvent after each write.
+
+    Reads delegate transparently. A failed write doesn't publish -- the
+    event only fires after the inner store reports success. Designed to
+    wrap any DesignStore impl (FileDesignStore today, SQLite tomorrow).
+    """
+
+    def __init__(self, inner: DesignStore, events: DesignEventBus) -> None:
+        self._inner = inner
+        self._events = events
+
+    # Read-through delegation.
+
+    def exists(self, design_id: str) -> bool:
+        return self._inner.exists(design_id)
+
+    def list(self) -> list[SavedDesignSummary]:
+        return self._inner.list()
+
+    def load(self, design_id: str) -> dict:
+        return self._inner.load(design_id)
+
+    # Writes publish on success.
+
+    def save(self, design: dict, design_id: Optional[str] = None) -> tuple[str, str]:
+        result_id, saved_at = self._inner.save(design, design_id=design_id)
+        self._events.publish(DesignEvent(kind="saved", design_id=result_id, at=saved_at))
+        return result_id, saved_at
+
+    def delete(self, design_id: str) -> bool:
+        removed = self._inner.delete(design_id)
+        if removed:
+            self._events.publish(DesignEvent(kind="deleted", design_id=design_id))
+        return removed


### PR DESCRIPTION
## Summary

Closes the **drive-from-chat, see-it-in-the-browser** loop. Any write to a saved design (MCP tool, `POST /designs`, future CLI) fans out to subscribed browser tabs via an in-process pub/sub.

- \`wirestudio/designs/events.py\`:
  - \`DesignEventBus\`: per-design \`asyncio.Queue\` fan-out. Sync publish so callers don't have to restructure.
  - \`EventEmittingDesignStore\`: \`DesignStore\` Protocol impl that wraps the inner store + publishes after save/delete.
- \`create_app()\` always wraps the underlying store with the emitter; bus injectable via \`event_bus=\` param for tests.
- \`GET /designs/{id}/events\`: SSE endpoint with 15s heartbeat + a \`hello\` frame on connect for late-join reconciliation. Cleans up the subscription on disconnect.
- \`App.tsx\`: opens \`EventSource\` per active \`selectedSaved\` id; re-fetches on \`saved\` (skipped if the user has local unsaved edits, so an MCP write doesn't blow away the buffer they're typing into); clears state on \`deleted\`. Refs gate the dirty check so we don't tear down + reopen the stream on every keystroke.

Phase 1.3 (\`library://\` + \`design://\` MCP resources) and 1.4 (\`set_active_design\` tool + browser cookie) remain in the queue.

## Test plan

- [x] 331 pytest pass — bus (subscribe/publish/fan-out/unsubscribe/filter) + store wrapper (save publishes, delete only when removed, reads delegate)
- [x] 129 vitest pass
- [x] \`ruff\` + \`tsc\` + \`vite build\` clean
- [x] Manual SSE smoke against running uvicorn:
  - \`POST /api/designs\` → SSE stream emits \`event: saved\` with id + timestamp
  - \`DELETE /api/designs/{id}\` → SSE stream emits \`event: deleted\`
- [ ] Recommended manual verification: open the SPA in browser, then drive an MCP tool from Claude Desktop (e.g. \`add a BME280 to my-design\`), confirm the browser updates without a manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)