### PR TITLE
docs: refresh documentation + cut 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(no changes since v0.11.0)
+(no changes since v0.12.0)
+
+## [0.12.0] — 2026-05-23
+
+Headline: three of the four priority tiers (YAML, wiring schema,
+enclosure) are now gated in CI; onboard peripherals auto-populate when
+you adopt a board; and every library component and board is exercised
+by a bundled example (100% coverage, enforced).
+
+### Added
+
+- **Onboard-peripheral auto-populate.** Adopting a dev board — via USB
+  detection or **New design** — now seeds its built-in parts (LCD,
+  buttons, IMU, RGB/IR, LoRa, GPS, ...) already wired. Covers all 13
+  boards that carry `onboard_peripherals` metadata; peripherals with no
+  library component (e.g. the AXP192 PMIC) are skipped with a warning.
+  New `POST /design/seed_onboard` endpoint.
+- **New library components:** `mpu6886` (Atom-family IMU),
+  `remote_transmitter` (IR blaster), `i2s_microphone` (I2S/PDM mic).
+- **Schematic gate (KiCad) — Verified.** `kicad-schematic` workflow
+  runs every example's SKiDL script against the pinned upstream KiCad
+  symbol libraries and fails on any unresolved symbol or pin.
+- **Enclosure gate (OpenSCAD) — Verified.** `enclosure-render` workflow
+  renders every enclosure-capable board's `.scad` and asserts a
+  non-empty manifold solid.
+- **Coverage `--strict` gate** wired into CI, plus an **`esphome-matrix`**
+  workflow that runs the example gate across the pin + latest stables so
+  pin bumps are evidence-driven.
+- **100% library coverage:** every component (59) and board (21) is now
+  exercised by a bundled example that passes both the ESPHome-config and
+  KiCad-netlist gates; the `--strict` baseline is empty.
+- Agent streaming failure-mode tests; API schema field descriptions.
+
+### Fixed
+
+- USB-connect board detection now matches esptool's detailed chip names
+  (e.g. `ESP32-PICO-D4`) to the right board family; the board-picker
+  modal scrolls and the confirm button stays reachable.
+- ~16 library `kicad:` blocks corrected to real upstream symbols (the
+  schematic gate surfaced hallucinated/wrong references).
+- `BusList` web build break (missing `useEffect` import).
 
 ## [0.11.0] — 2026-05-17
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ Detailed docs live in [`docs/`](docs/):
 
 ## Status
 
-`v0.11.0` — on PyPI (`pip install wirestudio`). The studio has wide
+`v0.12.0` — on PyPI (`pip install wirestudio`). The studio has wide
 surface area (YAML, schematic, enclosure, agent, MCP server, fleet
-handoff, web UI) and a narrow set of things actually verified against
-upstream tools. This section is honest about which is which, ordered
-by how much it matters that it works.
+handoff, web UI) and a set of things actually verified against upstream
+tools. Three of the four priority tiers (YAML, wiring schema, enclosure)
+are now gated in CI, and **every library component and board is
+exercised by a bundled example** that passes those gates. This section
+is honest about which is which, ordered by how much it matters that it
+works.
 
 Tiers, in priority order:
 
@@ -62,7 +65,7 @@ that pin moves, this line moves with it.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:v0.11.0
+  ghcr.io/moellere/wirestudio:v0.12.0
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,7 +11,7 @@ FastAPI serves the API and the built SPA from one process.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:v0.11.0
+  ghcr.io/moellere/wirestudio:v0.12.0
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +
@@ -23,7 +23,7 @@ Available tags:
 
 | Tag | What it tracks |
 |---|---|
-| `:v0.11.0` / `:0.11.0` / `:0.11` / `:latest` | the v0.11.0 release |
+| `:v0.12.0` / `:0.12.0` / `:0.12` / `:latest` | the v0.12.0 release |
 | `:main` | latest commit on `main` (rolling) |
 | `:sha-<short>` | a specific commit |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,7 +80,9 @@ non-negotiable bar: every artifact the studio emits round-trips
 through upstream `esphome config`. Shipped: the `esphome config` CI
 gate over every bundled example; a nightly `esphome compile` smoke;
 the component-coverage matrix ([`library-coverage.md`](library-coverage.md))
-with a `--strict` no-regression gate; a pinned ESPHome version called
+with a `--strict` no-regression gate now at **zero uncovered** (every
+one of the 59 components and 21 boards is exercised by a bundled
+example that passes the gate); a pinned ESPHome version called
 out in the README + workflow; an
 [`esphome-matrix`](../.github/workflows/esphome-matrix.yml) compatibility
 report that runs the gate across the pin + latest stables so a pin bump
@@ -118,8 +120,9 @@ solver (`0.6`), fleet handoff (`0.7`), enclosure (`0.8`), KiCad
 schematic (`0.9`), MCP server + KiCad symbol importer (`0.10`),
 Docker single-image deploy + K8s manifest.
 
