### PR TITLE
ci: add esphome-matrix compatibility report across ESPHome versions

### DIFF
--- a/.github/workflows/esphome-matrix.yml
+++ b/.github/workflows/esphome-matrix.yml
@@ -1,0 +1,70 @@
+name: esphome-matrix
+
+# Compatibility report across ESPHome versions.
+#
+# The `esphome-config` gate validates every example against ONE pinned
+# ESPHome (the merge bar). This workflow runs the same validation across
+# a small matrix of versions -- the pin plus the latest stables -- so we
+# can see, at a glance, whether what the studio emits still validates on
+# newer ESPHome before we bump the pin. It's a *report*, not a gate:
+# legs are allowed to fail without failing the run (the pinned version
+# is already enforced per-PR by esphome-config.yml).
+#
+# When a newer version goes green here across the board, that's the
+# signal to bump the pin (see CONTRIBUTING.md "Bumping the pinned
+# ESPHome"). When it goes red, the failing examples tell you what
+# upstream changed.
+#
+# Runs on a schedule + manual dispatch only -- a multi-version sweep is
+# too heavy for every PR.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # 09:00 UTC Monday (ahead of the per-PR gates)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: esphome-matrix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    # Informational: a version that rejects our YAML must not fail the run.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        # The pinned baseline + the latest stables. Bump as releases land;
+        # the pin itself lives in esphome-config.yml / esphome-compile.yml.
+        esphome_version: ["2025.12.7", "2026.4.5", "2026.5.0"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install studio + ESPHome ${{ matrix.esphome_version }}
+        run: |
+          pip install -e .
+          pip install "esphome==${{ matrix.esphome_version }}"
+
+      - name: Validate every example through `esphome config`
+        id: gate
+        continue-on-error: true
+        run: python scripts/check_examples.py
+
+      - name: Report result
+        if: always()
+        run: |
+          if [ "${{ steps.gate.outcome }}" = "success" ]; then
+            echo "### ESPHome ${{ matrix.esphome_version }} — ✅ all examples validate" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### ESPHome ${{ matrix.esphome_version }} — ❌ some examples failed" >> "$GITHUB_STEP_SUMMARY"
+            echo "Re-run with the logs open to see which; this version is not the pinned merge bar." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,13 @@ below), and `README.md` (the version we advertise). Bump all three
 in the same diff. The bump PR's burden of proof is "the gate passes
 against the new version" — not "the new version is fashionable."
 
+The [`esphome-matrix`](.github/workflows/esphome-matrix.yml) workflow
+(scheduled + manual) runs the example gate across the pin plus the
+latest stables, so you can see a candidate version go green across the
+board *before* bumping. When it does, bump the pin (and add the new
+version to the matrix list); when it's red, the failing examples show
+what upstream changed.
+
 ### Nightly compile smoke
 
 `.github/workflows/esphome-compile.yml` runs `esphome compile`

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,9 +81,12 @@ through upstream `esphome config`. Shipped: the `esphome config` CI
 gate over every bundled example; a nightly `esphome compile` smoke;
 the component-coverage matrix ([`library-coverage.md`](library-coverage.md))
 with a `--strict` no-regression gate; a pinned ESPHome version called
-out in the README + workflow; CONTRIBUTING.md establishes the gate as
-the merge bar. Next: an ESPHome version matrix in CI so component
-support can be called out per release.
+out in the README + workflow; an
+[`esphome-matrix`](../.github/workflows/esphome-matrix.yml) compatibility
+report that runs the gate across the pin + latest stables so a pin bump
+is evidence-driven; CONTRIBUTING.md establishes the gate as the merge
+bar. Next: attribute matrix failures to specific components so support
+can be stated per ESPHome release.
 
 **Priority 2 — Wiring schema correctness.** *Verified.* SKiDL
 emitter, 100% library `kicad:` coverage, and a `.kicad_sym` symbol
@@ -115,7 +118,8 @@ solver (`0.6`), fleet handoff (`0.7`), enclosure (`0.8`), KiCad
 schematic (`0.9`), MCP server + KiCad symbol importer (`0.10`),
 Docker single-image deploy + K8s manifest.
 
-**Future** — multi-writer state backend so the studio can run as a
-HA replica; agent eval harness against a task list; ESPHome version
-matrix in CI (last 2 stables) so we can call out which components
-work where.
+**Future** — full library coverage (close the last components + the
+two camera boards, then flip `--strict` to zero-uncovered); an agent
+eval harness scoring tool-use against a fixed task list; PCB layout
+(Priority 4); a multi-writer state backend so the studio can run as a
+HA replica.


### PR DESCRIPTION
## Summary

Milestone **D**: an ESPHome version-compatibility report in CI.

The `esphome-config` gate validates every example against **one** pinned ESPHome (the merge bar, currently `2025.12.7`). The pin is now ~6 months behind upstream (`2026.5.0`). This adds a scheduled + manual **`esphome-matrix`** workflow that runs the same example gate across a small matrix — the pin plus the latest stables (`2026.4.5`, `2026.5.0`) — so bumping the pin becomes **evidence-driven**: when a newer version goes green across the board, that's the signal to bump; when it's red, the failing examples show what upstream changed.

- **Report, not a gate.** Legs are `continue-on-error` so a version that rejects our YAML never fails the run — the pinned version stays enforced per-PR by `esphome-config.yml`. Each leg writes a pass/fail line to the job summary.
- **Scheduled + dispatch only** (Mondays 09:00 UTC), since a multi-version sweep is too heavy for every PR.
- Roadmap (`docs/index.md`) and CONTRIBUTING's "Bumping the pinned ESPHome" updated to point at the matrix as the bump signal.

Independent of the #58/#59 seeder stack — branches off `main`.

## Test plan
- [x] workflow YAML parses; no code changes (workflow + docs only)
- [ ] first scheduled/dispatch run shows the per-version pass/fail report (will reveal whether our output validates on 2026.x — informs the next pin bump)

Note: I couldn't validate against 2026.x locally — installing it here fails on a `crcmod` C-extension build (sandbox lacks the toolchain). CI has the build tools; surfacing that 2026.x result is exactly what this workflow is for.

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_