### PR TITLE
library: rtttl GND pin + chip-family-aware default platform

### DIFF
--- a/tests/test_library_rtttl.py
+++ b/tests/test_library_rtttl.py
@@ -1,0 +1,91 @@
+"""Tests for the rtttl library entry's chip-family conditional + GND pin."""
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from wirestudio.agent.tools import _run_add_component, _run_render
+from wirestudio.library import default_library
+
+
+@pytest.fixture
+def library():
+    return default_library()
+
+
+def _design(board_id: str) -> dict:
+    return {
+        "schema_version": "0.1",
+        "id": "rtttl-test",
+        "name": "RTTTL Test",
+        "board": {"library_id": board_id, "mcu": "esp32", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [],
+        "buses": [],
+        "connections": [],
+    }
+
+
+def test_rtttl_has_gnd_pin(library):
+    """Library entry models the piezo's second terminal as a ground pin so
+    add_component seeds a GND -> ground-rail connection automatically."""
+    rtttl = library.component("rtttl")
+    pin_roles = {p.role for p in rtttl.electrical.pins}
+    assert pin_roles == {"OUT", "GND"}
+    gnd = next(p for p in rtttl.electrical.pins if p.role == "GND")
+    assert gnd.kind == "ground"
+
+
+def test_rtttl_add_seeds_gnd_to_ground_rail(library):
+    """Regression: piezo GND must land on the GND rail, not floating."""
+    design = _design("esp32-s3-devkitc-1")
+    _run_add_component(design, library, library_id="rtttl")
+    gnd_conn = next(
+        c for c in design["connections"]
+        if c["component_id"].startswith("rtttl_") and c["pin_role"] == "GND"
+    )
+    assert gnd_conn["target"] == {"kind": "rail", "rail": "GND"}
+
+
+def test_rtttl_template_picks_ledc_on_esp32(library):
+    """ESP32 family boards must default to `ledc` (the only PWM platform
+    that works on ESP32) rather than the legacy esp8266_pwm."""
+    design = _design("esp32-s3-devkitc-1")
+    _run_add_component(design, library, library_id="rtttl")
+    result = _run_render(design, library)
+    assert result["ok"] is True, result.get("error")
+    parsed = yaml.safe_load(result["yaml"])
+    output_entries = parsed.get("output", [])
+    rtttl_output = next(o for o in output_entries if "rtttl_" in o.get("id", ""))
+    assert rtttl_output["platform"] == "ledc"
+
+
+def test_rtttl_template_picks_esp8266_pwm_on_esp8266(library):
+    """ESP8266 boards must default to `esp8266_pwm` -- ledc doesn't exist
+    on that chip family."""
+    design = _design("wemos-d1-mini")
+    design["board"]["mcu"] = "esp8266"
+    _run_add_component(design, library, library_id="rtttl")
+    result = _run_render(design, library)
+    assert result["ok"] is True, result.get("error")
+    parsed = yaml.safe_load(result["yaml"])
+    output_entries = parsed.get("output", [])
+    rtttl_output = next(o for o in output_entries if "rtttl_" in o.get("id", ""))
+    assert rtttl_output["platform"] == "esp8266_pwm"
+
+
+def test_rtttl_template_respects_explicit_param_override(library):
+    """If the user explicitly sets `output_platform`, that wins over the
+    chip-family default. Lets a user force `ledc` on weird ESP32 forks
+    or `esp8266_pwm` on an ESP8266 variant where the chip-family heuristic
+    might guess wrong."""
+    design = _design("esp32-s3-devkitc-1")
+    _run_add_component(
+        design, library, library_id="rtttl",
+        params={"output_platform": "esp8266_pwm"},
+    )
+    result = _run_render(design, library)
+    assert result["ok"] is True
+    parsed = yaml.safe_load(result["yaml"])
+    rtttl_output = next(o for o in parsed.get("output", []) if "rtttl_" in o.get("id", ""))
+    assert rtttl_output["platform"] == "esp8266_pwm"

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -117,6 +117,21 @@ def _render_component(comp: Component, design: Design, library: Library) -> dict
         return {}
     bus = _bus_for(comp.id, design)
     parent = _parent_for(comp.id, design)
+    # `board` carries the chip family / variant / mcu / framework so a
+    # template can pick chip-specific platform names (e.g. rtttl uses
+    # `ledc` on ESP32, `esp8266_pwm` on ESP8266). Templates that don't
+    # need it ignore the key.
+    try:
+        board_lib = library.board(design.board.library_id)
+        board_ctx = {
+            "library_id": board_lib.id,
+            "mcu": board_lib.mcu,
+            "chip_variant": board_lib.chip_variant,
+            "framework": board_lib.framework,
+            "platformio_board": board_lib.platformio_board,
+        }
+    except FileNotFoundError:
+        board_ctx = None
     ctx = {
         "id": comp.id,
         "label": comp.label,
@@ -124,6 +139,7 @@ def _render_component(comp: Component, design: Design, library: Library) -> dict
         "pins": _pins_for(comp.id, design, library),
         "bus": bus.model_dump() if bus else None,
         "parent": parent,
+        "board": board_ctx,
     }
     try:
         rendered = _jinja.from_string(template_str).render(**ctx)

--- a/wirestudio/library/components/rtttl.yaml
+++ b/wirestudio/library/components/rtttl.yaml
@@ -10,16 +10,22 @@ electrical:
   current_ma_typical: 8
   current_ma_peak: 30
   pins:
+    # The piezo is two-terminal: one terminal driven by a PWM-capable GPIO,
+    # the other tied to ground. Modelling both pins lets the generator
+    # auto-target GND to a ground rail and lets the schematic export show
+    # the full connection.
     - role: OUT
       kind: digital_out
       voltage: 3.3
+    - role: GND
+      kind: ground
   passives: []
 
 esphome:
   required_components: []
   yaml_template: |
     output:
-      - platform: {{ params.output_platform | default('esp8266_pwm') }}
+      - platform: {{ params.output_platform | default(('ledc' if board and board.chip_variant.startswith('esp32') else 'esp8266_pwm')) }}
         pin: {{ pins.OUT | tojson }}
         id: {{ id }}_out
     rtttl:
@@ -33,12 +39,11 @@ params_schema:
   output_platform:
     type: string
     enum: [esp8266_pwm, ledc]
-    default: esp8266_pwm
-    description: "Use `ledc` on ESP32; `esp8266_pwm` on ESP8266."
+    description: "Defaults to `ledc` on ESP32 family boards, `esp8266_pwm` on ESP8266. Override only if you have a specific reason."
   on_finished_playback:
     type: array
 
-notes: "RTTTL needs a PWM-capable output, not a plain GPIO. ESP8266 can only PWM on a subset of pins (see board capabilities); ESP32 LEDC works on any GPIO. The piezo itself is passive -- a typical 5V active buzzer should NOT be wired here, since RTTTL drives a frequency, not a level. Calls look like `rtttl.play: 'success:d=24,o=5,b=100:c,g,b'`."
+notes: "RTTTL needs a PWM-capable output, not a plain GPIO. ESP8266 can only PWM on a subset of pins (see board capabilities); ESP32 LEDC works on any GPIO. The platform is auto-picked from the board's chip family; override via params.output_platform only if necessary. The piezo itself is passive -- a typical 5V active buzzer should NOT be wired here, since RTTTL drives a frequency, not a level. The GND pin ties to the board's ground rail. Calls look like `rtttl.play: 'success:d=24,o=5,b=100:c,g,b'`."
 # KiCad symbol mapping (0.9). RTTTL plays melodies through a piezo
 # buzzer; the schematic part is just the buzzer itself.
 kicad:


### PR DESCRIPTION
## Summary

Two RTTTL improvements flagged by Claude during real-world testing of an ESP32-S3 design:

1. **Library entry now models the piezo's GND terminal.** Previously the entry only had \`OUT\` (kind: digital_out), so the schematic showed half a piezo and \`add_component\` seeded no GND connection. Added a \`GND\` pin (\`kind: ground\`); the existing default-target logic in \`seed.py\` ties it to the 0V rail automatically.
2. **\`yaml_template\` now picks \`ledc\` on ESP32 family, \`esp8266_pwm\` on ESP8266.** The old default was \`esp8266_pwm\` regardless of board, which makes ESP32 designs uncompilable. \`_render_component\` now exposes a \`board\` dict (mcu / chip_variant / framework / library_id / platformio_board) to the Jinja context; the template uses \`board.chip_variant.startswith('esp32')\` to switch. Explicit \`params.output_platform\` still wins for the edge cases.

The \`board\` ctx key is opt-in — templates that don't reference it ignore it, so other library components are unchanged. Future chip-specific platform decisions (esp32_camera variants, the ws2812 RMT vs bit-banged split, etc.) can use the same hook.

## Test plan

- [x] 356 pytest pass (5 new RTTTL tests)
- [x] \`ruff check\` — clean
- [x] New tests cover GND-pin modelling, GND auto-seeded to ground rail, ESP32 → ledc, ESP8266 → esp8266_pwm, explicit param override still wins
- [ ] CI's \`check_examples.py\` will validate all 20 bundled examples still pass \`esphome config\` against ESPHome 2025.12.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)