### PR TITLE
dev process: dev-branch workflow + CI parity guardrails + ArgoCD prod/dev

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,45 @@
+name: changelog
+
+# Nudge, not a wall: if a PR changes shipped code under wirestudio/ but
+# leaves CHANGELOG.md untouched, fail with a hint. The point is to make
+# "does this need a changelog entry?" a conscious choice, not to block
+# refactors or test-only changes.
+#
+# Escape hatches (either one):
+#   - put [skip changelog] anywhere in the PR title, or
+#   - add the `skip-changelog` label to the PR.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    if: >-
+      !contains(github.event.pull_request.title, '[skip changelog]') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Require a CHANGELOG entry for code changes
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE" "$HEAD")
+          echo "Changed files:"
+          echo "$changed"
+          code=$(echo "$changed" | grep -E '^wirestudio/' || true)
+          changelog=$(echo "$changed" | grep -E '^CHANGELOG\.md$' || true)
+          if [ -n "$code" ] && [ -z "$changelog" ]; then
+            echo "::error::Code under wirestudio/ changed but CHANGELOG.md was not updated."
+            echo "Add an entry under [Unreleased], or use [skip changelog] in the PR title / the skip-changelog label."
+            exit 1
+          fi
+          echo "changelog check: OK"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,7 +11,7 @@ name: changelog
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
 permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,9 +3,15 @@ name: docker
 # Build + publish the runtime image to GitHub Container Registry.
 #
 # Triggers:
+#   - push to dev       -> ghcr.io/<owner>/wirestudio:dev + :sha-<short>
 #   - push to main      -> ghcr.io/<owner>/wirestudio:main + :sha-<short>
-#   - tag push v*       -> ghcr.io/<owner>/wirestudio:v1.2.3 + :1.2.3 + :1.2 + :latest
+#   - tag push v*       -> ghcr.io/<owner>/wirestudio:1.2.3 + :1.2 + :latest
 #   - PR target         -> build only (no push), as a sanity gate
+#
+# Deployment model: the :dev tag rolls forward on every dev merge (point
+# a staging Argo app at it); prod pins an immutable release tag (:1.2.3)
+# and bumps in git on release. :latest also moves on each release tag if
+# you'd rather track that.
 #
 # Auth: GITHUB_TOKEN with packages:write. No external secrets needed.
 #
@@ -14,10 +20,10 @@ name: docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     tags: ["v*"]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch:
 
 permissions:
@@ -54,8 +60,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/wirestudio
           # Tag strategy:
+          #   dev push       -> :dev, :sha-<short>
           #   main push      -> :main, :sha-<short>
-          #   v1.2.3 tag     -> :v1.2.3, :1.2.3, :1.2, :latest
+          #   v1.2.3 tag     -> :1.2.3, :1.2, :latest
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,3 +87,32 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Roll the dev Argo app forward: pin deploy/overlays/dev to the image
+  # just built and commit it back to dev. ArgoCD (automated sync) deploys
+  # the new sha. Pushes made with GITHUB_TOKEN don't retrigger workflows,
+  # and [skip ci] makes that explicit.
+  bump-dev:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+      - name: Pin dev overlay to the freshly built image
+        run: |
+          tag="sha-$(echo "${GITHUB_SHA}" | cut -c1-7)"
+          file=deploy/overlays/dev/kustomization.yaml
+          sed -i -E "s|^( *newTag: ).*|\1${tag}|" "$file"
+          if git diff --quiet -- "$file"; then
+            echo "dev overlay already at ${tag}"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$file"
+          git commit -m "deploy(dev): roll to ${tag} [skip ci]"
+          git push origin dev

--- a/.github/workflows/enclosure-render.yml
+++ b/.github/workflows/enclosure-render.yml
@@ -15,9 +15,9 @@ name: enclosure-render
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-    branches: [main]
+    branches: [main, dev]
   schedule:
     - cron: '0 10 * * 1'   # 10:00 UTC every Monday
   workflow_dispatch:

--- a/.github/workflows/esphome-config.yml
+++ b/.github/workflows/esphome-config.yml
@@ -23,9 +23,9 @@ name: esphome-config
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-    branches: [main]
+    branches: [main, dev]
   schedule:
     - cron: '0 10 * * 1'   # 10:00 UTC every Monday
   workflow_dispatch:

