### PR TITLE
⚡ Bolt: Memoize expensive computations in ConnectionForm

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Stable Array References from design.ts Readers
 **Learning:** Helper functions like `readComponents` or `readConnections` in `web/src/lib/design.ts` map over the raw `Design` object and return *new* array references on every call. If called directly in the body of a React component, they defeat any downstream `useMemo` hooks (e.g., in `PinoutView.tsx` drag-and-drop), causing expensive re-computations on every render.
 **Action:** Always wrap the return values of `read*` helpers in `useMemo(..., [design])` at the call site within a React component.
+
+## 2024-05-20 - React Hooks and Early Returns
+**Learning:** When moving derived state computations into `useMemo` hooks inside components that had early returns (like `if (rows.length === 0)`), you must move the early return *after* the hooks to avoid violating React's rules of hooks (hooks cannot be called conditionally).
+**Action:** When adding hooks to an existing component, always check for early returns and ensure all hooks are called unconditionally before any early returns.

--- a/web/src/components/ConnectionForm.tsx
+++ b/web/src/components/ConnectionForm.tsx
@@ -6,6 +6,7 @@
  * target up to the App via onChange(index, target).
  */
 
+import { useMemo } from "react";
 import type { ComponentSummary } from "../types/api";
 import {
   type ConnectionRow,
@@ -30,19 +31,31 @@ interface Props {
 export function ConnectionForm({
   rows, design, boardData, libraryComponents, onChange, onLockedPinChange,
 }: Props) {
+  const board = (boardData ?? {}) as Record<string, unknown>;
+
+  const railNames = useMemo(() => {
+    return Array.isArray(board.rails)
+      ? (board.rails as Array<Record<string, unknown>>).map((r) => String(r.name))
+      : [];
+  }, [board.rails]);
+
+  const gpioPins = useMemo(() => {
+    return Object.keys((board.gpio_capabilities ?? {}) as Record<string, unknown>);
+  }, [board.gpio_capabilities]);
+
+  const buses = useMemo(() => readBuses(design), [design]);
+
+  const expanders = useMemo(() => expandersFromDesign(design, libraryComponents), [design, libraryComponents]);
+
+  const componentInstances = useMemo(() => {
+    return readComponents(design).map((c) => ({
+      id: c.id, library_id: c.library_id,
+    }));
+  }, [design]);
+
   if (rows.length === 0) {
     return <div className="text-xs text-zinc-500">No connections.</div>;
   }
-  const board = (boardData ?? {}) as Record<string, unknown>;
-  const railNames = Array.isArray(board.rails)
-    ? (board.rails as Array<Record<string, unknown>>).map((r) => String(r.name))
-    : [];
-  const gpioPins = Object.keys((board.gpio_capabilities ?? {}) as Record<string, unknown>);
-  const buses = readBuses(design);
-  const expanders = expandersFromDesign(design, libraryComponents);
-  const componentInstances = readComponents(design).map((c) => ({
-    id: c.id, library_id: c.library_id,
-  }));
 
   return (
     <div className="space-y-2">


### PR DESCRIPTION
⚡ Bolt: Memoize expensive computations in ConnectionForm

💡 What: Wrapped `readBuses`, `readComponents`, `expandersFromDesign` and board-derived props in `useMemo` hooks. Also moved the early return for empty rows after the hooks.
🎯 Why: `read*` helpers iterate over the entire design and return new array references every time. When these were calculated in the render body of `ConnectionForm`, any state change (like typing in a field) caused expensive re-computations and generated new array references that broke downstream memoization.
📊 Impact: Eliminates O(N) array traversals (where N is number of components/buses) on every keystroke when editing connection targets. Maintains stable object references for child components.
🔬 Measurement: Observe React DevTools Profiler while rapidly toggling a pin lock or editing a target; the render duration of `ConnectionForm` will be significantly shorter.

---
*PR created automatically by Jules for task [738821551525359117](https://jules.google.com/task/738821551525359117) started by @moellere*