### PR TITLE
fix: import useEffect in BusList (unbreaks the Docker web build)

### DIFF
--- a/web/src/components/BusList.tsx
+++ b/web/src/components/BusList.tsx
@@ -4,7 +4,7 @@
  * for the type; removing leaves any connection targeting the bus
  * dangling (the inspector's render warnings surface that).
  */
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
   type BusType,
   addBus,


### PR DESCRIPTION
## Summary

Fixes the Docker `build` check that's been red on `main` and every open PR. It's a **real, pre-existing bug on `main`**, not from any feature branch.

`web/src/components/BusList.tsx` uses `useEffect` (the draft-id resync that came in with the bus-rename memoization, #51/#52) but the import is only `{ useState, useMemo }`. Local `tsc -b` is **incremental** and had the file cached, so it slipped through every local build; the Docker web-builder does a **clean** compile and fails:

```
src/components/BusList.tsx(127,3): error TS2304: Cannot find name 'useEffect'.
```

One-line import fix. Verified with a cache-cleared `npm run build` (clean `tsc -b` + vite) and `vitest run BusList` (8 pass).

This unblocks the docker build for `main`, the #58/#59 seeder stack, and #60 — **merge this first.**

## Test plan
- [x] clean `npm run build` passes (removed `*.tsbuildinfo` to force a full recheck)
- [x] `vitest run BusList` — 8/8

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_