--- a/.github/workflows/kicad-schematic.yml
+++ b/.github/workflows/kicad-schematic.yml
@@ -22,9 +22,9 @@ name: kicad-schematic
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-    branches: [main]
+    branches: [main, dev]
   schedule:
     - cron: '0 10 * * 1'   # 10:00 UTC every Monday
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,8 @@ name: release
 #   3. Create the matching `pypi` GitHub environment in repo settings.
 #
 # Trigger: any pushed `v*` tag + manual workflow_dispatch. Tag must
-# match pyproject.toml's version.
+# match the version in wirestudio/__init__.py (pyproject reads it
+# dynamically from there at build time).
 
 on:
   push:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,14 @@ repos:
         # Requires `pip install 'esphome==2025.12.7'` in the same env.
         # On Debian-patched setuptools hosts you'll need a venv first;
         # see CONTRIBUTING.md.
+
+      - id: web-clean-build
+        name: Clean web build (wipes tsc -b cache so CI parity holds)
+        # CI builds the SPA in a fresh container, so a stale
+        # web/node_modules/.tmp can pass locally while CI fails on a real
+        # type error (it has, once). Wipe the cache, then build.
+        entry: bash -c 'rm -rf web/node_modules/.tmp && cd web && npm run build'
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+        files: ^web/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(no changes since v0.12.0)
+### Added
+
+- **`make check`** — one local command that runs the same fast gates CI
+  runs (ruff, pytest, a clean web build, vitest). Heavy external-CLI
+  gates live under `make gates`.
+- **Pre-push clean web build.** The pre-push hook now wipes the `tsc -b`
+  cache and rebuilds the SPA, so a stale local cache can't pass while a
+  fresh-container CI build fails on a real type error.
+- **CHANGELOG nudge.** A `changelog` workflow fails a PR that changes
+  `wirestudio/` code without touching `CHANGELOG.md`; escape with
+  `[skip changelog]` in the PR title or the `skip-changelog` label.
+
+### Changed
+
+- **Version is single-sourced** from `wirestudio/__init__.py`;
+  `pyproject.toml` reads it dynamically. Bump it in one place.
 
 ## [0.12.0] — 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CHANGELOG nudge.** A `changelog` workflow fails a PR that changes
   `wirestudio/` code without touching `CHANGELOG.md`; escape with
   `[skip changelog]` in the PR title or the `skip-changelog` label.
+- **`dev` integration branch.** The PR gates and image build now run on
+  `dev` as well as `main`; `dev` merges publish a rolling `:dev` image.
+- **Side-by-side ArgoCD deploys.** `deploy/overlays/{prod,dev}` +
+  `deploy/argocd/` run a pinned-release prod app and a rolling dev app
+  from one tree; CI commits the new image sha to the dev overlay on each
+  `dev` merge. See `docs/deployment.md`.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# Developer entry points. `make check` runs the fast gates CI runs, so a
+# green check locally should mean a green PR. The heavy external-CLI gates
+# (esphome / kicad / openscad) live under `make gates`; CI runs those on
+# every PR regardless.
+
+PY  ?= python
+NPM ?= npm
+
+.PHONY: check lint test web web-test gates examples schematics enclosures coverage clean
+
+# Everyday pre-PR gate: lint + Python tests + a CLEAN web build + web tests.
+check: lint test web web-test
+	@echo "make check: OK"
+
+lint:
+	ruff check .
+
+test:
+	$(PY) -m pytest -q
+
+# Clean web build -- mirrors the Docker/CI build, which always starts from a
+# fresh container. `tsc -b` caches type results in web/node_modules/.tmp; a
+# stale cache once hid a real type error locally while CI stayed red, so we
+# wipe it before building.
+web:
+	rm -rf web/node_modules/.tmp
+	cd web && $(NPM) run build
+
+web-test:
+	cd web && $(NPM) run test
+
+# Heavy gates that shell out to external CLIs. Run before a release or when
+# touching examples/library; require esphome, kicad-symbols, and openscad.
+gates: examples schematics enclosures coverage
+
+examples:
+	$(PY) scripts/check_examples.py
+
+schematics:
+	$(PY) scripts/check_schematics.py
+
+enclosures:
+	$(PY) scripts/check_enclosures.py
+
+coverage:
+	$(PY) scripts/coverage_matrix.py --strict
+
+clean:
+	rm -rf web/node_modules/.tmp web/dist

