### PR TITLE
release: 0.10.0 — MCP server + chat-driven design loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wirestudio"
-version = "0.9.0"
+version = "0.10.0"
 description = "Agent-driven IoT device design tool that produces ESPHome YAML."
 readme = "README.md"
 license = { text = "MIT" }

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.1.0"
+__version__ = "0.10.0"


### PR DESCRIPTION
## Summary

Minor bump for the MCP capability surface. Highlights since 0.9.0:

- **#27** Streamable HTTP MCP server wrapping all 12 agent tools at \`/mcp\`, bearer-token auth on that path only (**#28**, scoped correctly after a regression).
- **#29** \`design-changed\` SSE channel: in-process pub/sub fans out writes from MCP / HTTP / CLI to subscribed browser tabs so the SPA refreshes without polling. Skips refresh while the user has unsaved local edits.
- **#31** \`add_component\` seeds connections: MCP add now creates a connection per pin (rails for power, buses for I2C/SPI, empty GPIO placeholders for \`solve_pins\` to fill). \`yaml_gen\` catches the \`StrictUndefined\`-in-\`tojson\` leak and translates to a \`ValueError\` so HTTP \`/design/render\` 422s cleanly instead of 500'ing.
- **#32** \`add_bus\` fills board defaults: a bus added by MCP without \`sda\`/\`scl\`/etc. now picks those up from \`board.default_buses\`.
- **#33** \`rtttl\` library entry: GND pin modelled so the piezo's second terminal lands on the ground rail automatically; \`output_platform\` default switches on \`board.chip_variant\` (\`ledc\` on ESP32 family, \`esp8266_pwm\` on ESP8266) instead of hardcoded \`esp8266_pwm\`.
- **#30** Inspector layout: "Add component" control sits at the top of the components section instead of below the list.

Also fixes a pre-existing version drift: \`wirestudio/__init__.py\` was stuck at \`0.1.0\` (the \`/health\` endpoint reported that) while \`pyproject\` read \`0.9.0\`. Both now read \`0.10.0\`.

## Test plan

- [x] \`pytest -q\` — 356 pass
- [x] \`python -c "import wirestudio; print(wirestudio.__version__)"\` → \`0.10.0\`
- [ ] On merge, tag \`v0.10.0\` and push → fires \`release.yml\` (PyPI publish, contingent on Trusted Publisher being configured) and \`docker.yml\` (image published to \`ghcr.io/moellere/wirestudio:v0.10.0\` + \`:0.10.0\` + \`:0.10\` + \`:latest\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)