### PR TITLE
🔒 [security fix] restrict overly permissive CORS policy

### DIFF
--- a/tests/test_security_cors.py
+++ b/tests/test_security_cors.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+from wirestudio.api.app import create_app
+
+def test_cors_preflight_headers_restricted():
+    app = create_app()
+    client = TestClient(app)
+
+    # Simulate a preflight request from an allowed origin
+    # asking for a header that is NOT in our new whitelist.
+    headers = {
+        "Origin": "http://localhost:5173",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "X-Custom-Header",
+    }
+
+    response = client.options("/health", headers=headers)
+
+    assert response.status_code == 200
+    allow_headers = response.headers.get("access-control-allow-headers", "")
+
+    # After the fix, X-Custom-Header should NOT be allowed.
+    # CORSMiddleware typically only returns the intersection of requested and allowed headers,
+    # or the full allowed list. In either case, X-Custom-Header should not be there.
+    assert "X-Custom-Header" not in allow_headers
+    assert allow_headers != "*"
+
+    # Verify that our whitelisted headers ARE allowed if requested
+    headers_ok = {
+        "Origin": "http://localhost:5173",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Content-Type, Authorization",
+    }
+    response_ok = client.options("/health", headers=headers_ok)
+    assert response_ok.status_code == 200
+    allow_headers_ok = response_ok.headers.get("access-control-allow-headers", "").split(", ")
+    assert "Content-Type" in allow_headers_ok or "content-type" in [h.lower() for h in allow_headers_ok]
+    assert "Authorization" in allow_headers_ok or "authorization" in [h.lower() for h in allow_headers_ok]

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -202,7 +202,7 @@ def create_app(
         CORSMiddleware,
         allow_origins=origins,
         allow_methods=["GET", "POST", "PUT", "DELETE"],
-        allow_headers=["*"],
+        allow_headers=["Content-Type", "Authorization", "Accept"],
     )
 
     @app.get("/docs", include_in_schema=False)


### PR DESCRIPTION
### 🎯 What:
Fixed an overly permissive CORS policy by replacing the wildcard `allow_headers=["*"]` with an explicit whitelist of required headers.

### ⚠️ Risk:
A wildcard `allow_headers` allows any custom header to be sent in cross-origin requests. While the API currently uses Bearer tokens and is mostly stateless, allowing arbitrary headers increases the attack surface for potential vulnerabilities in header processing or future authentication mechanisms.

### 🛡️ Solution:
- Restricted `allow_headers` in the `CORSMiddleware` configuration to `["Content-Type", "Authorization", "Accept"]`.
- Added a security test `tests/test_security_cors.py` that verifies:
  - Unauthorized headers are not listed in `Access-Control-Allow-Headers`.
  - Authorized headers are correctly allowed.
  - The wildcard `*` is no longer used for headers.

---
*PR created automatically by Jules for task [3968908410947745275](https://jules.google.com/task/3968908410947745275) started by @moellere*