### PR TITLE
mcp: add_bus fills missing pin fields from board.default_buses

### DIFF
--- a/tests/test_tools_add_bus.py
+++ b/tests/test_tools_add_bus.py
@@ -1,0 +1,90 @@
+"""Tests for `add_bus` board-defaults behavior."""
+from __future__ import annotations
+
+import pytest
+
+from wirestudio.agent.tools import _run_add_bus
+from wirestudio.library import default_library
+
+
+@pytest.fixture
+def library():
+    return default_library()
+
+
+def _design(board_id: str) -> dict:
+    return {
+        "schema_version": "0.1",
+        "id": "bus-test",
+        "name": "Bus Test",
+        "board": {"library_id": board_id, "mcu": "esp32", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [],
+        "buses": [],
+        "connections": [],
+    }
+
+
+def test_add_bus_fills_i2c_defaults_for_esp32_s3(library):
+    """Regression: Claude calls add_bus(id='i2c0', type='i2c') without
+    sda/scl. The previous behavior stored a bus with null pins, which
+    ESPHome refuses to compile. With board-defaults applied, the bus
+    picks up GPIO8/GPIO9 from the board's `default_buses.i2c` block."""
+    design = _design("esp32-s3-devkitc-1")
+    result = _run_add_bus(design, library, id="i2c0", type="i2c")
+    assert result["ok"] is True
+    assert "sda" in result.get("board_defaults_applied", [])
+    assert "scl" in result.get("board_defaults_applied", [])
+
+    bus = design["buses"][0]
+    assert bus["id"] == "i2c0"
+    assert bus["type"] == "i2c"
+    assert bus["sda"] == "GPIO8"
+    assert bus["scl"] == "GPIO9"
+
+
+def test_add_bus_fills_spi_defaults(library):
+    design = _design("esp32-s3-devkitc-1")
+    result = _run_add_bus(design, library, id="spi0", type="spi")
+    assert result["ok"] is True
+    bus = design["buses"][0]
+    assert bus["clk"] == "GPIO12"
+    assert bus["miso"] == "GPIO13"
+    assert bus["mosi"] == "GPIO11"
+
+
+def test_user_supplied_fields_override_defaults(library):
+    design = _design("esp32-s3-devkitc-1")
+    result = _run_add_bus(design, library, id="i2c0", type="i2c", sda="GPIO5")
+    assert result["ok"] is True
+    bus = design["buses"][0]
+    assert bus["sda"] == "GPIO5"          # user value wins
+    assert bus["scl"] == "GPIO9"          # filled from board defaults
+    # scl was missing from caller -> appears in the applied list, sda doesn't.
+    assert "scl" in result.get("board_defaults_applied", [])
+    assert "sda" not in result.get("board_defaults_applied", [])
+
+
+def test_add_bus_with_no_board_defaults_for_type_is_noop(library):
+    """uart isn't in default_buses for ESP32-S3 -- the bus should still
+    be created, just without auto-filled pins. ESPHome won't compile
+    until the user provides rx/tx, but the tool itself doesn't fail."""
+    design = _design("esp32-s3-devkitc-1")
+    result = _run_add_bus(design, library, id="uart0", type="uart", baud_rate=115200)
+    assert result["ok"] is True
+    bus = design["buses"][0]
+    assert bus["baud_rate"] == 115200
+    assert "rx" not in bus
+    assert "board_defaults_applied" not in result
+
+
+def test_add_bus_with_unknown_board_doesnt_crash(library):
+    design = _design("esp32-s3-devkitc-1")
+    design["board"]["library_id"] = "not-a-real-board"
+    # The tool must not raise -- the user can fix the board later. The
+    # bus gets created with exactly what was provided.
+    result = _run_add_bus(design, library, id="i2c0", type="i2c", sda="GPIO1", scl="GPIO2")
+    assert result["ok"] is True
+    bus = design["buses"][0]
+    assert bus["sda"] == "GPIO1"
+    assert bus["scl"] == "GPIO2"

--- a/wirestudio/agent/tools.py
+++ b/wirestudio/agent/tools.py
@@ -358,8 +358,35 @@ def _run_add_bus(design: dict, library: Library, **fields: Any) -> dict:
     buses = design.setdefault("buses", [])
     if any(b.get("id") == fields["id"] for b in buses):
         return {"ok": False, "error": f"bus id '{fields['id']}' already exists"}
-    buses.append({k: v for k, v in fields.items() if v is not None})
-    return {"ok": True}
+
+    # User-provided fields win; whatever's missing is filled from the
+    # board's default_buses[type] map (e.g. for esp32-devkitc-v4,
+    # i2c default = {sda: GPIO21, scl: GPIO22}). The LLM almost never
+    # remembers the right pins for every board variant, and ESPHome
+    # refuses to compile an I2C bus with null sda/scl, so the previous
+    # behavior of "store exactly what was passed" silently produced
+    # uncompilable designs.
+    bus_type = fields.get("type")
+    defaults: dict = {}
+    board_id = (design.get("board") or {}).get("library_id")
+    if board_id and bus_type:
+        try:
+            board = library.board(board_id)
+        except FileNotFoundError:
+            board = None
+        if board is not None:
+            defaults = (getattr(board, "default_buses", None) or {}).get(bus_type, {}) or {}
+
+    new_bus: dict[str, Any] = {**defaults}
+    for k, v in fields.items():
+        if v is not None:
+            new_bus[k] = v
+    buses.append(new_bus)
+    applied_defaults = sorted(k for k, v in defaults.items() if fields.get(k) is None)
+    out: dict[str, Any] = {"ok": True}
+    if applied_defaults:
+        out["board_defaults_applied"] = applied_defaults
+    return out
 
 
 def _run_render(design: dict, library: Library) -> dict:


### PR DESCRIPTION
## Summary

Companion to #31 (which seeded connections in \`add_component\`). Same shape of bug in a different tool: Claude calls \`add_bus(id=\"i2c0\", type=\"i2c\")\` without remembering which GPIO numbers map to SDA/SCL on the current board. The previous behavior stored a bus with null pins, which made ESPHome refuse to compile.

Now the tool looks up the design's board, reads the \`default_buses[type]\` block (e.g. esp32-s3-devkitc-1 → i2c → \`{sda: GPIO8, scl: GPIO9}\`), and fills any field the caller didn't pass. User-supplied fields always win; the response includes \`board_defaults_applied: [...]\` listing which fields it filled so the caller can audit. Boards without a default for the bus type and unknown \`board.library_id\` both fall through gracefully — the bus is stored exactly as passed.

## Test plan

- [x] \`pytest -q\` — 351 pass, 5 new
- [x] \`ruff check\` — clean
- [x] Manual smoke: \`_run_add_bus(design, library, id=\"i2c0\", type=\"i2c\")\` against an ESP32-S3 design fills sda=GPIO8, scl=GPIO9; user-passed \`sda=\"GPIO5\"\` wins while scl still fills from defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)