### PR TITLE
🧪 Add tests for _run_solve_pins wrapper

### DIFF
--- a/tests/test_tools_solve_pins.py
+++ b/tests/test_tools_solve_pins.py
@@ -1,0 +1,105 @@
+"""Tests for `_run_solve_pins` wrapper function."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wirestudio.agent.tools import _run_solve_pins
+from wirestudio.library import default_library
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "wirestudio" / "examples"
+
+
+@pytest.fixture
+def library():
+    return default_library()
+
+
+def _load(name: str) -> dict:
+    return json.loads((EXAMPLES_DIR / f"{name}.json").read_text())
+
+
+def _connection(d: dict, component_id: str, pin_role: str) -> dict:
+    return next(
+        c for c in d["connections"]
+        if c["component_id"] == component_id and c["pin_role"] == pin_role
+    )
+
+
+def test_run_solve_pins_mutates_design(library):
+    """Verify that _run_solve_pins mutates the input design dictionary in-place."""
+    design = _load("wasserpir")
+    # Unbind the PIR's OUT connection.
+    _connection(design, "pir1", "OUT")["target"] = {"kind": "gpio", "pin": ""}
+
+    # Run the wrapper
+    result = _run_solve_pins(design, library)
+
+    # Verify the output format
+    assert result["ok"] is True
+    assert len(result["assigned"]) == 1
+    assignment = result["assigned"][0]
+    assert assignment["component_id"] == "pir1"
+    assert assignment["pin_role"] == "OUT"
+    assert assignment["old_target"] == {"kind": "gpio", "pin": ""}
+    assert "pin" in assignment["new_target"]
+    assert assignment["new_target"]["pin"] != ""
+    assert result["unresolved"] == []
+    assert result["warnings"] == []
+
+    # Verify the design was mutated in-place
+    mutated_target = _connection(design, "pir1", "OUT")["target"]
+    assert mutated_target == assignment["new_target"]
+
+def test_run_solve_pins_already_solved(library):
+    """Verify that an already solved design returns an empty assigned list and doesn't mutate."""
+    design = _load("wasserpir")
+    original_target = _connection(design, "pir1", "OUT")["target"]
+
+    result = _run_solve_pins(design, library)
+
+    assert result["ok"] is True
+    assert result["assigned"] == []
+    assert result["unresolved"] == []
+    assert result["warnings"] == []
+
+    # Verify the design wasn't changed
+    mutated_target = _connection(design, "pir1", "OUT")["target"]
+    assert mutated_target == original_target
+
+def test_run_solve_pins_unresolved(library):
+    """Verify that unresolved dependencies are correctly reported."""
+    design = _load("wasserpir")
+
+    # BME280 requires i2c but we won't supply the bus
+    design["components"].append({
+        "id": "bme1",
+        "library_id": "bme280",
+        "label": "BME",
+        "params": {}
+    })
+    design["connections"].append({
+        "component_id": "bme1",
+        "pin_role": "SDA",
+        "target": {"kind": "bus", "bus_id": ""}
+    })
+
+    result = _run_solve_pins(design, library)
+
+    assert result["ok"] is True
+    # The BME280 should trigger an unresolved bus warning since no i2c bus exists
+    assert any(u["code"] == "no_matching_bus" and "bme1" in u["text"] for u in result["unresolved"])
+
+def test_run_solve_pins_warnings(library):
+    """Verify that warnings are correctly reported."""
+    design = _load("wasserpir")
+    # Change the existing board to a missing one
+    design["board"]["library_id"] = "non_existent_board"
+
+    result = _run_solve_pins(design, library)
+    assert result["ok"] is True
+    assert any(w["code"] == "unknown_board" for w in result["warnings"])

