### PR TITLE
mcp: phase 1.4 — active-design tracker + tool default + browser sync

### DIFF
--- a/START.md
+++ b/START.md
@@ -277,13 +277,23 @@ testing surfaced two strategic items below.)
       state on each read (verified by a regression test that
       adds a component via the MCP tool and confirms the YAML
       resource reflects it).
-   4. **`set_active_design(id)` tool + UI plumbing.** Browser
-      cookies the active id; MCP tools default to it. So the
-      user's "add a BME280 to this design" prompt resolves
-      against whatever the browser tab is showing. Until this
-      lands, every design-bound MCP tool needs an explicit
-      `design_id` and the design must already exist in the
-      store (created via the web UI's save flow).
+   4. **`set_active_design(id)` tool + UI plumbing — shipped
+      (PR #TBD, 2026-05-11).** `ActiveDesignTracker` is a
+      single-slot in-process tracker (single-user homelab; one
+      tracker per server process). Wired into both the HTTP
+      surface (`GET / PUT /api/designs/active`) and the MCP
+      surface (`set_active_design` + `get_active_design` tools).
+      Every design-bound MCP tool (render, validate, set_board,
+      add_component, remove_component, set_param, set_connection,
+      add_bus, solve_pins) now takes `design_id` as an optional
+      keyword; when omitted the tool resolves from the tracker
+      and returns a clean `{ok: false, error: ...}` if neither
+      is set. The web SPA mirrors `selectedSaved` into the
+      server's active pointer via a useEffect, so the moment
+      the user clicks a design in the sidebar, Claude can act
+      on it without an explicit id. Deleting the active design
+      auto-clears the pointer so the next default-resolved call
+      doesn't 500 on a dangling id.
    5. **MCP docs.** Polished walkthrough on top of the
       Phase 1.1 `docs/MCP.md` skeleton — end-to-end "click here,
       paste this, ask Claude to do that" flow.

--- a/tests/test_active_design.py
+++ b/tests/test_active_design.py
@@ -1,0 +1,304 @@
+"""Tests for the active-design tracker, HTTP endpoints, and MCP fallback."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from wirestudio.designs.active import ActiveDesignTracker
+from wirestudio.designs.store import FileDesignStore
+from wirestudio.library import default_library
+from wirestudio.mcp.server import build_mcp_server
+
+
+pytestmark = pytest.mark.anyio
+
+
+def _seed_design(store: FileDesignStore, design_id: str = "active-test") -> str:
+    """Save a renderable design so the MCP tools have something to work on."""
+    design: dict[str, Any] = {
+        "schema_version": "0.1",
+        "id": design_id,
+        "name": "Active Test",
+        "board": {"library_id": "esp32-devkitc-v4", "mcu": "esp32", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [],
+        "buses": [],
+        "connections": [],
+    }
+    store.save(design, design_id=design_id)
+    return design_id
+
+
+def _tool_payload(content: list[Any]) -> dict:
+    """Decode the first TextContent payload as JSON."""
+    assert content
+    text = getattr(content[0], "text", None)
+    assert isinstance(text, str)
+    return json.loads(text)
+
+
+# ---------------------------------------------------------------------------
+# ActiveDesignTracker unit
+# ---------------------------------------------------------------------------
+
+
+def test_tracker_starts_unset():
+    assert ActiveDesignTracker().get() is None
+
+
+def test_tracker_set_and_clear():
+    t = ActiveDesignTracker()
+    t.set("d1")
+    assert t.get() == "d1"
+    t.clear()
+    assert t.get() is None
+
+
+def test_tracker_empty_string_normalizes_to_none():
+    t = ActiveDesignTracker(initial="d1")
+    t.set("")
+    assert t.get() is None
+
+
+def test_tracker_initial_value():
+    assert ActiveDesignTracker(initial="garage").get() == "garage"
+
+
+# ---------------------------------------------------------------------------
+# HTTP /designs/active
+# ---------------------------------------------------------------------------
+
+
+async def test_http_get_active_starts_null(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("WIRESTUDIO_MCP_TOKEN", "test")
+    monkeypatch.setenv("DESIGNS_DIR", str(tmp_path / "designs"))
+    monkeypatch.setenv("SESSIONS_DIR", str(tmp_path / "sessions"))
+    from wirestudio.api.app import create_app
+    app = create_app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://t"
+    ) as c:
+        r = await c.get("/designs/active")
+        assert r.status_code == 200
+        assert r.json() == {"id": None}
+
+
+async def test_http_put_then_get_active(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("WIRESTUDIO_MCP_TOKEN", "test")
+    monkeypatch.setenv("DESIGNS_DIR", str(tmp_path / "designs"))
+    monkeypatch.setenv("SESSIONS_DIR", str(tmp_path / "sessions"))
+    from wirestudio.api.app import create_app
+    app = create_app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://t"
+    ) as c:
+        r = await c.put("/designs/active", json={"id": "garage"})
+        assert r.status_code == 200
+        assert r.json() == {"id": "garage"}
+
+        r = await c.get("/designs/active")
+        assert r.json() == {"id": "garage"}
+
+
+async def test_http_put_null_clears_active(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("WIRESTUDIO_MCP_TOKEN", "test")
+    monkeypatch.setenv("DESIGNS_DIR", str(tmp_path / "designs"))
+    monkeypatch.setenv("SESSIONS_DIR", str(tmp_path / "sessions"))
+    from wirestudio.api.app import create_app
+    app = create_app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://t"
+    ) as c:
+        await c.put("/designs/active", json={"id": "garage"})
+        r = await c.put("/designs/active", json={"id": None})
+        assert r.json() == {"id": None}
+
+
+async def test_http_put_rejects_non_string_id(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("WIRESTUDIO_MCP_TOKEN", "test")
+    monkeypatch.setenv("DESIGNS_DIR", str(tmp_path / "designs"))
+    monkeypatch.setenv("SESSIONS_DIR", str(tmp_path / "sessions"))
+    from wirestudio.api.app import create_app
+    app = create_app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://t"
+    ) as c:
+        r = await c.put("/designs/active", json={"id": 42})
+        assert r.status_code == 422
+
+
+async def test_delete_design_clears_active_if_matched(monkeypatch, tmp_path: Path):
+    """Deleting the active design must clear the pointer; otherwise the next
+    default-resolved MCP call hits an unknown id and 500s."""
+    monkeypatch.setenv("WIRESTUDIO_MCP_TOKEN", "test")
+    monkeypatch.setenv("DESIGNS_DIR", str(tmp_path / "designs"))
+    monkeypatch.setenv("SESSIONS_DIR", str(tmp_path / "sessions"))
+    from wirestudio.api.app import create_app
+    app = create_app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://t"
+    ) as c:
+        # Save a design so we can delete it.
+        design = {
+            "schema_version": "0.1",
+            "id": "doomed",
+            "name": "Doomed",
+            "board": {"library_id": "esp32-devkitc-v4", "mcu": "esp32", "framework": "arduino"},
+            "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+            "components": [],
+            "buses": [],
+            "connections": [],
+        }
+        await c.post("/designs", json={"design_id": "doomed", "design": design})
+        await c.put("/designs/active", json={"id": "doomed"})
+        assert (await c.get("/designs/active")).json() == {"id": "doomed"}
+
+        await c.delete("/designs/doomed")
+        assert (await c.get("/designs/active")).json() == {"id": None}
+
+
+async def test_delete_unrelated_design_doesnt_clear_active(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("WIRESTUDIO_MCP_TOKEN", "test")
+    monkeypatch.setenv("DESIGNS_DIR", str(tmp_path / "designs"))
+    monkeypatch.setenv("SESSIONS_DIR", str(tmp_path / "sessions"))
+    from wirestudio.api.app import create_app
+    app = create_app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://t"
+    ) as c:
+        design = {
+            "schema_version": "0.1",
+            "id": "keep-me",
+            "name": "Keep Me",
+            "board": {"library_id": "esp32-devkitc-v4", "mcu": "esp32", "framework": "arduino"},
+            "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+            "components": [], "buses": [], "connections": [],
+        }
+        await c.post("/designs", json={"design_id": "keep-me", "design": design})
+        await c.put("/designs/active", json={"id": "keep-me"})
+
+        other = {**design, "id": "delete-me"}
+        await c.post("/designs", json={"design_id": "delete-me", "design": other})
+        await c.delete("/designs/delete-me")
+        # Active pointer untouched -- only keep-me was active.
+        assert (await c.get("/designs/active")).json() == {"id": "keep-me"}
+
+
+# ---------------------------------------------------------------------------
+# MCP set_active_design + get_active_design
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mcp_server(tmp_path: Path):
+    store = FileDesignStore(root=tmp_path / "designs")
+    active = ActiveDesignTracker()
+    server = build_mcp_server(default_library(), store, active=active)
+    return server, store, active
+
+
+async def test_mcp_set_active_design_records_id(mcp_server):
+    server, store, active = mcp_server
+    design_id = _seed_design(store, "garage")
+    out = _tool_payload(
+        await server.call_tool("set_active_design", {"design_id": design_id})
+    )
+    assert out == {"ok": True, "active_design_id": "garage"}
+    assert active.get() == "garage"
+
+
+async def test_mcp_set_active_design_unknown_id_returns_error(mcp_server):
+    server, _, active = mcp_server
+    out = _tool_payload(
+        await server.call_tool("set_active_design", {"design_id": "no-such"})
+    )
+    assert out["ok"] is False
+    assert "no design" in out["error"]
+    assert active.get() is None
+
+
+async def test_mcp_set_active_design_empty_string_clears(mcp_server):
+    server, store, active = mcp_server
+    _seed_design(store, "garage")
+    await server.call_tool("set_active_design", {"design_id": "garage"})
+    out = _tool_payload(
+        await server.call_tool("set_active_design", {"design_id": ""})
+    )
+    assert out == {"ok": True, "active_design_id": None}
+    assert active.get() is None
+
+
+async def test_mcp_get_active_design(mcp_server):
+    server, store, _ = mcp_server
+    _seed_design(store, "garage")
+    out = _tool_payload(await server.call_tool("get_active_design", {}))
+    assert out == {"active_design_id": None}
+    await server.call_tool("set_active_design", {"design_id": "garage"})
+    out = _tool_payload(await server.call_tool("get_active_design", {}))
+    assert out == {"active_design_id": "garage"}
+
+
+# ---------------------------------------------------------------------------
+# MCP tools default to active when design_id omitted
+# ---------------------------------------------------------------------------
+
+
+async def test_render_uses_active_when_design_id_omitted(mcp_server):
+    server, store, active = mcp_server
+    _seed_design(store, "garage")
+    active.set("garage")
+
+    out = _tool_payload(await server.call_tool("render", {}))
+    assert out.get("ok") is True
+    assert "yaml" in out
+
+
+async def test_render_explicit_design_id_overrides_active(mcp_server):
+    server, store, active = mcp_server
+    _seed_design(store, "garage")
+    _seed_design(store, "other")
+    active.set("garage")
+
+    out = _tool_payload(
+        await server.call_tool("render", {"design_id": "other"})
+    )
+    assert out.get("ok") is True
+    # Result includes the design_id "other"; just confirm it didn't error.
+
+
+async def test_render_with_no_active_or_id_returns_error(mcp_server):
+    server, _, _ = mcp_server
+    out = _tool_payload(await server.call_tool("render", {}))
+    assert out["ok"] is False
+    assert "no active design" in out["error"].lower()
+
+
+async def test_add_component_uses_active_when_design_id_omitted(mcp_server):
+    server, store, active = mcp_server
+    _seed_design(store, "garage")
+    active.set("garage")
+
+    out = _tool_payload(
+        await server.call_tool(
+            "add_component", {"library_id": "bme280"}
+        )
+    )
+    assert out["ok"] is True
+    # Reload and confirm bme280 was persisted to the active design.
+    saved = store.load("garage")
+    assert any(c["library_id"] == "bme280" for c in saved["components"])
+
+
+async def test_add_component_with_no_design_id_or_active_errors(mcp_server):
+    server, _, _ = mcp_server
+    out = _tool_payload(
+        await server.call_tool(
+            "add_component", {"library_id": "bme280"}
+        )
+    )
+    assert out["ok"] is False
+    assert "no active design" in out["error"].lower()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -29,6 +29,8 @@ EXPECTED_TOOLS = {
     "set_connection",
     "add_bus",
     "solve_pins",
+    "set_active_design",
+    "get_active_design",
 }
 
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -152,6 +152,14 @@ export default function App() {
   useEffect(() => { designRef.current = design; }, [design]);
   useEffect(() => { originalDesignRef.current = originalDesign; }, [originalDesign]);
 
+  // Mirror the browser's selectedSaved into the server's active-design
+  // pointer so MCP tool calls default their `design_id` to whatever the
+  // user is currently looking at. "Add a BME280 to this design" in chat
+  // then resolves naturally against the visible design.
+  useEffect(() => {
+    void api.setActiveDesign(selectedSaved);
+  }, [selectedSaved]);
+
   // Subscribe to design-changed events for the active saved design. Any
   // write from the MCP tool surface (or another tab, or the CLI) fires a
   // `saved` event we react to by re-fetching. If the user has unsaved

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -127,6 +127,12 @@ export const api = {
     request<{ deleted: boolean; id: string }>(`/designs/${encodeURIComponent(id)}`, {
       method: "DELETE",
     }),
+  getActiveDesign: () => request<{ id: string | null }>("/designs/active"),
+  setActiveDesign: (id: string | null) =>
+    request<{ id: string | null }>("/designs/active", {
+      method: "PUT",
+      body: JSON.stringify({ id }),
+    }),
 
   fleetStatus: () => request<FleetStatus>("/fleet/status"),
   fleetPush: (body: { design: Design; compile?: boolean; device_name?: string; strict?: boolean }) =>

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -49,6 +49,7 @@ from wirestudio.api.schemas import (
     UseCaseEntry,
     ValidateResponse,
 )
+from wirestudio.designs.active import ActiveDesignTracker
 from wirestudio.designs.events import DesignEventBus, EventEmittingDesignStore
 from wirestudio.fleet.client import FleetClient, FleetUnavailable
 from wirestudio.csp.compatibility import check_pin_compatibility
@@ -134,6 +135,7 @@ def create_app(
     designs: Optional[DesignStore] = None,
     fleet_client_factory=None,
     event_bus: Optional[DesignEventBus] = None,
+    active_design: Optional[ActiveDesignTracker] = None,
 ) -> FastAPI:
     import os as _os
     lib = library or default_library()
@@ -147,6 +149,7 @@ def create_app(
     # and any future CLI all fan out to subscribed browser tabs without
     # the caller knowing about the bus.
     designs_store = EventEmittingDesignStore(inner_designs, bus)
+    active = active_design or ActiveDesignTracker()
     # Tests substitute a factory that returns a FleetClient bound to an
     # httpx.MockTransport so we never hit the network in CI.
     make_fleet: callable = fleet_client_factory or (lambda: FleetClient())
@@ -155,7 +158,7 @@ def create_app(
 
 
     mcp_enabled = os.environ.get("WIRESTUDIO_MCP_ENABLED", "true").lower() != "false"
-    mcp_server = build_mcp_server(lib, designs_store) if mcp_enabled else None
+    mcp_server = build_mcp_server(lib, designs_store, active=active) if mcp_enabled else None
 
     @asynccontextmanager
     async def lifespan(_: FastAPI):
@@ -488,6 +491,29 @@ def create_app(
             raise HTTPException(status_code=422, detail=str(e)) from e
         return SaveDesignResponse(id=design_id, saved_at=saved_at)
 
+    # `/designs/active` must register before `/designs/{design_id}` so the
+    # literal path wins matching -- otherwise `active` is captured as a
+    # design id and GET 404s with "no saved design with id 'active'".
+    @app.get("/designs/active", tags=["designs"])
+    def get_active_design() -> dict:
+        """Return the currently-active design id (or null if none set).
+
+        Drives the chat-driven UX: MCP tools fall back to this id when the
+        caller doesn't supply `design_id`. The browser writes it via PUT
+        whenever the user selects a saved design so a prompt like
+        "add a BME280 to this design" resolves naturally.
+        """
+        return {"id": active.get()}
+
+    @app.put("/designs/active", tags=["designs"])
+    def set_active_design(body: dict) -> dict:
+        """Set or clear the active design id. Body: `{id: string | null}`."""
+        new_id = body.get("id")
+        if new_id is not None and not isinstance(new_id, str):
+            raise HTTPException(status_code=422, detail="`id` must be a string or null")
+        active.set(new_id)
+        return {"id": active.get()}
+
     @app.get("/designs/{design_id}", tags=["designs"])
     def get_saved_design(design_id: str) -> dict:
         try:
@@ -505,6 +531,11 @@ def create_app(
             raise HTTPException(status_code=400, detail=str(e)) from e
         if not removed:
             raise HTTPException(status_code=404, detail=f"no saved design with id {design_id!r}")
+        # Clear the active design pointer if it was just deleted -- a
+        # dangling active id would have MCP tools fail with "no such
+        # design" on every default-resolved call.
+        if active.get() == design_id:
+            active.clear()
         return {"deleted": True, "id": design_id}
 
     @app.get("/designs/{design_id}/events", tags=["designs"])

--- a/wirestudio/designs/active.py
+++ b/wirestudio/designs/active.py
@@ -1,0 +1,36 @@
+"""Server-side "active design" tracker.
+
+A single string slot that records which design id the user is currently
+working on. The browser writes it when the user selects a saved design;
+MCP tools read it as the default for `design_id` so a chat like "add a
+BME280 to this design" resolves against whatever the browser is showing.
+
+Single-operator homelab assumption: one tracker per server process,
+shared across browser tabs and MCP clients. A multi-user deployment
+would key this by session, but that's out of scope until/unless
+wirestudio grows past a single-operator surface.
+
+The tracker is just a mutable string box. Concurrency-safe because the
+underlying assignment is atomic in CPython; no lock needed for a single
+slot.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+class ActiveDesignTracker:
+    """Holds the currently-active design id."""
+
+    def __init__(self, initial: Optional[str] = None) -> None:
+        self._id: Optional[str] = initial
+
+    def get(self) -> Optional[str]:
+        return self._id
+
+    def set(self, design_id: Optional[str]) -> None:
+        """Set or clear the active design id. Empty string normalizes to None."""
+        self._id = design_id if design_id else None
+
+    def clear(self) -> None:
+        self._id = None

--- a/wirestudio/mcp/server.py
+++ b/wirestudio/mcp/server.py
@@ -34,6 +34,7 @@ from wirestudio.agent.tools import (
     _run_solve_pins,
     _run_validate,
 )
+from wirestudio.designs.active import ActiveDesignTracker
 from wirestudio.designs.store import DesignStore
 from wirestudio.generate.ascii_gen import render_ascii
 from wirestudio.generate.yaml_gen import render_yaml
@@ -46,11 +47,22 @@ def build_mcp_server(
     designs: DesignStore,
     *,
     name: str = "wirestudio",
+    active: Optional[ActiveDesignTracker] = None,
 ) -> FastMCP:
-    """Build a FastMCP server with all wirestudio tools + resources registered."""
+    """Build a FastMCP server with all wirestudio tools + resources registered.
+
+    `active` is the shared active-design tracker (Phase 1.4). When set,
+    design-bound tools default their `design_id` argument to the tracker's
+    current value, so "add a BME280 to this design" resolves against
+    whatever the browser is showing. A fresh tracker is built if the
+    caller doesn't supply one (test-only path -- production wires through
+    `create_app`).
+    """
     mcp = FastMCP(name=name)
+    tracker = active or ActiveDesignTracker()
     _register_library_tools(mcp, library)
-    _register_design_tools(mcp, library, designs)
+    _register_design_tools(mcp, library, designs, tracker)
+    _register_active_tools(mcp, tracker, designs)
     _register_resources(mcp, library, designs)
     return mcp
 
@@ -100,11 +112,33 @@ def _register_library_tools(mcp: FastMCP, library: Library) -> None:
         )
 
 
+_DESIGN_ID_HINT = (
+    " Pass `design_id` explicitly to target a specific design; omit it "
+    "to default to the active design set via `set_active_design` (or by "
+    "the browser when the user selects a design)."
+)
+
+_NO_DESIGN_ERROR = {
+    "ok": False,
+    "error": (
+        "design_id was not provided and no active design is set. "
+        "Either pass design_id explicitly or call set_active_design first."
+    ),
+}
+
+
 def _register_design_tools(
-    mcp: FastMCP, library: Library, designs: DesignStore
+    mcp: FastMCP, library: Library, designs: DesignStore,
+    active: ActiveDesignTracker,
 ) -> None:
-    def _load(design_id: str) -> dict:
-        return designs.load(design_id)
+    def _resolve(design_id: Optional[str]) -> Optional[str]:
+        return design_id or active.get()
+
+    def _load(design_id: Optional[str]) -> tuple[Optional[str], Optional[dict]]:
+        rid = _resolve(design_id)
+        if not rid:
+            return None, None
+        return rid, designs.load(rid)
 
     def _save(design_id: str, design: dict) -> None:
         designs.save(design, design_id=design_id)
@@ -113,35 +147,43 @@ def _register_design_tools(
         name="render",
         description=(
             "Render the named design to ESPHome YAML + ASCII diagram. "
-            "Returns both as strings. Read-only."
+            "Returns both as strings. Read-only." + _DESIGN_ID_HINT
         ),
     )
-    def render(design_id: str) -> dict:
-        return _run_render(_load(design_id), library)
+    def render(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
+        return _run_render(design, library)
 
     @mcp.tool(
         name="validate",
         description=(
             "Validate the named design against the JSON schema and library. "
             "Returns ok=true plus a summary, or ok=false with the failing "
-            "field path + message. Read-only."
+            "field path + message. Read-only." + _DESIGN_ID_HINT
         ),
     )
-    def validate(design_id: str) -> dict:
-        return _run_validate(_load(design_id), library)
+    def validate(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
+        return _run_validate(design, library)
 
     @mcp.tool(
         name="set_board",
         description=(
             "Replace the design's board. Looks up the library board by id "
             "and updates `design.board.{library_id, mcu, framework}`. Does "
-            "NOT translate existing pin references."
+            "NOT translate existing pin references." + _DESIGN_ID_HINT
         ),
     )
-    def set_board(design_id: str, library_id: str) -> dict:
-        design = _load(design_id)
+    def set_board(library_id: str, design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
         result = _run_set_board(design, library, library_id=library_id)
-        _save(design_id, design)
+        _save(rid, design)
         return result
 
     @mcp.tool(
@@ -150,17 +192,19 @@ def _register_design_tools(
             "Add a component instance to the design. Auto-generates a "
             "unique instance_id (or use `instance_id_hint`), sets `label` "
             "(default = library component name), copies any provided "
-            "`params`. Returns the new instance_id."
+            "`params`. Returns the new instance_id." + _DESIGN_ID_HINT
         ),
     )
     def add_component(
-        design_id: str,
         library_id: str,
         label: Optional[str] = None,
         instance_id_hint: Optional[str] = None,
         params: Optional[dict] = None,
+        design_id: Optional[str] = None,
     ) -> dict:
-        design = _load(design_id)
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
         result = _run_add_component(
             design,
             library,
@@ -169,7 +213,7 @@ def _register_design_tools(
             instance_id_hint=instance_id_hint,
             params=params,
         )
-        _save(design_id, design)
+        _save(rid, design)
         return result
 
     @mcp.tool(
@@ -177,33 +221,37 @@ def _register_design_tools(
         description=(
             "Remove a component instance and all connections originating "
             "from it. Connections that target it via expander_id are left "
-            "as orphans."
+            "as orphans." + _DESIGN_ID_HINT
         ),
     )
-    def remove_component(design_id: str, instance_id: str) -> dict:
-        design = _load(design_id)
+    def remove_component(instance_id: str, design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
         result = _run_remove_component(design, library, instance_id=instance_id)
-        _save(design_id, design)
+        _save(rid, design)
         return result
 
     @mcp.tool(
         name="set_param",
         description=(
             "Set a single param on a component instance. Pass `value: null` "
-            "to delete the param entirely."
+            "to delete the param entirely." + _DESIGN_ID_HINT
         ),
     )
     def set_param(
-        design_id: str,
         instance_id: str,
         key: str,
         value: Any = None,
+        design_id: Optional[str] = None,
     ) -> dict:
-        design = _load(design_id)
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
         result = _run_set_param(
             design, library, instance_id=instance_id, key=key, value=value
         )
-        _save(design_id, design)
+        _save(rid, design)
         return result
 
     @mcp.tool(
@@ -212,15 +260,18 @@ def _register_design_tools(
             "Set the target of a single connection identified by "
             "component_id + pin_role. The `target` shape mirrors the "
             "design.json schema: rail, gpio, bus, or expander_pin."
+            + _DESIGN_ID_HINT
         ),
     )
     def set_connection(
-        design_id: str,
         component_id: str,
         pin_role: str,
         target: dict,
+        design_id: Optional[str] = None,
     ) -> dict:
-        design = _load(design_id)
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
         result = _run_set_connection(
             design,
             library,
@@ -228,7 +279,7 @@ def _register_design_tools(
             pin_role=pin_role,
             target=target,
         )
-        _save(design_id, design)
+        _save(rid, design)
         return result
 
     @mcp.tool(
@@ -237,11 +288,10 @@ def _register_design_tools(
             "Add a bus to the design. `type` must be one of i2c / spi / "
             "uart / 1wire / i2s. Other fields depend on type: i2c needs "
             "sda + scl, spi needs clk + miso? + mosi?, uart needs rx + tx "
-            "+ baud_rate, i2s needs lrclk + bclk."
+            "+ baud_rate, i2s needs lrclk + bclk." + _DESIGN_ID_HINT
         ),
     )
     def add_bus(
-        design_id: str,
         id: str,
         type: str,
         sda: Optional[str] = None,
@@ -256,8 +306,11 @@ def _register_design_tools(
         baud_rate: Optional[int] = None,
         lrclk: Optional[str] = None,
         bclk: Optional[str] = None,
+        design_id: Optional[str] = None,
     ) -> dict:
-        design = _load(design_id)
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
         fields = {
             "id": id,
             "type": type,
@@ -277,7 +330,7 @@ def _register_design_tools(
         result = _run_add_bus(
             design, library, **{k: v for k, v in fields.items() if v is not None}
         )
-        _save(design_id, design)
+        _save(rid, design)
         return result
 
     @mcp.tool(
@@ -287,13 +340,54 @@ def _register_design_tools(
             "already-bound pins. Returns the count of assignments made, "
             "any unresolved connections, and any conflict / current-budget "
             "warnings the solver detected. Mutates the design."
+            + _DESIGN_ID_HINT
         ),
     )
-    def solve_pins(design_id: str) -> dict:
-        design = _load(design_id)
+    def solve_pins(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
         result = _run_solve_pins(design, library)
-        _save(design_id, design)
+        _save(rid, design)
         return result
+
+
+def _register_active_tools(
+    mcp: FastMCP, active: ActiveDesignTracker, designs: DesignStore
+) -> None:
+    @mcp.tool(
+        name="set_active_design",
+        description=(
+            "Set the active design id. Subsequent design-editing tools "
+            "(render, validate, add_component, etc.) default their "
+            "`design_id` to this value when not supplied, so a user "
+            "prompt like 'add a BME280 to this design' resolves without "
+            "an explicit id. Pass an empty string to clear. Validates "
+            "the id exists in the store; returns ok=false otherwise so "
+            "the model knows to create or save a design first."
+        ),
+    )
+    def set_active_design(design_id: str) -> dict:
+        if not design_id:
+            active.clear()
+            return {"ok": True, "active_design_id": None}
+        if not designs.exists(design_id):
+            return {
+                "ok": False,
+                "error": f"no design with id {design_id!r}; save it first",
+            }
+        active.set(design_id)
+        return {"ok": True, "active_design_id": design_id}
+
+    @mcp.tool(
+        name="get_active_design",
+        description=(
+            "Read the current active design id. Returns "
+            "{active_design_id: string | null}."
+        ),
+    )
+    def get_active_design() -> dict:
+        return {"active_design_id": active.get()}
 
 
 def _register_resources(mcp: FastMCP, library: Library, designs: DesignStore) -> None:


### PR DESCRIPTION
## Summary

Closes the chat UX loop. A user can now say *"add a BME280 to this design"* without naming the design id: the browser writes its current selection to the server, and the MCP tools fall back to that pointer when the caller doesn't supply \`design_id\`.

### What ships

- **\`wirestudio/designs/active.py\`** — \`ActiveDesignTracker\`, a single mutable string slot. Single-operator homelab; one tracker per server process.
- **HTTP**: \`GET /designs/active\` returns \`{id: string | null}\`, \`PUT /designs/active\` accepts \`{id: string | null}\`. Literal-path routes register before \`/designs/{design_id}\` so \"active\" isn't captured as an id by the templated route. Deleting an active design auto-clears the pointer.
- **MCP**: \`set_active_design(design_id)\` (empty string clears, unknown id returns \`{ok: false, error: ...}\`) and \`get_active_design()\`.
- **Tool defaults**: every existing design-bound MCP tool (\`render\`, \`validate\`, \`set_board\`, \`add_component\`, \`remove_component\`, \`set_param\`, \`set_connection\`, \`add_bus\`, \`solve_pins\`) now takes \`design_id\` as an optional keyword. When omitted, the tool resolves from the tracker and returns a structured \`{ok: false, error: \"...\"}\` if neither is set.
- **Frontend**: a \`useEffect\` mirrors \`selectedSaved\` → \`/api/designs/active\` on every change. Clicking a design in the sidebar implicitly points the server at it; clearing the selection sets the pointer to null.

## Test plan

- [x] \`pytest -q\` — 387 pass (19 new in \`tests/test_active_design.py\` covering tracker unit, HTTP endpoints, MCP set/get tools, and tool fallback)
- [x] \`ruff check\` — clean
- [x] \`tsc --noEmit\` + \`vite build\` — clean
- [x] \`vitest\` — 129 pass
- [x] Manual end-to-end smoke against running uvicorn:
  - \`PUT /api/designs/active\` with \`{id: \"test1\"}\` → returns \`{id: \"test1\"}\`
  - \`get_active_design\` MCP tool → returns \`{active_design_id: \"test1\"}\`
  - \`validate\` MCP tool with no \`design_id\` argument → operates on \`test1\` (correctly defaults from active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)