### PR TITLE
ui: move Add component control to top of components section

### DIFF
--- a/web/src/components/Inspector.tsx
+++ b/web/src/components/Inspector.tsx
@@ -144,10 +144,16 @@ function DesignInspector({
       </Section>
 
       <Section title={`Components (${components.length})`}>
+        <div className="mb-2">
+          <AddComponentControl
+            libraryComponents={libraryComponents}
+            onAdd={onAddComponent}
+          />
+        </div>
         {components.length === 0 ? (
-          <div className="mb-2 text-xs text-zinc-500">no components</div>
+          <div className="text-xs text-zinc-500">no components</div>
         ) : (
-          <ul className="mb-2 space-y-1">
+          <ul className="space-y-1">
             {components.map((c) => (
               <li key={c.id} className="flex items-stretch gap-1">
                 <button
@@ -171,10 +177,6 @@ function DesignInspector({
             ))}
           </ul>
         )}
-        <AddComponentControl
-          libraryComponents={libraryComponents}
-          onAdd={onAddComponent}
-        />
       </Section>
 
       <Section title={`Buses (${buses.length})`}>


### PR DESCRIPTION
## Summary

The Add control sat below the components list, so on a long design the dropdown + Add button got pushed off-screen and the user had to scroll the right sidebar to add anything. Moving it under the section title keeps it always visible regardless of how many components are in the design. The list below stays the user's \"what's there\" reference.

Surfaced from real-world usage testing PR #29.

## Test plan

- [x] \`npm test\` — 129 vitest pass
- [x] \`tsc --noEmit\` — clean
- [x] \`vite build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)