-**Future** — full library coverage (close the last components + the
-two camera boards, then flip `--strict` to zero-uncovered); an agent
-eval harness scoring tool-use against a fixed task list; PCB layout
-(Priority 4); a multi-writer state backend so the studio can run as a
-HA replica.
+**Future** — PCB layout (Priority 4): SKiDL → KiCad PCB, Freerouting,
+Gerber + JLCPCB export, now that the schematic is Verified; an agent
+eval harness scoring tool-use against a fixed task list (to promote the
+agent from Experimental); a multi-writer state backend so the studio
+can run as a HA replica; attributing `esphome-matrix` failures to
+specific components for per-release support tables.

--- a/docs/library.md
+++ b/docs/library.md
@@ -49,6 +49,7 @@ _Specialty sensors:_
 - `hx711` — AVIA 24-bit load-cell ADC (custom 2-wire serial)
 - `tsl2561` — AMS ambient light sensor (lux, I2C)
 - `mpu6050` — InvenSense 6-axis IMU (3-axis accel + 3-axis gyro + die temp, I2C)
+- `mpu6886` — InvenSense MPU6886 6-axis IMU (the onboard IMU on the M5Stack Atom / AtomS3 family, I2C)
 
 _Presence / distance:_
 - `hc-sr04` — ultrasonic distance sensor (4-pin: VCC, GND, TRIGGER, ECHO)
@@ -94,7 +95,9 @@ _Light / audio / camera:_
 - `esp32_rmt_led_strip` — same WS2812 / SK6812 silicon, ESP32 RMT-driven (preferred on ESP32 / S2 / S3 / C3)
 - `apa102` — APA102 / SK9822 addressable RGB strip (DotStar, SPI-style)
 - `max98357a` — Maxim Class-D mono I2S amp + DAC
+- `i2s_microphone` — I2S / PDM microphone (SPM1423 on the M5Stack Atom Echo / AtomU, or a standard I2S mic)
 - `rtttl` — piezo buzzer + RTTTL melody player (PWM output)
+- `remote_transmitter` — IR transmitter / blaster on a single GPIO (the onboard IR LED on the M5Stack Atom family)
 - `esp32_camera` — ESP32 OV2640 / OV7670 / OV5640 camera
 
 _Power metering:_

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -10,9 +10,11 @@
   library matches against use cases. Drag-and-drop pinout for
   component-to-board pin assignment. Pin locks per role. Bus editor
   with rename propagation + inline compatibility warnings. USB
-  bootstrap from a plugged-in ESP via WebSerial + esptool-js. Saved
-  designs at `designs/<id>.json` with a **Saved** tab + **New design**
-  dialog.
+  bootstrap from a plugged-in ESP via WebSerial + esptool-js — the
+  detected chip is matched to a board family, and the board's built-in
+  peripherals (LCD, button, IMU, RGB/IR, LoRa, GPS, ...) are
+  auto-populated and wired. Saved designs at `designs/<id>.json` with a
+  **Saved** tab + **New design** dialog (which seeds onboard parts too).
 - **Validate.** CSP pin solver assigns every unbound connection with
   capability-aware fallback (boot strap pins de-prioritised; ADC1
   preferred over ADC2 on classic ESP32). Port-compatibility checker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wirestudio"
-version = "0.11.0"
+version = "0.12.0"
 description = "Agent-driven IoT device design tool that produces ESPHome YAML."
 readme = "README.md"
 license = { text = "MIT" }

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"


### PR DESCRIPTION
## Summary

Documentation pass after the gate/coverage/onboard-seeding arc, plus the **0.12.0** version bump.

**Docs refreshed:**
- **CHANGELOG** — a full `0.12.0` entry: onboard auto-populate, the schematic + enclosure **Verified** gates, the `--strict` coverage gate (now at zero-uncovered), the `esphome-matrix` report, 100% library coverage, the connect/board-match + BusList fixes, agent failure-mode tests, API field descriptions.
- **docs/library.md** — adds `mpu6886`, `remote_transmitter`, `i2s_microphone`.
- **docs/index.md** roadmap — P1 notes zero-uncovered coverage; *Future* drops the now-done "full coverage" item and leads with **PCB layout (Priority 4)**.
- **docs/user_guide.md** + **README** — describe the connect / new-design onboard auto-populate; README status reflects three gated tiers + 100% coverage.

**Release 0.12.0:** version bumped in `pyproject.toml`, `wirestudio/__init__.py`, `README`, and `docs/deployment.md`.

## Test plan
- [x] `wirestudio.__version__ == 0.12.0`; no stray `0.11.0` refs outside the CHANGELOG history
- [x] `test_api` passes; ruff clean

After merge, tag **`v0.12.0`** to trigger the release workflow (PyPI + GHCR publish).

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_