--- a/web/src/components/Inspector.test.tsx
+++ b/web/src/components/Inspector.test.tsx
@@ -37,12 +37,12 @@ const libraryBoards: BoardSummary[] = [
   {
     id: "wemos-d1-mini", name: "WeMos D1 Mini",
     mcu: "esp8266", chip_variant: "esp8266", framework: "arduino",
-    platformio_board: "d1_mini", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"],
+    platformio_board: "d1_mini", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"], image: "",
   },
   {
     id: "esp32-devkitc-v4", name: "ESP32 DevKitC",
     mcu: "esp32", chip_variant: "esp32", framework: "arduino",
-    platformio_board: "esp32dev", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"],
+    platformio_board: "esp32dev", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"], image: "",
   },
 ];
 

--- a/web/src/lib/bootstrap.test.ts
+++ b/web/src/lib/bootstrap.test.ts
@@ -8,11 +8,11 @@ import {
 import type { BoardSummary } from "../types/api";
 
 const boards: BoardSummary[] = [
-  { id: "esp32-devkitc-v4", name: "ESP32-DevKitC-V4", mcu: "esp32", chip_variant: "esp32", framework: "arduino", platformio_board: "esp32dev", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"] },
-  { id: "nodemcu-32s",      name: "NodeMCU-32S",      mcu: "esp32", chip_variant: "esp32", framework: "arduino", platformio_board: "nodemcu-32s", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"] },
-  { id: "ttgo-lora32-v1",   name: "TTGO LoRa32 V1",   mcu: "esp32", chip_variant: "esp32", framework: "arduino", platformio_board: "ttgo-lora32-v1", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"] },
-  { id: "wemos-d1-mini",    name: "WeMos D1 Mini",    mcu: "esp8266", chip_variant: "esp8266", framework: "arduino", platformio_board: "d1_mini", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"] },
-  { id: "esp01_1m",         name: "ESP-01S 1MB",      mcu: "esp8266", chip_variant: "esp8266", framework: "arduino", platformio_board: "esp01_1m", flash_size_mb: 1, rail_names: ["5V", "3V3", "GND"] },
+  { id: "esp32-devkitc-v4", name: "ESP32-DevKitC-V4", mcu: "esp32", chip_variant: "esp32", framework: "arduino", platformio_board: "esp32dev", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"], image: "" },
+  { id: "nodemcu-32s",      name: "NodeMCU-32S",      mcu: "esp32", chip_variant: "esp32", framework: "arduino", platformio_board: "nodemcu-32s", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"], image: "" },
+  { id: "ttgo-lora32-v1",   name: "TTGO LoRa32 V1",   mcu: "esp32", chip_variant: "esp32", framework: "arduino", platformio_board: "ttgo-lora32-v1", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"], image: "" },
+  { id: "wemos-d1-mini",    name: "WeMos D1 Mini",    mcu: "esp8266", chip_variant: "esp8266", framework: "arduino", platformio_board: "d1_mini", flash_size_mb: 4, rail_names: ["5V", "3V3", "GND"], image: "" },
+  { id: "esp01_1m",         name: "ESP-01S 1MB",      mcu: "esp8266", chip_variant: "esp8266", framework: "arduino", platformio_board: "esp01_1m", flash_size_mb: 1, rail_names: ["5V", "3V3", "GND"], image: "" },
 ];
 
 describe("normalizeChipFamily", () => {


### PR DESCRIPTION
🎯 **What:** The testing gap for `_run_solve_pins` in `wirestudio/agent/tools.py` has been addressed. The internal solver was tested, but the wrapper function that mutates the design dictionary and returns the required structure was untested.
📊 **Coverage:** Tests now cover:
- Happy path mutation of the design dictionary with correct return structure.
- Empty assignments when the design is already solved.
- Correct handling and surfacing of unresolved dependency errors (e.g., missing buses).
- Correct handling and surfacing of warnings (e.g., unknown boards).
✨ **Result:** The `_run_solve_pins` wrapper logic is now fully verified to conform to its expected signature and return values.

---
*PR created automatically by Jules for task [9047835309430604963](https://jules.google.com/task/9047835309430604963) started by @moellere*