### PR TITLE
🔒 Fix path traversal vulnerability in /examples endpoint

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -354,3 +354,20 @@ def test_list_use_cases_includes_known_capabilities(client):
     flat = {(row["use_case"], lib_id) for row in r for lib_id in row["example_components"]}
     assert ("motion", "hc-sr501") in flat
     assert any(uc == "temperature" and lib == "bme280" for uc, lib in flat)
+
+def test_get_example_path_traversal(client):
+    # Attempt to use path traversal
+    r = client.get("/examples/..%2f..%2fetc%2fpasswd")
+    assert r.status_code == 404
+
+    # Attempt to use absolute path
+    r = client.get("/examples/%2fetc%2fpasswd")
+    assert r.status_code == 404
+
+    # Attempt to use forward slash
+    r = client.get("/examples/some%2ffolder")
+    assert r.status_code == 404
+
+    # Attempt to use backslash
+    r = client.get("/examples/some%5cfolder")
+    assert r.status_code == 404

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -524,9 +524,13 @@ def create_app(
 
     @app.get("/examples/{example_id}", tags=["examples"])
     def get_example(example_id: str) -> dict:
-        path = EXAMPLES_DIR / f"{example_id}.json"
-        if not path.exists():
+        if "/" in example_id or "\\" in example_id:
             raise HTTPException(status_code=404, detail=f"Unknown example '{example_id}'")
+
+        path = (EXAMPLES_DIR / f"{example_id}.json").resolve()
+        if not path.is_relative_to(EXAMPLES_DIR.resolve()) or not path.exists():
+            raise HTTPException(status_code=404, detail=f"Unknown example '{example_id}'")
+
         return json.loads(path.read_text())
 
     # ---------------------------------------------------------------------


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in the `/examples/{example_id}` API endpoint. The endpoint was previously constructing a file path using an unsanitized `example_id` string directly, allowing attackers to escape the `EXAMPLES_DIR` and read arbitrary `.json` files on the filesystem.
⚠️ **Risk:** If left unfixed, an attacker could supply directory traversal characters (e.g., `../`) or absolute paths to access unauthorized files, potentially exposing sensitive information or source code located elsewhere on the host.
🛡️ **Solution:** Added defensive checks to explicitly reject `example_id` values containing `/` or `\` characters. Furthermore, we implemented defense-in-depth by resolving the constructed path and verifying it is strictly relative to the resolved `EXAMPLES_DIR` path using `pathlib.Path.is_relative_to()`. We also added dedicated tests in `tests/test_api.py` to ensure these traversal attempts are reliably blocked with a 404 response.

---
*PR created automatically by Jules for task [636918339769397668](https://jules.google.com/task/636918339769397668) started by @moellere*