### PR TITLE
mcp: phase 1.3 — read-only resources for library + design

### DIFF
--- a/START.md
+++ b/START.md
@@ -264,10 +264,19 @@ testing surfaced two strategic items below.)
       clears state on `deleted`. Skips refresh while the user has
       unsaved local edits so an MCP write doesn't blow away the
       buffer they're typing into.
-   3. **MCP resources** — `library://components`,
-      `library://boards`, `design://{id}/yaml`,
-      `design://{id}/ascii`. Read-only views the LLM can pull
-      without burning tokens reconstructing them.
+   3. **MCP resources — shipped (PR #TBD, 2026-05-11).** Seven
+      read-only resources registered on the FastMCP server:
+      `library://components` + `library://components/{id}` (compact
+      index + full per-component detail), `library://boards` +
+      `library://boards/{id}`, `design://{id}/json`,
+      `design://{id}/yaml`, `design://{id}/ascii`. Compact indexes
+      surface id + name + category + use_cases + aliases; the
+      `{id}` templates serve the full library entry on demand so
+      the LLM doesn't have to round-trip a tool call. Design YAML
+      and ASCII resources re-render against the latest stored
+      state on each read (verified by a regression test that
+      adds a component via the MCP tool and confirms the YAML
+      resource reflects it).
    4. **`set_active_design(id)` tool + UI plumbing.** Browser
       cookies the active id; MCP tools default to it. So the
       user's "add a BME280 to this design" prompt resolves

--- a/tests/test_mcp_resources.py
+++ b/tests/test_mcp_resources.py
@@ -1,0 +1,206 @@
+"""Tests for the MCP resources registered in `wirestudio/mcp/server.py`."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from wirestudio.designs.store import FileDesignStore
+from wirestudio.library import default_library
+from wirestudio.mcp.server import build_mcp_server
+
+
+pytestmark = pytest.mark.anyio
+
+
+EXPECTED_STATIC_URIS = {
+    "library://components",
+    "library://boards",
+}
+
+EXPECTED_TEMPLATE_URIS = {
+    "library://components/{component_id}",
+    "library://boards/{board_id}",
+    "design://{design_id}/json",
+    "design://{design_id}/yaml",
+    "design://{design_id}/ascii",
+}
+
+
+def _seed_design(store: FileDesignStore, design_id: str = "res-test") -> str:
+    """Save a minimal design with one component so the design resources
+    have something to render against."""
+    library = default_library()
+    design: dict[str, Any] = {
+        "schema_version": "0.1",
+        "id": design_id,
+        "name": "Resource Test",
+        "board": {"library_id": "esp32-devkitc-v4", "mcu": "esp32", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [],
+        "buses": [],
+        "connections": [],
+    }
+    # Seed via the same helper the MCP add_component tool uses so the
+    # design lands with real connections.
+    from wirestudio.designs.seed import add_component_with_connections
+    add_component_with_connections(design, library, library_id="bme280")
+    store.save(design, design_id=design_id)
+    return design_id
+
+
+def _content_as_text(content: list[Any]) -> str:
+    assert content, "expected resource content"
+    return content[0].content
+
+
+@pytest.fixture
+def mcp_server(tmp_path: Path):
+    store = FileDesignStore(root=tmp_path / "designs")
+    server = build_mcp_server(default_library(), store)
+    return server, store
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+async def test_static_resources_registered(mcp_server):
+    server, _ = mcp_server
+    resources = await server.list_resources()
+    uris = {str(r.uri) for r in resources}
+    assert EXPECTED_STATIC_URIS <= uris
+
+
+async def test_template_resources_registered(mcp_server):
+    server, _ = mcp_server
+    templates = await server.list_resource_templates()
+    uris = {t.uriTemplate for t in templates}
+    assert EXPECTED_TEMPLATE_URIS <= uris
+
+
+# ---------------------------------------------------------------------------
+# Library catalog
+# ---------------------------------------------------------------------------
+
+
+async def test_components_index_returns_compact_entries(mcp_server):
+    server, _ = mcp_server
+    content = _content_as_text(await server.read_resource("library://components"))
+    payload = json.loads(content)
+    ids = {c["id"] for c in payload["components"]}
+    assert "bme280" in ids
+    # Compact shape: id/name/category/use_cases/aliases only.
+    entry = next(c for c in payload["components"] if c["id"] == "bme280")
+    assert set(entry.keys()) == {"id", "name", "category", "use_cases", "aliases"}
+
+
+async def test_component_detail_returns_full_library_entry(mcp_server):
+    server, _ = mcp_server
+    content = _content_as_text(
+        await server.read_resource("library://components/bme280")
+    )
+    payload = json.loads(content)
+    # Full entry has the electrical block + esphome template.
+    assert "electrical" in payload
+    assert "esphome" in payload
+    assert payload["id"] == "bme280"
+
+
+async def test_component_detail_unknown_id_raises(mcp_server):
+    server, _ = mcp_server
+    with pytest.raises(Exception):
+        await server.read_resource("library://components/not-a-real-part")
+
+
+async def test_boards_index_returns_compact_entries(mcp_server):
+    server, _ = mcp_server
+    content = _content_as_text(await server.read_resource("library://boards"))
+    payload = json.loads(content)
+    ids = {b["id"] for b in payload["boards"]}
+    assert "esp32-devkitc-v4" in ids
+    entry = next(b for b in payload["boards"] if b["id"] == "esp32-devkitc-v4")
+    assert "mcu" in entry and "chip_variant" in entry
+
+
+async def test_board_detail_returns_full_entry(mcp_server):
+    server, _ = mcp_server
+    content = _content_as_text(
+        await server.read_resource("library://boards/esp32-devkitc-v4")
+    )
+    payload = json.loads(content)
+    # Full entry exposes the GPIO pinout + default buses.
+    assert "gpio_capabilities" in payload
+    assert "default_buses" in payload
+
+
+# ---------------------------------------------------------------------------
+# Design resources
+# ---------------------------------------------------------------------------
+
+
+async def test_design_json_returns_raw_dict(mcp_server):
+    server, store = mcp_server
+    design_id = _seed_design(store)
+    content = _content_as_text(
+        await server.read_resource(f"design://{design_id}/json")
+    )
+    payload = json.loads(content)
+    assert payload["id"] == design_id
+    assert any(c["library_id"] == "bme280" for c in payload["components"])
+
+
+async def test_design_yaml_renders_esphome_yaml(mcp_server):
+    server, store = mcp_server
+    design_id = _seed_design(store)
+    content = _content_as_text(
+        await server.read_resource(f"design://{design_id}/yaml")
+    )
+    parsed = yaml.safe_load(content)
+    assert "esphome" in parsed
+    # BME280 lands as an I2C sensor under the sensor: list (it's a
+    # canonical ESPHome platform).
+    assert "sensor" in parsed or "i2c" in parsed
+
+
+async def test_design_ascii_renders_diagram(mcp_server):
+    server, store = mcp_server
+    design_id = _seed_design(store)
+    content = _content_as_text(
+        await server.read_resource(f"design://{design_id}/ascii")
+    )
+    # ASCII output should include the board name and the BME280 instance.
+    assert "ESP32" in content or "esp32" in content
+    assert "bme280" in content.lower()
+
+
+async def test_design_resource_unknown_id_raises(mcp_server):
+    server, _ = mcp_server
+    with pytest.raises(Exception):
+        await server.read_resource("design://no-such-design/yaml")
+
+
+async def test_design_yaml_reflects_latest_state(mcp_server):
+    """Read-after-write: an MCP tool mutation followed by a re-read of
+    the design://{id}/yaml resource must show the new component."""
+    server, store = mcp_server
+    design_id = _seed_design(store)
+
+    # Add a second component via the MCP tool surface.
+    result = await server.call_tool(
+        "add_component",
+        {"design_id": design_id, "library_id": "hc-sr501"},
+    )
+    assert result is not None  # tool succeeded
+
+    content = _content_as_text(
+        await server.read_resource(f"design://{design_id}/yaml")
+    )
+    # HC-SR501 emits a binary_sensor entry with its human label set as
+    # the ESPHome `name`. The post-write YAML must surface it.
+    assert "HC-SR501" in content
+    assert "binary_sensor" in content

--- a/wirestudio/mcp/server.py
+++ b/wirestudio/mcp/server.py
@@ -5,6 +5,11 @@ Mutating tools take a `design_id` argument, load the design from the store,
 call the underlying handler (which mutates the dict in place), and persist
 the result back. Read-only library tools skip the store entirely.
 
+Resources expose read-only views over the library and stored designs:
+- `library://components` + `library://components/{id}` for the library catalog
+- `library://boards` + `library://boards/{id}` for boards
+- `design://{id}/{format}` for rendered design output (json / yaml / ascii)
+
 The server is a `FastMCP` instance. The caller is responsible for mounting
 its `streamable_http_app()` into the parent FastAPI app and arranging
 `session_manager.run()` in the parent's lifespan.
@@ -30,7 +35,10 @@ from wirestudio.agent.tools import (
     _run_validate,
 )
 from wirestudio.designs.store import DesignStore
+from wirestudio.generate.ascii_gen import render_ascii
+from wirestudio.generate.yaml_gen import render_yaml
 from wirestudio.library import Library
+from wirestudio.model import Design
 
 
 def build_mcp_server(
@@ -39,10 +47,11 @@ def build_mcp_server(
     *,
     name: str = "wirestudio",
 ) -> FastMCP:
-    """Build a FastMCP server with all wirestudio tools registered."""
+    """Build a FastMCP server with all wirestudio tools + resources registered."""
     mcp = FastMCP(name=name)
     _register_library_tools(mcp, library)
     _register_design_tools(mcp, library, designs)
+    _register_resources(mcp, library, designs)
     return mcp
 
 
@@ -285,3 +294,141 @@ def _register_design_tools(
         result = _run_solve_pins(design, library)
         _save(design_id, design)
         return result
+
+
+def _register_resources(mcp: FastMCP, library: Library, designs: DesignStore) -> None:
+    """Read-only views of the library and stored designs.
+
+    The library catalog resources serve a dual purpose: they let an LLM
+    client pull a compact index without burning tool-call tokens, and
+    they're the natural place for a host (Claude Desktop, Claude Code)
+    to surface attachable references like `@library://components/bme280`.
+    Design resources expose the rendered output (yaml / ascii) so a
+    user can drop the current design into chat without copy-paste.
+    """
+
+    @mcp.resource(
+        "library://components",
+        name="components_index",
+        title="Library: components index",
+        description=(
+            "Compact list of every library component (id, name, category, "
+            "use_cases, aliases). Pull this first to discover available "
+            "parts, then read library://components/{id} for the full "
+            "electrical + ESPHome detail of a specific entry."
+        ),
+        mime_type="application/json",
+    )
+    def components_index() -> dict:
+        return {
+            "components": [
+                {
+                    "id": c.id,
+                    "name": c.name,
+                    "category": c.category,
+                    "use_cases": list(c.use_cases),
+                    "aliases": list(c.aliases),
+                }
+                for c in library.list_components()
+            ],
+        }
+
+    @mcp.resource(
+        "library://components/{component_id}",
+        name="component_detail",
+        title="Library: component detail",
+        description=(
+            "Full library entry for one component: electrical pins, ESPHome "
+            "Jinja template, params schema, KiCad symbol mapping, current "
+            "draw, vcc band. Use this before add_component to learn the "
+            "exact pin roles + param keys the part expects."
+        ),
+        mime_type="application/json",
+    )
+    def component_detail(component_id: str) -> dict:
+        return library.component(component_id).model_dump()
+
+    @mcp.resource(
+        "library://boards",
+        name="boards_index",
+        title="Library: boards index",
+        description=(
+            "Compact list of every supported board (id, name, mcu, "
+            "chip_variant, framework, platformio_board). Pull this to "
+            "pick a board target; read library://boards/{id} for pinout, "
+            "rails, default_buses."
+        ),
+        mime_type="application/json",
+    )
+    def boards_index() -> dict:
+        return {
+            "boards": [
+                {
+                    "id": b.id,
+                    "name": b.name,
+                    "mcu": b.mcu,
+                    "chip_variant": b.chip_variant,
+                    "framework": b.framework,
+                    "platformio_board": b.platformio_board,
+                    "flash_size_mb": b.flash_size_mb,
+                }
+                for b in library.list_boards()
+            ],
+        }
+
+    @mcp.resource(
+        "library://boards/{board_id}",
+        name="board_detail",
+        title="Library: board detail",
+        description=(
+            "Full library entry for one board: rails, GPIO capabilities "
+            "per-pin, default buses (sda/scl/clk/miso/mosi), enclosure "
+            "metadata, KiCad symbol mapping."
+        ),
+        mime_type="application/json",
+    )
+    def board_detail(board_id: str) -> dict:
+        return library.board(board_id).model_dump()
+
+    @mcp.resource(
+        "design://{design_id}/json",
+        name="design_json",
+        title="Design: raw design.json",
+        description=(
+            "The on-disk design.json for the named design. Read-only view; "
+            "to mutate, use the design-editing tools."
+        ),
+        mime_type="application/json",
+    )
+    def design_json(design_id: str) -> dict:
+        return designs.load(design_id)
+
+    @mcp.resource(
+        "design://{design_id}/yaml",
+        name="design_yaml",
+        title="Design: rendered ESPHome YAML",
+        description=(
+            "Current ESPHome YAML for the named design. Refreshes on every "
+            "read against the latest stored state, so an MCP write followed "
+            "by a re-read shows the new output."
+        ),
+        mime_type="text/yaml",
+    )
+    def design_yaml(design_id: str) -> str:
+        d = Design.model_validate(designs.load(design_id))
+        return render_yaml(d, library)
+
+    @mcp.resource(
+        "design://{design_id}/ascii",
+        name="design_ascii",
+        title="Design: ASCII diagram",
+        description=(
+            "ASCII pinout diagram for the named design. A compact view of "
+            "rails, components, pin assignments, and BOM that fits in a "
+            "single chat message."
+        ),
+        mime_type="text/plain",
+    )
+    def design_ascii(design_id: str) -> str:
+        d = Design.model_validate(designs.load(design_id))
+        return render_ascii(d, library)


### PR DESCRIPTION
## Summary

Seven MCP resources so an LLM client can pull library data and rendered design output without burning tool-call tokens. Resources are the natural place for a host (Claude Desktop, Claude Code) to surface attachable references like \`@library://components/bme280\` — the host inlines the resource content as a regular attachment.

| URI | What |
|---|---|
| \`library://components\` | compact index (id, name, category, use_cases, aliases) |
| \`library://components/{component_id}\` | full library entry: pins, ESPHome template, params schema, KiCad map |
| \`library://boards\` | compact board index |
| \`library://boards/{board_id}\` | full board entry: rails, GPIO caps, default_buses |
| \`design://{design_id}/json\` | raw design.json |
| \`design://{design_id}/yaml\` | rendered ESPHome YAML (re-rendered each read) |
| \`design://{design_id}/ascii\` | ASCII pinout diagram |

The design resources re-render on every read, so an MCP write followed by a re-read sees the new state without a separate refresh.

Aligns with the deferred **cost-tuning item 1.3** from the agent roadmap: the LLM no longer needs the full library YAML baked into every system prompt — it pulls the compact index, then fetches per-component detail only when adding that part.

## Test plan

- [x] \`pytest -q\` — 368 pass (12 new in \`tests/test_mcp_resources.py\`)
- [x] \`ruff check\` — clean
- [x] New tests cover: static + template URI registration, compact index shapes, full-detail shapes, unknown-id raising, yaml/ascii rendering, and a read-after-write regression (add via tool → yaml resource reflects it)
- [x] Manual end-to-end smoke against running uvicorn:
  - \`resources/list\` returns both static URIs
  - \`resources/templates/list\` returns all 5 templated URIs
  - \`resources/read library://boards\` returns JSON content with all 14 boards
  - bearer-token gate on /api/mcp still enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)