### PR TITLE
⚡ Bolt: memoize bus derivation in BusList to prevent unnecessary re-renders

### DIFF
--- a/web/src/components/BusList.tsx
+++ b/web/src/components/BusList.tsx
@@ -4,7 +4,7 @@
  * for the type; removing leaves any connection targeting the bus
  * dangling (the inspector's render warnings surface that).
  */
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import {
   type BusType,
   addBus,
@@ -43,12 +43,15 @@ export function BusList({
   compatibilityWarnings: CompatibilityWarning[];
   onChange: (updater: (d: Design) => Design) => void;
 }) {
-  const buses = ((design.buses as Array<Record<string, unknown>> | undefined) ?? []).map((b) => ({
-    id: String(b.id),
-    type: String(b.type) as BusType,
-    raw: b,
-  }));
-  const allBusIds = new Set(buses.map((b) => b.id));
+  // ⚡ Bolt: memoize bus derivation to prevent mapping the design.buses array into new object references on every render
+  const buses = useMemo(() => {
+    return ((design.buses as Array<Record<string, unknown>> | undefined) ?? []).map((b) => ({
+      id: String(b.id),
+      type: String(b.type) as BusType,
+      raw: b,
+    }));
+  }, [design.buses]);
+  const allBusIds = useMemo(() => new Set(buses.map((b) => b.id)), [buses]);
 
   const [pickedType, setPickedType] = useState<BusType>("i2c");
 


### PR DESCRIPTION
💡 **What:** Wrapped the mapping of `design.buses` array and computation of `allBusIds` set in `useMemo` hooks inside the `BusList` component.
🎯 **Why:** Previously, the `BusList` component was re-mapping the raw `design.buses` object and creating new Array and Set references on every single render, even when the underlying data hadn't changed. This breaks referential equality and can lead to expensive downstream re-renders or excessive garbage collection, especially during high-frequency updates.
📊 **Impact:** Reduces unnecessary object allocations and helps preserve referential equality downstream, marginally decreasing render cycles when the `design.buses` array remains stable.
🔬 **Measurement:** Verify by placing a console log inside the `BusList` component or profiling the React component tree while changing unrelated parts of the design (e.g. Inspector data); the mappings should no longer execute.

---
*PR created automatically by Jules for task [12734636654227547875](https://jules.google.com/task/12734636654227547875) started by @moellere*