### PR TITLE
mcp: seed connections in add_component + guard renderer against StrictUndefined

### DIFF
--- a/tests/test_designs_seed.py
+++ b/tests/test_designs_seed.py
@@ -1,0 +1,185 @@
+"""Tests for the connection-seeding helpers used by the MCP add_component tool."""
+from __future__ import annotations
+
+import pytest
+
+from wirestudio.agent.tools import _run_add_component, _run_render
+from wirestudio.designs.seed import (
+    add_component_with_connections,
+    default_target_for_pin,
+    needed_bus_types,
+    prepare_buses,
+)
+from wirestudio.library import default_library
+
+
+@pytest.fixture
+def library():
+    return default_library()
+
+
+def _empty_design(board_id: str = "esp32-s3-devkitc-1") -> dict:
+    return {
+        "schema_version": "0.1",
+        "id": "seed-test",
+        "name": "Seed Test",
+        "board": {"library_id": board_id, "mcu": "esp32", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [],
+        "buses": [],
+        "connections": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# default_target_for_pin
+# ---------------------------------------------------------------------------
+
+
+def test_power_pin_picks_lowest_compatible_rail():
+    rails = [{"name": "5V", "voltage": 5.0}, {"name": "3V3", "voltage": 3.3}]
+    target = default_target_for_pin(
+        "power", rails=rails, buses=[], vcc_min=3.0, vcc_max=3.6
+    )
+    assert target == {"kind": "rail", "rail": "3V3"}
+
+
+def test_power_pin_falls_back_to_3v3_when_constraints_unmet():
+    rails = [{"name": "5V", "voltage": 5.0}, {"name": "3V3", "voltage": 3.3}]
+    target = default_target_for_pin("power", rails=rails, buses=[])
+    # No vcc constraints -> picks the lowest non-zero voltage rail.
+    assert target == {"kind": "rail", "rail": "3V3"}
+
+
+def test_ground_pin_picks_zero_voltage_rail():
+    rails = [
+        {"name": "5V", "voltage": 5.0},
+        {"name": "3V3", "voltage": 3.3},
+        {"name": "GND", "voltage": 0},
+    ]
+    assert default_target_for_pin("ground", rails=rails, buses=[]) == {
+        "kind": "rail", "rail": "GND",
+    }
+
+
+def test_i2c_sda_pin_picks_first_matching_bus():
+    buses = [{"id": "spi_1", "type": "spi"}, {"id": "i2c_1", "type": "i2c"}]
+    assert default_target_for_pin("i2c_sda", rails=[], buses=buses) == {
+        "kind": "bus", "bus_id": "i2c_1",
+    }
+
+
+def test_i2c_pin_with_no_bus_yields_empty_bus_id():
+    assert default_target_for_pin("i2c_sda", rails=[], buses=[]) == {
+        "kind": "bus", "bus_id": "",
+    }
+
+
+def test_digital_in_pin_yields_empty_gpio():
+    assert default_target_for_pin("digital_in", rails=[], buses=[]) == {
+        "kind": "gpio", "pin": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# needed_bus_types
+# ---------------------------------------------------------------------------
+
+
+def test_needed_bus_types_for_i2c_component(library):
+    assert needed_bus_types(library.component("sht3xd")) == {"i2c"}
+
+
+def test_needed_bus_types_for_gpio_component(library):
+    # gpio_input is plain digital, no buses needed.
+    assert needed_bus_types(library.component("gpio_input")) == set()
+
+
+# ---------------------------------------------------------------------------
+# prepare_buses
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_buses_adds_i2c_with_board_defaults(library):
+    design = _empty_design("esp32-devkitc-v4")
+    prepare_buses(design, library.component("sht3xd"), library.board("esp32-devkitc-v4"))
+    assert len(design["buses"]) == 1
+    bus = design["buses"][0]
+    assert bus["type"] == "i2c"
+    # ESP32-DevKitC-V4 default I2C is GPIO21/GPIO22.
+    assert bus.get("sda") and bus.get("scl")
+
+
+def test_prepare_buses_idempotent_when_bus_present(library):
+    design = _empty_design()
+    design["buses"].append({"id": "i2c_existing", "type": "i2c", "sda": "GPIO8", "scl": "GPIO9"})
+    prepare_buses(design, library.component("sht3xd"), library.board("esp32-s3-devkitc-1"))
+    assert len(design["buses"]) == 1  # didn't add a second one
+
+
+# ---------------------------------------------------------------------------
+# add_component_with_connections
+# ---------------------------------------------------------------------------
+
+
+def test_add_creates_a_connection_per_pin(library):
+    design = _empty_design()
+    instance_id, _ = add_component_with_connections(
+        design, library, library_id="hc-sr501"
+    )
+    own = [c for c in design["connections"] if c["component_id"] == instance_id]
+    pin_roles = {c["pin_role"] for c in own}
+    expected = {p.role for p in library.component("hc-sr501").electrical.pins}
+    assert pin_roles == expected, f"expected {expected}, got {pin_roles}"
+
+
+def test_add_seeds_buses_for_i2c_component(library):
+    design = _empty_design()
+    add_component_with_connections(design, library, library_id="sht3xd")
+    bus_types = {b["type"] for b in design["buses"]}
+    assert "i2c" in bus_types
+
+
+def test_add_targets_power_pins_to_compatible_rail(library):
+    # HC-SR501 wants 5V; on a board with both 5V and 3V3 rails it should
+    # bind to 5V.
+    design = _empty_design()
+    instance_id, _ = add_component_with_connections(
+        design, library, library_id="hc-sr501"
+    )
+    vcc = next(
+        c for c in design["connections"]
+        if c["component_id"] == instance_id and c["pin_role"] == "VCC"
+    )
+    assert vcc["target"]["kind"] == "rail"
+    assert vcc["target"]["rail"] == "5V"
+
+
+# ---------------------------------------------------------------------------
+# _run_add_component (the MCP tool wrapper)
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_add_component_seeds_connections(library):
+    design = _empty_design()
+    result = _run_add_component(design, library, library_id="gpio_input")
+    assert result["ok"] is True
+    instance_id = result["instance_id"]
+    own = [c for c in design["connections"] if c["component_id"] == instance_id]
+    assert own, "MCP add_component must seed connections, otherwise the renderer crashes on pins.X"
+
+
+def test_mcp_add_then_render_works_for_three_realistic_components(library):
+    """Regression: user asked Claude to add hc_sr501 + gpio_input + rtttl;
+    the MCP tool created components without connections, and render() then
+    crashed with `StrictUndefined is not JSON serializable` when the rtttl
+    template hit `{{ pins.OUT | tojson }}`."""
+    design = _empty_design()
+    for lib_id in ("hc-sr501", "gpio_input", "rtttl"):
+        result = _run_add_component(design, library, library_id=lib_id)
+        assert result["ok"] is True
+
+    rendered = _run_render(design, library)
+    assert rendered["ok"] is True, f"render failed: {rendered.get('error')}"
+    assert "rtttl" in rendered["yaml"]
+    assert "binary_sensor" in rendered["yaml"]

--- a/wirestudio/agent/tools.py
+++ b/wirestudio/agent/tools.py
@@ -11,6 +11,7 @@ from typing import Any, Callable
 
 from wirestudio.csp.compatibility import check_pin_compatibility
 from wirestudio.csp.pin_solver import solve_pins as _solve_pins
+from wirestudio.designs.seed import add_component_with_connections
 from wirestudio.generate.ascii_gen import render_ascii
 from wirestudio.generate.yaml_gen import render_yaml
 from wirestudio.library import Library
@@ -303,25 +304,13 @@ def _run_add_component(
     instance_id_hint: str | None = None,
     params: dict | None = None,
 ) -> dict:
-    lib = library.component(library_id)  # raises if unknown
-    components = design.setdefault("components", [])
-    used = {c["id"] for c in components}
-
-    if instance_id_hint and instance_id_hint not in used:
-        instance_id = instance_id_hint
-    else:
-        base = "".join(ch if ch.isalnum() else "_" for ch in library_id)
-        n = 1
-        while f"{base}_{n}" in used:
-            n += 1
-        instance_id = f"{base}_{n}"
-
-    components.append({
-        "id": instance_id,
-        "library_id": library_id,
-        "label": label or lib.name,
-        "params": params or {},
-    })
+    instance_id, _ = add_component_with_connections(
+        design, library,
+        library_id=library_id,
+        label=label,
+        instance_id_hint=instance_id_hint,
+        params=params,
+    )
     return {"ok": True, "instance_id": instance_id}
 
 

--- a/wirestudio/designs/seed.py
+++ b/wirestudio/designs/seed.py
@@ -1,0 +1,200 @@
+"""Default-target picking + bus seeding for newly-added components.
+
+Mirror of the frontend `web/src/lib/design.ts` helpers (`addComponent`,
+`prepareBusesForLib`, `defaultTargetForPin`). Kept in sync by hand: when
+the frontend changes one, change the matching helper here, otherwise the
+MCP tool surface and the web UI drift in their interpretation of the
+same design edit.
+
+The helpers are deliberately pure -- they take dicts in and return new
+dicts -- so they're easy to test and easy to call from any code path
+that mutates a design (today: the MCP `add_component` tool).
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from wirestudio.library import Library, LibraryBoard, LibraryComponent
+
+
+_BUS_KIND_TO_TYPE: dict[str, str] = {
+    "i2c_sda": "i2c", "i2c_scl": "i2c",
+    "spi_clk": "spi", "spi_miso": "spi", "spi_mosi": "spi",
+    "i2s_lrclk": "i2s", "i2s_bclk": "i2s",
+    "uart_rx": "uart", "uart_tx": "uart",
+    "onewire_data": "1wire",
+}
+
+
+def needed_bus_types(lib: LibraryComponent) -> set[str]:
+    """Bus types this component needs based on its pin kinds."""
+    return {
+        _BUS_KIND_TO_TYPE[p.kind] for p in lib.electrical.pins
+        if p.kind in _BUS_KIND_TO_TYPE
+    }
+
+
+def default_target_for_pin(
+    pin_kind: str,
+    *,
+    rails: list[dict],
+    buses: list[dict],
+    vcc_min: Optional[float] = None,
+    vcc_max: Optional[float] = None,
+) -> dict:
+    """Pick the most plausible target for a fresh connection.
+
+    Power pins → lowest rail satisfying the part's [vcc_min, vcc_max]
+    band, falling back to 3V3 then any non-zero rail. Ground → 0V rail
+    or one literally named GND. Bus pins → first bus of the matching
+    type, or an empty placeholder bus_id (the form will surface as
+    "(invalid)" so the user can pick or fix). Everything else → empty
+    GPIO pin (solve_pins fills these in).
+    """
+    if pin_kind == "power":
+        candidates = [
+            r for r in rails
+            if (vcc_min is None or r["voltage"] >= vcc_min)
+            and (vcc_max is None or r["voltage"] <= vcc_max)
+        ]
+        candidates.sort(key=lambda r: r["voltage"])
+        chosen = (
+            (candidates[0] if candidates else None)
+            or next((r for r in rails if r["name"] == "3V3"), None)
+            or next((r for r in rails if r["voltage"] > 0), None)
+            or (rails[0] if rails else None)
+        )
+        return {"kind": "rail", "rail": chosen["name"] if chosen else "3V3"}
+
+    if pin_kind == "ground":
+        gnd = (
+            next((r["name"] for r in rails if r["voltage"] == 0), None)
+            or next((r["name"] for r in rails if "gnd" in r["name"].lower()), None)
+            or "GND"
+        )
+        return {"kind": "rail", "rail": gnd}
+
+    bus_type = _BUS_KIND_TO_TYPE.get(pin_kind)
+    if bus_type:
+        match = next((b for b in buses if b.get("type") == bus_type), None)
+        return {"kind": "bus", "bus_id": match["id"] if match else ""}
+
+    # spi_cs, i2s_dout, digital_in/out, analog_in -> per-component native GPIO.
+    return {"kind": "gpio", "pin": ""}
+
+
+def prepare_buses(design: dict, lib: LibraryComponent, board: LibraryBoard) -> dict:
+    """Append any bus types the component needs but the design lacks.
+
+    Pulls SDA/SCL/etc. from the board's `default_buses` block when
+    available; falls back to an empty bus skeleton (the user fills in
+    via the inspector when that lands). Mutates the design dict in
+    place and returns it.
+    """
+    buses = design.setdefault("buses", [])
+    have_types = {b.get("type") for b in buses}
+    need = needed_bus_types(lib) - have_types
+    if not need:
+        return design
+
+    # Library board exposes `default_buses` -- a dict of bus type -> default
+    # field map (e.g. {"i2c": {"sda": "GPIO21", "scl": "GPIO22"}}).
+    defaults: dict[str, dict[str, Any]] = getattr(board, "default_buses", {}) or {}
+
+    for bus_type in need:
+        bus: dict[str, Any] = {"id": _next_bus_id(buses, bus_type), "type": bus_type}
+        bus.update(defaults.get(bus_type, {}))
+        buses.append(bus)
+    return design
+
+
+def _next_bus_id(existing: list[dict], bus_type: str) -> str:
+    used = {b.get("id") for b in existing}
+    for n in range(1, 1000):
+        candidate = f"{bus_type}_{n}"
+        if candidate not in used:
+            return candidate
+    return f"{bus_type}_{len(existing)}"
+
+
+def seed_connections(
+    design: dict,
+    instance_id: str,
+    lib: LibraryComponent,
+    board: Optional[LibraryBoard],
+) -> dict:
+    """Append a connection per pin in the library entry for the new instance.
+
+    Mirrors the frontend `addComponent`: every pin role gets a connection
+    targeted at the most-plausible destination (rail / bus / empty GPIO).
+    Empty GPIO targets are placeholders that `solve_pins` will fill in.
+    """
+    rails = (
+        [{"name": r.name, "voltage": r.voltage} for r in board.rails]
+        if board is not None else []
+    )
+    buses = list(design.get("buses") or [])
+    connections = design.setdefault("connections", [])
+
+    for pin in lib.electrical.pins:
+        target = default_target_for_pin(
+            pin.kind,
+            rails=rails,
+            buses=buses,
+            vcc_min=lib.electrical.vcc_min,
+            vcc_max=lib.electrical.vcc_max,
+        )
+        connections.append({
+            "component_id": instance_id,
+            "pin_role": pin.role,
+            "target": target,
+        })
+    return design
+
+
+def add_component_with_connections(
+    design: dict,
+    library: Library,
+    *,
+    library_id: str,
+    label: Optional[str] = None,
+    instance_id_hint: Optional[str] = None,
+    params: Optional[dict] = None,
+) -> tuple[str, dict]:
+    """Add a component instance + auto-seed its buses and connections.
+
+    Returns (instance_id, design). The design is mutated in place.
+    Raises FileNotFoundError if `library_id` isn't in the library.
+    """
+    lib = library.component(library_id)
+    components = design.setdefault("components", [])
+    used = {c["id"] for c in components}
+
+    if instance_id_hint and instance_id_hint not in used:
+        instance_id = instance_id_hint
+    else:
+        base = "".join(ch if ch.isalnum() else "_" for ch in library_id)
+        n = 1
+        while f"{base}_{n}" in used:
+            n += 1
+        instance_id = f"{base}_{n}"
+
+    components.append({
+        "id": instance_id,
+        "library_id": library_id,
+        "label": label or lib.name,
+        "params": params or {},
+    })
+
+    board: Optional[LibraryBoard] = None
+    board_id = (design.get("board") or {}).get("library_id")
+    if board_id:
+        try:
+            board = library.board(board_id)
+        except FileNotFoundError:
+            board = None
+
+    if board is not None:
+        prepare_buses(design, lib, board)
+    seed_connections(design, instance_id, lib, board)
+    return instance_id, design

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -135,6 +135,20 @@ def _render_component(comp: Component, design: Design, library: Library) -> dict
             f"component '{comp.id}' (library_id={comp.library_id}) cannot be rendered: {e.message}. "
             f"Likely a missing bus connection; add a matching bus to the design or fix the connection target."
         ) from e
+    except TypeError as e:
+        # Jinja's StrictUndefined leaks past `tojson` because json.dumps gets
+        # the StrictUndefined object as input and TypeErrors out before
+        # Jinja's UndefinedError can fire (filters bypass the normal __call__
+        # that triggers it). Most often: `{{ pins.OUT | tojson }}` against a
+        # component whose OUT pin has no connection. Translate to a 422-able
+        # ValueError with a hint at the likely cause.
+        if "is not JSON serializable" in str(e):
+            raise ValueError(
+                f"component '{comp.id}' (library_id={comp.library_id}) cannot be rendered: "
+                f"a referenced pin or bus has no connection. Add the missing connection "
+                f"(or run solve_pins) and try again. Underlying error: {e}"
+            ) from e
+        raise
     parsed = yaml.safe_load(rendered)
     return parsed or {}
 


### PR DESCRIPTION
## Summary

Two related fixes for the user-reported \`StrictUndefined is not JSON serializable\` crash after Claude adds components via MCP.

### Root cause

The MCP \`add_component\` tool's docstring **promised** it creates a connection per pin (rails for power, buses for I2C/SPI/UART, etc.). The implementation only appended the component dict. So:

- Claude calls \`add_component\` 3 times → 3 components, **zero connections**
- User asks for \`render\` → \`_pins_for()\` returns \`{}\` because no connections exist
- Template hits \`{{ pins.OUT | tojson }}\` → \`pins.OUT\` is \`StrictUndefined\` → \`json.dumps\` raises \`TypeError\` that escapes Jinja's normal \`UndefinedError\` handler → 500 at the HTTP layer, \`isError: true\` at the MCP layer

### Fixes

- **\`wirestudio/designs/seed.py\`**: ports the frontend's \`addComponent\` + \`prepareBusesForLib\` + \`defaultTargetForPin\` into Python. Power pins target the lowest rail satisfying \`[vcc_min, vcc_max]\` (HC-SR501's VCC → 5V; BME280's VCC → 3V3). Ground → 0V rail. Bus pins → first matching bus, or auto-add a bus of that type pulling SDA/SCL/etc. from the board's \`default_buses\`. Everything else → empty GPIO for \`solve_pins\` to fill.
- **\`_run_add_component\`**: now calls \`add_component_with_connections\`. New components ship with their connections, so the renderer always has \`pins.X\` populated.
- **\`yaml_gen._render_component\`**: catches the \`TypeError\` with \`"not JSON serializable"\` and re-raises as a \`ValueError\` with a clear hint. The HTTP \`/design/render\` endpoint already \`422\`s on \`ValueError\`; the MCP \`render\` + \`validate\` tools already return \`{ok: false, error: ...}\`. Defense in depth — even if some future library template references an undefined pin, the user gets a useful error instead of 500.

### Tests

15 new tests cover:
- \`default_target_for_pin\` (power/ground/bus/gpio cases, vcc-band selection)
- \`needed_bus_types\` (i2c vs gpio-only components)
- \`prepare_buses\` (idempotent + uses board \`default_buses\`)
- \`add_component_with_connections\` (per-pin connections, bus seeding, power-rail matching)
- **Regression**: replays the exact three-component flow (\`hc-sr501\` + \`gpio_input\` + \`rtttl\`) the user hit and asserts render() succeeds.

\`338 pytest\`, ruff clean.

### Out of scope (filed as follow-ups)

- \`add_bus\` ignoring board defaults — same shape of bug, separate tool. Cover in a follow-up that applies \`default_buses\` inside \`_run_add_bus\` too.
- RTTTL ESP32-S3 platform mismatch (\`esp8266_pwm\` default) — library-modeling issue, needs chip-family conditional in the component template.
- RTTTL piezo second pin → GND in library entry — user-requested library improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)