--- a/deploy/argocd/wirestudio-dev.yaml
+++ b/deploy/argocd/wirestudio-dev.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: wirestudio-dev
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/moellere/WireStudio.git
+    targetRevision: dev             # integration branch
+    path: deploy/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: wirestudio-dev
+  syncPolicy:
+    # Rolls forward automatically: CI commits the new sha-<short> to
+    # deploy/overlays/dev on every dev merge, ArgoCD syncs it.
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/deploy/argocd/wirestudio-prod.yaml
+++ b/deploy/argocd/wirestudio-prod.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: wirestudio-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/moellere/WireStudio.git
+    targetRevision: main            # released code only
+    path: deploy/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: wirestudio-prod
+  syncPolicy:
+    # Automated, but the image tag in deploy/overlays/prod is a pinned
+    # release version, so prod only moves when you bump it in git on
+    # main. selfHeal reverts manual cluster edits; prune removes orphans.
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -69,7 +69,7 @@ spec:
         runAsGroup: 1000
       containers:
         - name: wirestudio
-          image: ghcr.io/moellere/wirestudio:v0.10.0
+          image: ghcr.io/moellere/wirestudio:v0.12.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Base layer = the plain manifest. `kubectl apply -f k8s.yaml` still works
+# standalone; the prod/dev overlays layer a namespace + image tag on top
+# of this so the two Argo apps can run side by side from one source tree.
+resources:
+  - k8s.yaml

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Dev/staging overlay. Rolling: the docker workflow's bump-dev job
+# rewrites newTag to the freshly built sha-<short> on every dev merge and
+# commits it here, so the dev Argo app auto-syncs to HEAD of dev. The
+# placeholder below is replaced on the first dev build.
+namespace: wirestudio-dev
+
+resources:
+  - ../../
+
+images:
+  - name: ghcr.io/moellere/wirestudio
+    newTag: sha-0000000

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Production overlay. Stable: the image is a pinned, immutable release
+# tag. To promote a release to prod, bump newTag below (in the same PR
+# that bumps wirestudio/__init__.py + CHANGELOG, or right after the tag
+# is cut) and let ArgoCD roll it out. One-line diff, one-commit rollback.
+namespace: wirestudio-prod
+
+resources:
+  - ../../
+
+images:
+  - name: ghcr.io/moellere/wirestudio
+    newTag: "0.12.0"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -23,8 +23,9 @@ Available tags:
 
 | Tag | What it tracks |
 |---|---|
-| `:v0.12.0` / `:0.12.0` / `:0.12` / `:latest` | the v0.12.0 release |
+| `:0.12.0` / `:0.12` / `:latest` | the v0.12.0 release |
 | `:main` | latest commit on `main` (rolling) |
+| `:dev` | latest commit on `dev` (rolling, pre-release) |
 | `:sha-<short>` | a specific commit |
 
 All feature-gating env vars are optional — the studio runs without any
@@ -48,6 +49,41 @@ is file-on-disk and not multi-writer safe.
 ```sh
 kubectl apply -f deploy/k8s.yaml
 ```
+
+## ArgoCD: side-by-side prod + dev
+
+Two Argo apps off one source tree, so a stable prod and a rolling dev
+run in their own namespaces:
+
+| App | Tracks | Image | Moves when |
+|---|---|---|---|
+| `wirestudio-prod` | branch `main`, path `deploy/overlays/prod` | pinned `:0.12.0` | you bump `newTag` in git |
+| `wirestudio-dev` | branch `dev`, path `deploy/overlays/dev` | rolling `:sha-<short>` | every `dev` merge (CI commits the bump) |
+
+```sh
+kubectl apply -f deploy/argocd/wirestudio-prod.yaml
+kubectl apply -f deploy/argocd/wirestudio-dev.yaml
+```
+
+How the image tag gets into git (no extra controller — pure GitOps):
+
+- **dev** rolls itself. On every push to `dev`, the `docker` workflow's
+  `bump-dev` job rewrites `deploy/overlays/dev/kustomization.yaml`'s
+  `newTag` to the just-built `sha-<short>` and commits it back to `dev`
+  (with `[skip ci]`). ArgoCD's automated sync deploys it.
+- **prod** is promoted by hand. On release, bump `newTag` in
+  `deploy/overlays/prod/kustomization.yaml` to the new version — do it in
+  the `dev → main` release PR alongside `wirestudio/__init__.py` and
+  `CHANGELOG.md`. ArgoCD rolls it out; rollback is a one-commit revert.
+
+Each overlay sets its own namespace, so the two apps get independent
+PVCs and never share `/data`.
+
+> Branch protection note: the `bump-dev` job pushes to `dev` as
+> `github-actions[bot]`. If you protect `dev`, add that bot to the
+> "allow to bypass" list (or keep `dev` protection to required status
+> checks on PRs only). Protect `main` strictly — PRs + green checks, no
+> direct pushes — since releases land there via PR.
 
 ## nginx-front compose recipe
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wirestudio"
-version = "0.12.0"
+# Single-sourced from wirestudio/__init__.py (see [tool.setuptools.dynamic]).
+# Bump __version__ there; the wheel + `python -m build` read it from the module.
+dynamic = ["version"]
 description = "Agent-driven IoT device design tool that produces ESPHome YAML."
 readme = "README.md"
 license = { text = "MIT" }
@@ -35,6 +37,9 @@ dev = [
 [project.scripts]
 wirestudio-generate = "wirestudio.generate.__main__:main"
 wirestudio-api = "wirestudio.api.__main__:main"
+
+[tool.setuptools.dynamic]
+version = { attr = "wirestudio.__version__" }
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

Sets up a production-style branching/release process and the local guardrails to support it. This is the **transitional PR**: it lands on `main` under the current model, after which `dev` is branched from `main` and future work targets `dev`.

**Dev-process guardrails**
- `make check` runs the fast CI gates locally (ruff, pytest, a **clean** web build, vitest); `make gates` runs the heavy esphome/kicad/openscad gates. The pre-push hook now wipes the `tsc -b` cache and rebuilds the SPA, so a stale local cache can't go green while a fresh-container CI build fails (the bug that bit us once).
- Version is **single-sourced** from `wirestudio/__init__.py`; `pyproject.toml` reads it dynamically via `[tool.setuptools.dynamic]`. Bump it in one place.
- A `changelog` workflow nudges: a PR changing `wirestudio/` without touching `CHANGELOG.md` fails, with `[skip changelog]` / `skip-changelog` escapes.

**`dev` integration branch**
- The PR gates (`esphome-config`, `kicad-schematic`, `enclosure-render`, `changelog`) and the image build now run on `dev` as well as `main`. `esphome-compile` / `esphome-matrix` stay cron/dispatch-only.
- `docker.yml` publishes a rolling `:dev` image on `dev` merges; `main` and release tags keep producing `:main` / `:1.2.3` / `:latest`.

**ArgoCD: side-by-side prod + dev**
- `deploy/overlays/{prod,dev}` (Kustomize) layer namespace + image tag on the existing base manifest; `deploy/argocd/wirestudio-{prod,dev}.yaml` are the two Applications.
- **prod**: pinned `:0.12.0`, bumped by hand in git on release (one-commit rollback).
- **dev**: rolling — the new `bump-dev` job commits the freshly built `sha-<short>` to the dev overlay on each `dev` merge, so ArgoCD auto-syncs. No extra controller.
- Separate namespaces ⇒ independent PVCs; dev can't touch prod's `/data`. Documented in `docs/deployment.md`.

## After merge
1. Branch `dev` from `main`.
2. Set branch protection (see the PR discussion / `docs/deployment.md` note).
3. `kubectl apply -f deploy/argocd/wirestudio-{prod,dev}.yaml`.
4. Henceforth: features → PR to `dev`; release = `dev → main` PR (roll `[Unreleased]` into a version, bump `__init__.py` + `deploy/overlays/prod`) + tag `vX.Y.Z`.

## Test plan
- [x] `make check`-equivalent locally: 502 passed / 1 skipped; ruff clean; clean web build OK
- [x] dynamic version resolves to `0.12.0`
- [x] all workflow + deploy YAML parses
- [ ] CI green on this PR (esphome-config, kicad-schematic, enclosure-render, build)

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_