### PR TITLE
feat(kicad): emit .kicad_pcb from a design (PCB layout, step 2)

### DIFF
--- a/.github/workflows/pcb-layout.yml
+++ b/.github/workflows/pcb-layout.yml
@@ -1,0 +1,78 @@
+name: pcb-layout
+
+# The board-emit gate. Companion to kicad-schematic.yml (symbols/netlist) and
+# kicad-footprint.yml (footprint existence): this proves every example emits a
+# structurally sound .kicad_pcb -- footprints embed, parens balance, and every
+# net a pad references is declared. It's the fast, KiCad-binary-free bar that
+# blocks a PR; the real open-and-DRC check belongs to a follow-up DRC tier that
+# installs KiCad and runs `kicad-cli pcb drc`.
+#
+# The emitter embeds real footprint geometry and resolves pad numbers via the
+# symbol libraries, so this needs BOTH kicad-footprints and kicad-symbols,
+# pinned to the same tags the other two gates use and bumped deliberately.
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+  schedule:
+    - cron: '0 10 * * 1'   # 10:00 UTC every Monday
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pcb-layout-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  KICAD_FOOTPRINTS_REF: "8.0.0"
+  KICAD_SYMBOLS_REF: "8.0.0"
+
+jobs:
+  pcb-layout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install studio
+        run: pip install -e .
+
+      - name: Cache KiCad footprint libraries
+        id: cache-footprints
+        uses: actions/cache@v4
+        with:
+          path: kicad-footprints
+          key: kicad-footprints-${{ env.KICAD_FOOTPRINTS_REF }}
+
+      - name: Fetch KiCad footprint libraries
+        if: steps.cache-footprints.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch "$KICAD_FOOTPRINTS_REF" \
+            https://gitlab.com/kicad/libraries/kicad-footprints.git kicad-footprints
+
+      - name: Cache KiCad symbol libraries
+        id: cache-symbols
+        uses: actions/cache@v4
+        with:
+          path: kicad-symbols
+          key: kicad-symbols-${{ env.KICAD_SYMBOLS_REF }}
+
+      - name: Fetch KiCad symbol libraries
+        if: steps.cache-symbols.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch "$KICAD_SYMBOLS_REF" \
+            https://gitlab.com/kicad/libraries/kicad-symbols.git kicad-symbols
+
+      - name: Verify every example emits a sound .kicad_pcb
+        env:
+          KICAD8_FOOTPRINT_DIR: ${{ github.workspace }}/kicad-footprints
+          KICAD8_SYMBOL_DIR: ${{ github.workspace }}/kicad-symbols
+        run: python scripts/check_pcb.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`wirestudio/kicad/netlist.py`). Feature-gated like the schematic render —
   needs the footprint + symbol libraries on the server (`GET
   /design/kicad/pcb/status`); a new `pcb-layout` CI gate proves every bundled
-  example emits a sound board. Freerouting autoroute and Gerber/CPL/BOM export
-  remain on the path to 1.0.
+  example emits a sound board. The KiCad export dialog gains a **Download
+  .kicad_pcb** button (gated on the server having the libraries). Freerouting
+  autoroute and Gerber/CPL/BOM export remain on the path to 1.0.
 - **Blank-board LoRaWAN flash.** The compile worker now also emits a merged
   factory image (bootloader + partitions + app via esptool `merge_bin` at the
   per-chip bootloader offset), served at `GET /lorawan/firmware/{key}/factory`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **KiCad PCB export (`.kicad_pcb`).** A new `POST /design/kicad/pcb` emits a
+  KiCad 8 board: every component + board footprint embedded from the pinned
+  KiCad libraries and grid-placed, each pad bound to the net it shares in the
+  design, plus an `Edge.Cuts` outline — no routing, so it opens in KiCad's PCB
+  editor with a complete ratsnest ready to route (PCB layout, step 2; the
+  footprint gate in 0.13.0 was step 1). Pad numbers resolve through the
+  component's `kicad.pin_map` and symbol; generic connectors bind positionally.
+  Reference designators and net names are shared with the schematic
+  (`wirestudio/kicad/netlist.py`). Feature-gated like the schematic render —
+  needs the footprint + symbol libraries on the server (`GET
+  /design/kicad/pcb/status`); a new `pcb-layout` CI gate proves every bundled
+  example emits a sound board. Freerouting autoroute and Gerber/CPL/BOM export
+  remain on the path to 1.0.
 - **Blank-board LoRaWAN flash.** The compile worker now also emits a merged
   factory image (bootloader + partitions + app via esptool `merge_bin` at the
   per-chip bootloader offset), served at `GET /lorawan/firmware/{key}/factory`.

--- a/scripts/check_pcb.py
+++ b/scripts/check_pcb.py
@@ -1,0 +1,91 @@
+"""Verify every bundled example emits a structurally sound .kicad_pcb.
+
+The fourth EDA gate, alongside check_schematics.py (symbols/netlist),
+check_footprints.py (footprint existence), and check_examples.py (ESPHome
+YAML). It generates each examples/*.json board against the pinned KiCad
+footprint + symbol libraries and asserts structure that KiCad would reject if
+wrong: the file parens-balance, at least one footprint embeds, and every net a
+pad references is declared at board level.
+
+This is the fast, KiCad-binary-free bar (the companion DRC tier in
+pcb-layout.yml installs KiCad and runs `kicad-cli pcb drc` for the real
+open-and-DRC check). It needs checkouts of kicad-footprints + kicad-symbols;
+point KICAD8_FOOTPRINT_DIR + KICAD8_SYMBOL_DIR at them (CI clones both at a
+pinned tag).
+
+Run locally:
+    git clone --depth 1 --branch 8.0.0 https://gitlab.com/kicad/libraries/kicad-footprints.git
+    git clone --depth 1 --branch 8.0.0 https://gitlab.com/kicad/libraries/kicad-symbols.git
+    export KICAD8_FOOTPRINT_DIR=$PWD/kicad-footprints
+    export KICAD8_SYMBOL_DIR=$PWD/kicad-symbols
+    python scripts/check_pcb.py
+
+Exit 0 = every example emits a sound board, 1 = at least one failed, 2 =
+libraries not found.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+from wirestudio.kicad.pcb import generate_kicad_pcb, pcb_status
+from wirestudio.library import default_library
+from wirestudio.model import Design
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "wirestudio" / "examples"
+
+
+def _check(pcb: str) -> list[str]:
+    """Return a list of structural problems with an emitted board (empty = ok)."""
+    problems: list[str] = []
+    if not pcb.startswith("(kicad_pcb"):
+        problems.append("does not start with (kicad_pcb")
+    if pcb.count("(") != pcb.count(")"):
+        problems.append(f"unbalanced parens ({pcb.count('(')} vs {pcb.count(')')})")
+    if not re.search(r'\(footprint "', pcb):
+        problems.append("no footprints embedded")
+    declared = {int(i) for i in re.findall(r'^\t\(net (\d+) "', pcb, re.M)}
+    referenced = {int(i) for i in re.findall(r'^\t\t\t?\(net (\d+) "', pcb, re.M)}
+    if not referenced <= declared:
+        problems.append(f"pads reference undeclared nets: {sorted(referenced - declared)}")
+    return problems
+
+
+def main() -> int:
+    status = pcb_status()
+    if not status["available"]:
+        print(f"error: {status['reason']}", file=sys.stderr)
+        return 2
+
+    lib = default_library()
+    failures: dict[str, list[str]] = {}
+    ok = 0
+    for path in sorted(EXAMPLES_DIR.glob("*.json")):
+        design = Design.model_validate(json.loads(path.read_text()))
+        try:
+            pcb = generate_kicad_pcb(design, lib)
+        except Exception as exc:  # noqa: BLE001 -- surface any emit failure per example
+            failures[path.stem] = [f"emit raised {type(exc).__name__}: {exc}"]
+            continue
+        problems = _check(pcb)
+        if problems:
+            failures[path.stem] = problems
+        else:
+            ok += 1
+
+    if failures:
+        print(f"{len(failures)} example(s) produced an unsound .kicad_pcb:", file=sys.stderr)
+        for name, problems in failures.items():
+            for p in problems:
+                print(f"  {name}: {p}", file=sys.stderr)
+        return 1
+
+    print(f"all {ok} examples emit a structurally sound .kicad_pcb.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kicad_pcb.py
+++ b/tests/test_kicad_pcb.py
@@ -1,0 +1,129 @@
+"""Tests for the shared netlist primitives and the .kicad_pcb emitter.
+
+`build_netlist` is pure, so its tests always run. The `generate_kicad_pcb`
+tests embed real footprint geometry, so they need the pinned KiCad libraries
+and skip when `KICAD8_FOOTPRINT_DIR` / `KICAD8_SYMBOL_DIR` aren't set. CI sets
+them (clones kicad-footprints@8.0.0 + kicad-symbols@8.0.0); locally, clone the
+two repos and point the env vars at them.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from wirestudio.kicad.netlist import assign_refs, build_netlist
+from wirestudio.kicad.pcb import generate_kicad_pcb, pcb_status
+from wirestudio.library import default_library
+from wirestudio.model import Design
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "wirestudio" / "examples"
+
+libs_required = pytest.mark.skipif(
+    not pcb_status()["available"],
+    reason="KiCad footprint/symbol libs not configured (KICAD8_FOOTPRINT_DIR / KICAD8_SYMBOL_DIR)",
+)
+
+
+@pytest.fixture
+def lib():
+    return default_library()
+
+
+def _design(name: str) -> Design:
+    return Design.model_validate(json.loads((EXAMPLES_DIR / f"{name}.json").read_text()))
+
+
+# ---------------------------------------------------------------------------
+# build_netlist -- pure, always runs
+# ---------------------------------------------------------------------------
+
+def test_build_netlist_groups_rails_and_buses(lib):
+    nets = {n.name: n for n in build_netlist(_design("garage-motion"), lib)}
+    assert {"GND", "+5V", "+3V3", "BUS_i2c0"} <= set(nets)
+    # The BME280's SDA + SCL both land on the single I2C bus net.
+    roles = {(p.component_id, p.pin_role) for p in nets["BUS_i2c0"].pads}
+    assert ("bme1", "SDA") in roles and ("bme1", "SCL") in roles
+
+
+def test_build_netlist_refs_agree_with_assign_refs(lib):
+    """Every pad's ref is exactly what assign_refs hands out -- the property
+    that keeps the schematic and PCB ref designators in lockstep."""
+    d = _design("garage-motion")
+    refs = assign_refs(d, lib)
+    for net in build_netlist(d, lib):
+        for pad in net.pads:
+            assert pad.ref == refs[pad.component_id]
+
+
+def test_build_netlist_is_sorted_and_stable(lib):
+    nets = build_netlist(_design("garage-motion"), lib)
+    names = [n.name for n in nets]
+    assert names == sorted(names)
+
+
+def test_build_netlist_skips_connection_to_absent_component(lib):
+    d = _design("garage-motion")
+    # Point a connection at a component id that isn't in the design.
+    d.connections[0].component_id = "ghost"
+    names = {(p.component_id) for net in build_netlist(d, lib) for p in net.pads}
+    assert "ghost" not in names
+
+
+# ---------------------------------------------------------------------------
+# generate_kicad_pcb -- needs the pinned KiCad libraries
+# ---------------------------------------------------------------------------
+
+@libs_required
+def test_pcb_starts_correctly_and_is_paren_balanced(lib):
+    pcb = generate_kicad_pcb(_design("garage-motion"), lib)
+    assert pcb.startswith("(kicad_pcb")
+    assert pcb.count("(") == pcb.count(")")
+    assert '(layer "Edge.Cuts")' in pcb and "gr_rect" in pcb
+
+
+@libs_required
+def test_pcb_embeds_board_and_component_footprints(lib):
+    pcb = generate_kicad_pcb(_design("garage-motion"), lib)
+    fps = re.findall(r'\(footprint "([^"]+)"', pcb)
+    assert "RF_Module:ESP32-WROOM-32" in fps  # the board, M1
+    assert "Package_LGA:Bosch_LGA-8_2.5x2.5mm_P0.65mm_ClockwisePinNumbering" in fps
+
+
+@libs_required
+def test_pcb_binds_pin_mapped_pad_to_net(lib):
+    """The BME280's VCC role -> VDD pin -> a real footprint pad, carrying the
+    +3V3 net; SDA/SCL land on the I2C bus net. Exercises symbol pin-name ->
+    number -> pad resolution end to end."""
+    pcb = generate_kicad_pcb(_design("garage-motion"), lib)
+    assert re.search(r'\(net \d+ "\+3V3"\)', pcb)
+    assert re.search(r'\(net \d+ "BUS_i2c0"\)', pcb)
+
+
+@libs_required
+def test_pcb_pad_net_indices_are_all_declared(lib):
+    """Every net index a pad references must be declared at board level, or
+    KiCad rejects the file."""
+    pcb = generate_kicad_pcb(_design("garage-motion"), lib)
+    declared = {int(i) for i, _ in re.findall(r'^\t\(net (\d+) "([^"]*)"\)', pcb, re.M)}
+    referenced = {int(i) for i in re.findall(r'^\t\t\t?\(net (\d+) "', pcb, re.M)}
+    assert referenced <= declared
+
+
+@libs_required
+def test_pcb_generic_connector_binds_positionally(lib):
+    """The HC-SR501 PIR maps to a generic header; its OUT role (3rd pin) must
+    bind to pad "3" carrying the GPIO net."""
+    pcb = generate_kicad_pcb(_design("garage-motion"), lib)
+    assert re.search(r'\(net \d+ "GPIO_GPIO13"\)', pcb)
+
+
+@libs_required
+def test_pcb_every_radio_and_sensor_example_emits(lib):
+    for name in ("garage-motion", "oled", "distance-sensor", "ttgo-lora32", "bluemotion"):
+        pcb = generate_kicad_pcb(_design(name), lib)
+        assert pcb.count("(") == pcb.count(")"), name
+        assert pcb.startswith("(kicad_pcb"), name

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -14,6 +14,7 @@ import type {
   FleetStatus,
   InventoryEntry,
   InventoryCheckResponse,
+  KicadPcbStatus,
   KicadRenderStatus,
   LorawanCompileEvent,
   LorawanCompileStatus,
@@ -146,6 +147,10 @@ export const api = {
     request<KicadRenderStatus>("/design/kicad/render/status"),
   kicadRender: (design: Design) =>
     requestText("/design/kicad/render", { method: "POST", body: JSON.stringify(design) }),
+  kicadPcbStatus: () =>
+    request<KicadPcbStatus>("/design/kicad/pcb/status"),
+  kicadPcb: (design: Design) =>
+    requestText("/design/kicad/pcb", { method: "POST", body: JSON.stringify(design) }),
   enclosureSearchStatus: () =>
     request<EnclosureSearchStatus>("/enclosure/search/status"),
   enclosureSearch: (params: { library_id: string; query?: string; limit?: number }) => {

--- a/web/src/components/SchematicDialog.test.tsx
+++ b/web/src/components/SchematicDialog.test.tsx
@@ -9,7 +9,7 @@ import userEvent from "@testing-library/user-event";
 
 import { SchematicDialog } from "./SchematicDialog";
 import { api } from "../api/client";
-import type { Design, KicadRenderStatus } from "../types/api";
+import type { Design, KicadPcbStatus, KicadRenderStatus } from "../types/api";
 
 vi.mock("../api/client", async () => {
   const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
@@ -20,6 +20,8 @@ vi.mock("../api/client", async () => {
       kicadSchematic: vi.fn(),
       kicadRenderStatus: vi.fn(),
       kicadRender: vi.fn(),
+      kicadPcbStatus: vi.fn(),
+      kicadPcb: vi.fn(),
     },
   };
 });
@@ -28,6 +30,8 @@ const mockApi = api as unknown as {
   kicadSchematic: ReturnType<typeof vi.fn>;
   kicadRenderStatus: ReturnType<typeof vi.fn>;
   kicadRender: ReturnType<typeof vi.fn>;
+  kicadPcbStatus: ReturnType<typeof vi.fn>;
+  kicadPcb: ReturnType<typeof vi.fn>;
 };
 
 const UNAVAILABLE: KicadRenderStatus = {
@@ -36,6 +40,13 @@ const UNAVAILABLE: KicadRenderStatus = {
 };
 const AVAILABLE: KicadRenderStatus = {
   available: true, kicad_cli: true, skidl: true, png: true, reason: null,
+};
+const PCB_UNAVAILABLE: KicadPcbStatus = {
+  available: false, footprints: false, symbols: false,
+  reason: "footprint libraries not found",
+};
+const PCB_AVAILABLE: KicadPcbStatus = {
+  available: true, footprints: true, symbols: true, reason: null,
 };
 
 const design: Design = {
@@ -54,7 +65,10 @@ beforeEach(() => {
   mockApi.kicadSchematic.mockReset();
   mockApi.kicadRenderStatus.mockReset();
   mockApi.kicadRender.mockReset();
+  mockApi.kicadPcbStatus.mockReset();
+  mockApi.kicadPcb.mockReset();
   mockApi.kicadRenderStatus.mockResolvedValue(UNAVAILABLE);
+  mockApi.kicadPcbStatus.mockResolvedValue(PCB_UNAVAILABLE);
   (URL as unknown as { createObjectURL: () => string }).createObjectURL = vi.fn(() => "blob:fake");
   (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = vi.fn();
 });
@@ -142,5 +156,23 @@ describe("SchematicDialog — inline preview", () => {
     const btn = await screen.findByRole("button", { name: /Render schematic/ });
     await userEvent.click(btn);
     await waitFor(() => screen.getByText(/kicad-cli failed: bad symbol/));
+  });
+});
+
+describe("SchematicDialog — PCB board", () => {
+  it("shows a notice when the libraries are unavailable", async () => {
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    await waitFor(() => screen.getByText(/board export needs the KiCad footprint/));
+    expect(screen.queryByRole("button", { name: /Download \.kicad_pcb/ })).toBeNull();
+  });
+
+  it("downloads a .kicad_pcb when the libraries are available", async () => {
+    mockApi.kicadPcbStatus.mockResolvedValue(PCB_AVAILABLE);
+    mockApi.kicadPcb.mockResolvedValue("(kicad_pcb)\n");
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    const btn = await screen.findByRole("button", { name: /Download \.kicad_pcb/ });
+    await userEvent.click(btn);
+    await waitFor(() => expect(mockApi.kicadPcb).toHaveBeenCalledWith(design));
+    await waitFor(() => screen.getByText(/Downloaded ✓/));
   });
 });

--- a/web/src/components/SchematicDialog.tsx
+++ b/web/src/components/SchematicDialog.tsx
@@ -9,7 +9,7 @@
  */
 import { useEffect, useState } from "react";
 import { api, ApiError } from "../api/client";
-import type { Design, KicadRenderStatus } from "../types/api";
+import type { Design, KicadPcbStatus, KicadRenderStatus } from "../types/api";
 
 interface Props {
   design: Design;
@@ -34,6 +34,11 @@ export function SchematicDialog({ design, onClose }: Props) {
   const [svgUrl, setSvgUrl] = useState<string | null>(null);
   const [renderError, setRenderError] = useState<string | null>(null);
 
+  const [pcbStatus, setPcbStatus] = useState<KicadPcbStatus | null>(null);
+  const [pcbDownloading, setPcbDownloading] = useState(false);
+  const [pcbDownloaded, setPcbDownloaded] = useState(false);
+  const [pcbError, setPcbError] = useState<string | null>(null);
+
   useEffect(() => {
     let live = true;
     api
@@ -42,6 +47,13 @@ export function SchematicDialog({ design, onClose }: Props) {
       .catch(() => live && setRenderStatus({
         available: false, kicad_cli: false, skidl: false, png: false,
         reason: "render status unavailable",
+      }));
+    api
+      .kicadPcbStatus()
+      .then((s) => live && setPcbStatus(s))
+      .catch(() => live && setPcbStatus({
+        available: false, footprints: false, symbols: false,
+        reason: "pcb status unavailable",
       }));
     return () => {
       live = false;
@@ -92,6 +104,28 @@ export function SchematicDialog({ design, onClose }: Props) {
     }
   }
 
+  async function handleDownloadPcb() {
+    setPcbDownloading(true);
+    setPcbDownloaded(false);
+    setPcbError(null);
+    try {
+      const board = await api.kicadPcb(design);
+      const url = URL.createObjectURL(new Blob([board], { type: "application/octet-stream" }));
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${design.id ?? "design"}.kicad_pcb`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setPcbDownloaded(true);
+    } catch (e) {
+      setPcbError(formatError(e));
+    } finally {
+      setPcbDownloading(false);
+    }
+  }
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
@@ -103,9 +137,9 @@ export function SchematicDialog({ design, onClose }: Props) {
       >
         <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
           <div>
-            <div className="text-sm font-semibold text-zinc-100">KiCad schematic</div>
+            <div className="text-sm font-semibold text-zinc-100">KiCad export</div>
             <div className="text-xs text-zinc-500">
-              Preview the schematic, or download a SKiDL script to run locally.
+              Preview the schematic, download a SKiDL script, or export a PCB board.
             </div>
           </div>
           <button
@@ -204,11 +238,47 @@ python ${design.id ?? "design"}.skidl.py
                 {error}
               </div>
             )}
-            <p className="text-[11px] text-zinc-500">
-              PCB layout (Freerouting + Gerber export) is on the 1.0+
-              roadmap; for now the netlist + schematic are sufficient to
-              open in KiCad and start a layout by hand.
+          </section>
+
+          {/* --- PCB board (.kicad_pcb) -------------------------------- */}
+          <section className="space-y-2 border-t border-zinc-800 pt-3">
+            <div className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
+              PCB board
+            </div>
+            <p className="text-xs leading-relaxed text-zinc-400">
+              A <code className="text-zinc-200">.kicad_pcb</code> with every
+              part placed on a grid and pads wired to nets — open it in KiCad's
+              PCB editor with a full ratsnest and route it. Autorouting and
+              Gerber/JLCPCB export are on the 1.0 roadmap.
             </p>
+            {pcbStatus === null ? (
+              <div className="text-xs text-zinc-500">Checking…</div>
+            ) : pcbStatus.available ? (
+              <button
+                onClick={handleDownloadPcb}
+                disabled={pcbDownloading}
+                className="rounded-md bg-blue-500/20 px-3 py-1.5 text-sm text-blue-100 ring-1 ring-blue-400/40 enabled:hover:bg-blue-500/30 disabled:opacity-40"
+              >
+                {pcbDownloading
+                  ? "Generating…"
+                  : pcbDownloaded
+                    ? "Downloaded ✓ — generate again"
+                    : "Download .kicad_pcb →"}
+              </button>
+            ) : (
+              <div className="rounded-md border border-zinc-800 bg-zinc-900/40 px-2 py-1.5 text-xs text-zinc-400">
+                The board export needs the KiCad footprint + symbol libraries
+                on the server.
+                {pcbStatus.reason && (
+                  <span className="text-zinc-500"> ({pcbStatus.reason})</span>
+                )}
+              </div>
+            )}
+            {pcbError && (
+              <div className="rounded-md border border-rose-700/40 bg-rose-900/15 px-2 py-1.5 text-xs text-rose-200">
+                {pcbError}
+              </div>
+            )}
           </section>
         </div>
       </div>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -282,6 +282,13 @@ export interface KicadRenderStatus {
   reason: string | null;
 }
 
+export interface KicadPcbStatus {
+  available: boolean;
+  footprints: boolean;
+  symbols: boolean;
+  reason: string | null;
+}
+
 export interface EnclosureHit {
   source: string;
   id: string;

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -83,6 +83,7 @@ from wirestudio.enclosure import (
     search_enclosures,
 )
 from wirestudio.kicad import generate_skidl
+from wirestudio.kicad.pcb import PcbUnavailable, generate_kicad_pcb, pcb_status
 from wirestudio.kicad.render import (
     RenderError,
     RenderUnavailable,
@@ -550,6 +551,34 @@ def create_app(
             raise HTTPException(status_code=500, detail=str(e)) from e
         media = "image/svg+xml" if format == "svg" else "image/png"
         return Response(content=data, media_type=media)
+
+    @app.get("/design/kicad/pcb/status", tags=["design"])
+    def design_kicad_pcb_status() -> dict:
+        """Probe whether the .kicad_pcb export is available. Unlike the SKiDL
+        script (always emittable), the board embeds real footprint geometry,
+        so it needs the pinned KiCad footprint + symbol libraries on the
+        server. The web UI gates the download on `available`."""
+        return pcb_status()
+
+    @app.post("/design/kicad/pcb", tags=["design"])
+    def design_kicad_pcb(design: dict) -> PlainTextResponse:
+        """Emit a `<design_id>.kicad_pcb`: footprints embedded + grid-placed,
+        pads bound to nets, an Edge.Cuts outline, no routing. Open it in
+        KiCad's PCB editor and route (or autoroute). Returns 503 when the
+        footprint/symbol libraries aren't installed -- check
+        `/design/kicad/pcb/status` first."""
+        d = _validate_design(design)
+        try:
+            board = generate_kicad_pcb(d, lib)
+        except PcbUnavailable as e:
+            raise HTTPException(status_code=503, detail=str(e)) from e
+        except (FileNotFoundError, ValueError) as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        filename = f"{d.id}.kicad_pcb"
+        return PlainTextResponse(
+            content=board,
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
 
     @app.get("/design/jlcpcb/status", tags=["design"])
     def design_jlcpcb_status() -> dict:

--- a/wirestudio/kicad/generator.py
+++ b/wirestudio/kicad/generator.py
@@ -24,8 +24,7 @@ mappings (symbol, footprint, pin_map applied) appear verbatim.
 """
 from __future__ import annotations
 
-import re
-
+from wirestudio.kicad.netlist import BOARD_KEY, _py_var, assign_refs, net_name
 from wirestudio.library import KicadSymbolRef, Library
 from wirestudio.model import Design
 
@@ -33,17 +32,6 @@ from wirestudio.model import Design
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_PY_IDENT_RE = re.compile(r"[^A-Za-z0-9_]")
-
-
-def _py_var(name: str) -> str:
-    """Coerce an arbitrary id into a safe Python identifier prefixed
-    with `c_` (component) or `n_` (net) by the caller."""
-    out = _PY_IDENT_RE.sub("_", name)
-    if out and out[0].isdigit():
-        out = "_" + out
-    return out
 
 
 def _quote(s: str) -> str:
@@ -104,59 +92,6 @@ def _resolve_pin_role(role: str, lib_comp) -> str:
     if role in kicad.pin_map:
         return kicad.pin_map[role]
     return role
-
-
-# ---------------------------------------------------------------------------
-# Reference-designator allocator
-# ---------------------------------------------------------------------------
-
-def _ref_for(category: str, counter: dict[str, int]) -> str:
-    prefix = {
-        "sensor": "U",
-        "binary_sensor": "U",
-        "io_expander": "U",
-        "display": "U",
-        "audio": "U",
-        "led": "D",
-        "amp": "U",
-    }.get(category, "U")
-    counter[prefix] = counter.get(prefix, 0) + 1
-    return f"{prefix}{counter[prefix]}"
-
-
-# ---------------------------------------------------------------------------
-# Net derivation
-# ---------------------------------------------------------------------------
-
-def _net_label_for_target(t: dict, design: Design, used_buses: dict[str, str]) -> str:
-    """Map a connection target to a SKiDL net handle.
-
-    rails -> +5V / +3V3 / GND (canonicalised),
-    bus -> the bus's id (sda/scl/clk/etc. resolved per role at the call site),
-    expander_pin -> a hub-relative net like `mcp_hub_GP3`,
-    component -> the parent component's ref-relative HUB net,
-    gpio -> a per-pin net like `GPIO13` or `D5`.
-    """
-    kind = t.get("kind")
-    if kind == "rail":
-        rail = t.get("rail", "")
-        if rail.lower() in ("gnd", "ground"):
-            return "GND"
-        return f"+{rail}".replace("V3", "V3").replace(" ", "")
-    if kind == "gpio":
-        pin = t.get("pin") or "UNBOUND"
-        return f"NET_{pin}"
-    if kind == "bus":
-        bus_id = t.get("bus_id") or "UNBOUND"
-        return f"BUS_{bus_id}"
-    if kind == "expander_pin":
-        ex = t.get("expander_id") or "EX"
-        n = t.get("number")
-        return f"{ex}_GP{n}"
-    if kind == "component":
-        cid = t.get("component_id") or "PARENT"
-        return f"{cid}_REF"
-    return "UNCONNECTED"
 
 
 # ---------------------------------------------------------------------------
@@ -243,7 +178,7 @@ def _render_components(
     text plus a {component_id: skidl_var_name} index for connection
     rendering. Also adds the board itself as a Part (the dev module
     sits at the top of the schematic just like a real design)."""
-    counter: dict[str, int] = {}
+    refs = assign_refs(design, library)
     lines: list[str] = []
     ref_index: dict[str, str] = {}
 
@@ -254,13 +189,13 @@ def _render_components(
         board = None
     if board is not None:
         var = "board"
-        ref = "M1"
+        ref = refs[BOARD_KEY]
         if board.kicad is not None:
             lines.append(_emit_part(var, ref, board.kicad,
                                      comment=f"Board: {board.name}"))
         else:
             lines.append(_emit_placeholder(var, ref, board.id))
-        ref_index["__board__"] = var
+        ref_index[BOARD_KEY] = var
 
     # Components.
     for c in design.components:
@@ -269,11 +204,10 @@ def _render_components(
             lib_comp = library.component(c.library_id)
         except FileNotFoundError:
             lib_comp = None
+        ref = refs[c.id]
         if lib_comp is None or lib_comp.kicad is None:
-            ref = _ref_for("sensor", counter)
             lines.append(_emit_placeholder(var, ref, c.library_id))
         else:
-            ref = _ref_for(lib_comp.category, counter)
             lines.append(_emit_part(var, ref, lib_comp.kicad,
                                      comment=f"{c.id} ({lib_comp.name})"))
         ref_index[c.id] = var
@@ -318,10 +252,10 @@ def _render_connections(
 
 def _net_handle_for(target, design: Design, ref_index: dict[str, str]) -> str:
     """Return a SKiDL expression that evaluates to the net for `target`.
-    For rails we reference the per-script Net handle (NET_PLUS_*, GND);
-    for buses we reference NET_BUS_<id>; for gpio/expander_pin we build
-    an inline Net(...) so each unique landing gets a fresh handle.
-    For component (hub) targets we use the hub's ref var."""
+    Rails and buses reference the per-script Net handle declared once
+    (`NET_PLUS_*` / `GND` / `NET_BUS_<id>`); gpio/expander_pin/component
+    targets build a fresh inline `Net(...)` named canonically (`net_name`)
+    so the schematic and the PCB land them on identically-named nets."""
     kind = target.kind
     if kind == "rail":
         if target.rail.lower() in ("gnd", "ground"):
@@ -329,17 +263,7 @@ def _net_handle_for(target, design: Design, ref_index: dict[str, str]) -> str:
         return f"NET_PLUS_{_py_var(target.rail)}"
     if kind == "bus":
         return f"NET_BUS_{_py_var(target.bus_id)}"
-    if kind == "gpio":
-        pin = target.pin or "UNBOUND"
-        return f'Net("GPIO_{_py_var(pin)}")'
-    if kind == "expander_pin":
-        ex = target.expander_id or "EX"
-        n = target.number
-        return f'Net("{ex}_GP{n}")'
-    if kind == "component":
-        cid = target.component_id or "PARENT"
-        return f'Net("{cid}_HUB")'
-    return 'Net("UNCONNECTED")'
+    return f'Net("{net_name(target)}")'
 
 
 # Re-export helpers used by tests.

--- a/wirestudio/kicad/netlist.py
+++ b/wirestudio/kicad/netlist.py
@@ -1,0 +1,92 @@
+"""Shared schematic/PCB netlist primitives: reference-designator assignment
+and canonical net names.
+
+Both the SKiDL schematic emitter (``wirestudio.kicad.generator``) and the
+``.kicad_pcb`` emitter (``wirestudio.kicad.pcb``) build on these so the two
+artifacts agree on reference designators (U1, D1, M1) and on net names for the
+same design. Pure: no I/O, no library mutation.
+"""
+from __future__ import annotations
+
+import re
+
+from wirestudio.model import Design
+
+_PY_IDENT_RE = re.compile(r"[^A-Za-z0-9_]")
+
+# The dev board sits at the top of the schematic/board as M1; this key stands
+# in for it in a ref map (component ids never collide with it).
+BOARD_REF = "M1"
+BOARD_KEY = "__board__"
+
+# Reference-designator prefix per component category. Anything unlisted (and
+# any component without a `kicad:` block) falls back to "U".
+_REF_PREFIX = {
+    "sensor": "U",
+    "binary_sensor": "U",
+    "io_expander": "U",
+    "display": "U",
+    "audio": "U",
+    "led": "D",
+    "amp": "U",
+}
+
+
+def _py_var(name: str) -> str:
+    """Coerce an arbitrary id into a safe Python identifier; callers prefix
+    it with ``c_`` (component) or ``n_`` (net)."""
+    out = _PY_IDENT_RE.sub("_", name)
+    if out and out[0].isdigit():
+        out = "_" + out
+    return out
+
+
+def _category_for(c, library) -> str:
+    """The category that drives a component's ref prefix. A component with no
+    library entry or no ``kicad:`` block is treated as a generic ``sensor``
+    (prefix U) -- the same fallback the schematic placeholder uses."""
+    try:
+        lib_comp = library.component(c.library_id)
+    except FileNotFoundError:
+        return "sensor"
+    if lib_comp.kicad is None:
+        return "sensor"
+    return lib_comp.category
+
+
+def assign_refs(design: Design, library) -> dict[str, str]:
+    """Map each component id -> KiCad reference designator, plus ``BOARD_KEY``
+    -> ``BOARD_REF``. Allocation order matches the schematic exactly: board
+    first, then components in design order, with a per-prefix counter."""
+    refs: dict[str, str] = {BOARD_KEY: BOARD_REF}
+    counter: dict[str, int] = {}
+    for c in design.components:
+        prefix = _REF_PREFIX.get(_category_for(c, library), "U")
+        counter[prefix] = counter.get(prefix, 0) + 1
+        refs[c.id] = f"{prefix}{counter[prefix]}"
+    return refs
+
+
+def net_name(target) -> str:
+    """Canonical net name for a connection target. Used verbatim in the PCB's
+    ``(net ...)`` declarations and pad bindings, and as the inline SKiDL net
+    name for gpio/expander/component targets, so both artifacts share names.
+
+    rails -> ``GND`` / ``+5V`` / ``+3V3``; bus -> ``BUS_<id>``;
+    gpio -> ``GPIO_<pin>``; expander_pin -> ``<expander>_GP<n>``;
+    component (hub) -> ``<component>_HUB``.
+    """
+    kind = target.kind
+    if kind == "rail":
+        if target.rail.lower() in ("gnd", "ground"):
+            return "GND"
+        return f"+{target.rail}"
+    if kind == "bus":
+        return f"BUS_{target.bus_id or 'UNBOUND'}"
+    if kind == "gpio":
+        return f"GPIO_{_py_var(target.pin or 'UNBOUND')}"
+    if kind == "expander_pin":
+        return f"{target.expander_id or 'EX'}_GP{target.number}"
+    if kind == "component":
+        return f"{target.component_id or 'PARENT'}_HUB"
+    return "UNCONNECTED"

--- a/wirestudio/kicad/netlist.py
+++ b/wirestudio/kicad/netlist.py
@@ -9,6 +9,7 @@ same design. Pure: no I/O, no library mutation.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 
 from wirestudio.model import Design
 
@@ -90,3 +91,40 @@ def net_name(target) -> str:
     if kind == "component":
         return f"{target.component_id or 'PARENT'}_HUB"
     return "UNCONNECTED"
+
+
+@dataclass(frozen=True)
+class NetPad:
+    """One landing of a net: a component's reference designator plus the
+    design pin role to bind. The role -> pad-number resolution against the
+    KiCad symbol/footprint happens in the PCB emitter, not here."""
+    ref: str
+    component_id: str
+    pin_role: str
+
+
+@dataclass
+class Net:
+    name: str
+    pads: list[NetPad] = field(default_factory=list)
+
+
+def build_netlist(design: Design, library) -> list[Net]:
+    """Group the design's connections into nets, keyed by canonical
+    ``net_name``. Mirrors the schematic's net derivation exactly (same
+    ``assign_refs`` + ``net_name``), so the schematic and the PCB land the
+    same pads on the same nets. Connections to a component not in the design
+    are skipped. Nets are returned sorted by name, pads in connection order,
+    for stable, diffable output."""
+    refs = assign_refs(design, library)
+    by_name: dict[str, Net] = {}
+    for conn in design.connections:
+        ref = refs.get(conn.component_id)
+        if ref is None:
+            continue
+        name = net_name(conn.target)
+        net = by_name.setdefault(name, Net(name=name))
+        net.pads.append(
+            NetPad(ref=ref, component_id=conn.component_id, pin_role=conn.pin_role)
+        )
+    return [by_name[n] for n in sorted(by_name)]

--- a/wirestudio/kicad/pcb.py
+++ b/wirestudio/kicad/pcb.py
@@ -1,0 +1,313 @@
+"""`.kicad_pcb` board export (PCB layout, step 2).
+
+Walks a ``design.json`` and emits a KiCad 8 board file: every component +
+board footprint embedded and grid-placed, each pad bound to the net it shares
+in the design, plus an ``Edge.Cuts`` outline. No routing -- the user opens it
+in KiCad's PCB editor with a complete ratsnest and routes (or hands it to an
+autorouter, a later step toward 1.0).
+
+Unlike the SKiDL schematic (a pure text emit with no external data), the board
+embeds real footprint geometry, so it needs the pinned KiCad **footprint**
+libraries (the ``.kicad_mod`` files) and the **symbol** libraries (to map a
+component's pin role -> symbol pin name -> pin number -> footprint pad). It is
+therefore feature-gated the same way the schematic *render* is gated on
+``kicad-cli``: ``pcb_status()`` probes for the libraries and the API/web gate
+the export on it.
+
+Determinism: same ``design.json`` + same pinned libraries -> byte-identical
+board. Reference designators and net names come from ``wirestudio.kicad.netlist``
+so the board and the schematic agree.
+
+Known limitation (step 2): the dev board's own pads aren't bound to nets -- the
+library models boards as generic headers with no GPIO-name -> pad map, so the
+board footprint is placed but its pins float, exactly as in the schematic. Nets
+shared between components (rails, buses, expander/hub pins) get a ratsnest.
+"""
+from __future__ import annotations
+
+import math
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+from wirestudio.kicad.netlist import BOARD_KEY, assign_refs, build_netlist
+from wirestudio.kicad.symbol_parser import load_symbols, resolve_symbol
+from wirestudio.library import Library
+from wirestudio.model import Design
+
+# Grid placement (mm). Parts land on a coarse grid; the user arranges in KiCad.
+_PITCH_MM = 25.4
+_ORIGIN_MM = 25.4
+_MARGIN_MM = 12.7  # Edge.Cuts border around the placement bounding box
+
+_FOOTPRINT_ENV_VARS = (
+    "KICAD8_FOOTPRINT_DIR", "KICAD9_FOOTPRINT_DIR", "KICAD7_FOOTPRINT_DIR",
+    "KICAD6_FOOTPRINT_DIR", "KICAD_FOOTPRINT_DIR",
+)
+_SYMBOL_ENV_VARS = (
+    "KICAD8_SYMBOL_DIR", "KICAD9_SYMBOL_DIR", "KICAD7_SYMBOL_DIR",
+    "KICAD6_SYMBOL_DIR", "KICAD_SYMBOL_DIR",
+)
+
+# Canonical KiCad 8 two-layer board layer table.
+_LAYERS = """\
+	(0 "F.Cu" signal)
+	(31 "B.Cu" signal)
+	(32 "B.Adhes" user "B.Adhesive")
+	(33 "F.Adhes" user "F.Adhesive")
+	(34 "B.Paste" user)
+	(35 "F.Paste" user)
+	(36 "B.SilkS" user "B.Silkscreen")
+	(37 "F.SilkS" user "F.Silkscreen")
+	(38 "B.Mask" user)
+	(39 "F.Mask" user)
+	(40 "Dwgs.User" user "User.Drawings")
+	(41 "Cmts.User" user "User.Comments")
+	(42 "Eco1.User" user "User.Eco1")
+	(43 "Eco2.User" user "User.Eco2")
+	(44 "Edge.Cuts" user)
+	(45 "Margin" user)
+	(46 "B.CrtYd" user "B.Courtyard")
+	(47 "F.CrtYd" user "F.Courtyard")
+	(48 "B.Fab" user)
+	(49 "F.Fab" user)"""
+
+
+class PcbUnavailable(RuntimeError):
+    """The pinned KiCad footprint/symbol libraries aren't available."""
+
+
+def _dir_from_env(env_vars: tuple[str, ...]) -> Optional[Path]:
+    for var in env_vars:
+        val = os.environ.get(var)
+        if val and Path(val).is_dir():
+            return Path(val)
+    return None
+
+
+def _resolve_footprint_dir() -> Optional[Path]:
+    return _dir_from_env(_FOOTPRINT_ENV_VARS)
+
+
+def _resolve_symbol_dir() -> Optional[Path]:
+    return _dir_from_env(_SYMBOL_ENV_VARS)
+
+
+def pcb_status() -> dict:
+    """Probe for the libraries the board export needs. Shape mirrors the
+    schematic render status: ``available`` is the headline, the rest says
+    what's missing."""
+    fp, sym = _resolve_footprint_dir(), _resolve_symbol_dir()
+    available = fp is not None and sym is not None
+    reason = None
+    if not available:
+        missing = []
+        if fp is None:
+            missing.append("footprint libraries not found (set KICAD8_FOOTPRINT_DIR)")
+        if sym is None:
+            missing.append("symbol libraries not found (set KICAD8_SYMBOL_DIR)")
+        reason = "; ".join(missing)
+    return {
+        "available": available,
+        "footprints": fp is not None,
+        "symbols": sym is not None,
+        "reason": reason,
+    }
+
+
+def _mod_path(footprint_ref: str, fp_dir: Path) -> Path:
+    """`LIB:NAME` -> `<fp_dir>/LIB.pretty/NAME.kicad_mod`."""
+    lib, name = footprint_ref.split(":", 1)
+    return fp_dir / f"{lib}.pretty" / f"{name}.kicad_mod"
+
+
+def _resolve_pad_number(
+    role: str, lib_comp, sym_dir: Path, sym_cache: dict,
+) -> Optional[str]:
+    """Map a component pin role to its KiCad footprint pad number.
+
+    Generic ``Connector_Generic`` symbols have positional pins, so the role
+    binds to its 1-based index in the component's electrical pin list. Real
+    symbols go role ->(pin_map) symbol pin name ->(symbol) pin number, which
+    equals the footprint pad number. Returns None when it can't resolve (the
+    caller collects these as warnings)."""
+    kicad = lib_comp.kicad
+    if kicad is None:
+        return None
+    if kicad.symbol_lib == "Connector_Generic":
+        roles = [p.role for p in lib_comp.electrical.pins]
+        return str(roles.index(role) + 1) if role in roles else None
+    pin_name = kicad.pin_map.get(role, role)
+    syms = sym_cache.get(kicad.symbol_lib)
+    if syms is None:
+        path = sym_dir / f"{kicad.symbol_lib}.kicad_sym"
+        syms = load_symbols(path) if path.is_file() else {}
+        sym_cache[kicad.symbol_lib] = syms
+    if kicad.symbol not in syms:
+        return None
+    for name, number in resolve_symbol(syms, kicad.symbol).pins:
+        if name == pin_name:
+            return number
+    return None
+
+
+def _inject_pad_net(text: str, pad_num: str, net_idx: int, net_name: str) -> str:
+    """Add ``(net idx "name")`` to the first ``(pad "pad_num" ...)`` block by
+    scanning to its matching close paren (skipping quoted strings)."""
+    marker = f'(pad "{pad_num}" '
+    start = text.find(marker)
+    if start == -1:
+        return text
+    depth, i, n = 0, start, len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':
+            i += 1
+            while i < n and text[i] != '"':
+                i += 2 if text[i] == "\\" else 1
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    return f'{text[:i]}\t\t(net {net_idx} "{net_name}")\n\t{text[i:]}'
+
+
+def _embed_footprint(
+    mod_text: str, footprint_ref: str, ref: str, value: str,
+    x: float, y: float, pad_nets: dict[str, tuple[int, str]],
+) -> str:
+    """Turn a standalone ``.kicad_mod`` into a placed board footprint: rewrite
+    the name to ``LIB:NAME``, inject placement, set the reference + value, and
+    bind pad nets. Pad/graphic geometry is preserved verbatim."""
+    lib, name = footprint_ref.split(":", 1)
+    opener = f'(footprint "{name}"'
+    text = mod_text.replace(
+        opener, f'(footprint "{footprint_ref}"\n\t(at {_fmt(x)} {_fmt(y)})', 1,
+    )
+    text = text.replace(
+        '(property "Reference" "REF**"', f'(property "Reference" "{ref}"', 1,
+    )
+    text = re.sub(
+        r'\(property "Value" "[^"]*"', f'(property "Value" "{value}"', text, count=1,
+    )
+    for pad_num, (net_idx, net_name) in pad_nets.items():
+        text = _inject_pad_net(text, pad_num, net_idx, net_name)
+    return _indent(text, 1)
+
+
+def _fmt(v: float) -> str:
+    """Trim trailing zeros so 25.4 -> '25.4', 50.0 -> '50'."""
+    return f"{v:.4f}".rstrip("0").rstrip(".")
+
+
+def _indent(block: str, level: int) -> str:
+    pad = "\t" * level
+    return "\n".join(pad + line if line else line for line in block.splitlines())
+
+
+def generate_kicad_pcb(
+    design: Design, library: Library, *,
+    footprint_dir: Optional[Path] = None, symbol_dir: Optional[Path] = None,
+) -> str:
+    """Emit a KiCad 8 ``.kicad_pcb`` for ``design``. Pure given the inputs.
+
+    Raises ``PcbUnavailable`` when the libraries aren't found and ``ValueError``
+    when a referenced footprint doesn't resolve to a ``.kicad_mod`` (the
+    footprint gate keeps this from happening for bundled examples)."""
+    fp_dir = Path(footprint_dir) if footprint_dir else _resolve_footprint_dir()
+    sym_dir = Path(symbol_dir) if symbol_dir else _resolve_symbol_dir()
+    if fp_dir is None or sym_dir is None:
+        raise PcbUnavailable(pcb_status()["reason"])
+
+    refs = assign_refs(design, library)
+    nets = build_netlist(design, library)
+    net_index = {net.name: i + 1 for i, net in enumerate(nets)}
+
+    # Resolve each net pad to a footprint pad number, grouped per ref.
+    components_by_id = {c.id: c for c in design.components}
+    pad_nets_by_ref: dict[str, dict[str, tuple[int, str]]] = {}
+    sym_cache: dict[str, dict] = {}
+    for net in nets:
+        for pad in net.pads:
+            comp = components_by_id.get(pad.component_id)
+            if comp is None:
+                continue
+            lib_comp = library.component(comp.library_id)
+            num = _resolve_pad_number(pad.pin_role, lib_comp, sym_dir, sym_cache)
+            if num is not None:
+                pad_nets_by_ref.setdefault(pad.ref, {})[num] = (
+                    net_index[net.name], net.name,
+                )
+
+    # The placement order: board (M1) first, then components in design order.
+    placements: list[tuple[str, str, str]] = []  # (ref, footprint_ref, value)
+    try:
+        board = library.board(design.board.library_id)
+    except FileNotFoundError:
+        board = None
+    if board is not None and board.kicad is not None and board.kicad.footprint:
+        placements.append((
+            refs[BOARD_KEY], board.kicad.footprint, board.kicad.value or board.id,
+        ))
+    for c in design.components:
+        lib_comp = library.component(c.library_id)
+        if lib_comp.kicad is not None and lib_comp.kicad.footprint:
+            placements.append((
+                refs[c.id], lib_comp.kicad.footprint,
+                lib_comp.kicad.value or c.library_id,
+            ))
+
+    cols = max(1, math.ceil(math.sqrt(len(placements))))
+    fp_blocks: list[str] = []
+    unresolved: list[str] = []
+    max_x = max_y = 0.0
+    for i, (ref, footprint_ref, value) in enumerate(placements):
+        mod = _mod_path(footprint_ref, fp_dir)
+        if not mod.is_file():
+            unresolved.append(f"{ref}: {footprint_ref}")
+            continue
+        x = _ORIGIN_MM + (i % cols) * _PITCH_MM
+        y = _ORIGIN_MM + (i // cols) * _PITCH_MM
+        max_x, max_y = max(max_x, x), max(max_y, y)
+        fp_blocks.append(_embed_footprint(
+            mod.read_text(), footprint_ref, ref, value, x, y,
+            pad_nets_by_ref.get(ref, {}),
+        ))
+
+    if unresolved:
+        raise ValueError(
+            "footprints not found in the library: " + "; ".join(unresolved)
+        )
+
+    net_decls = '\t(net 0 "")\n' + "\n".join(
+        f'\t(net {net_index[net.name]} "{net.name}")' for net in nets
+    )
+    x0, y0 = _ORIGIN_MM - _MARGIN_MM, _ORIGIN_MM - _MARGIN_MM
+    x1, y1 = max_x + _MARGIN_MM, max_y + _MARGIN_MM
+    outline = (
+        "\t(gr_rect\n"
+        f"\t\t(start {_fmt(x0)} {_fmt(y0)})\n"
+        f"\t\t(end {_fmt(x1)} {_fmt(y1)})\n"
+        "\t\t(stroke (width 0.1) (type default))\n"
+        "\t\t(fill none)\n"
+        '\t\t(layer "Edge.Cuts")\n'
+        "\t)"
+    )
+    return (
+        '(kicad_pcb\n'
+        "\t(version 20240108)\n"
+        '\t(generator "wirestudio")\n'
+        '\t(generator_version "8.0")\n'
+        "\t(general\n\t\t(thickness 1.6)\n\t)\n"
+        '\t(paper "A4")\n'
+        "\t(layers\n" + _LAYERS + "\n\t)\n"
+        "\t(setup\n\t\t(pad_to_mask_clearance 0)\n\t)\n"
+        + net_decls + "\n"
+        + "\n".join(fp_blocks) + ("\n" if fp_blocks else "")
+        + outline + "\n"
+        ")\n"
+    )

--- a/wirestudio/kicad/pcb.py
+++ b/wirestudio/kicad/pcb.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import math
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -311,3 +312,48 @@ def generate_kicad_pcb(
         + outline + "\n"
         ")\n"
     )
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    import argparse
+    import json
+
+    from wirestudio.library import default_library
+
+    parser = argparse.ArgumentParser(
+        prog="wirestudio.kicad.pcb",
+        description="Emit a KiCad .kicad_pcb board from a design.json.",
+    )
+    parser.add_argument("design", nargs="?", help="path to a design.json")
+    parser.add_argument("-o", "--out", help="output file (default: <design id>.kicad_pcb)")
+    parser.add_argument(
+        "--status", action="store_true",
+        help="print KiCad-library availability as JSON and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.status:
+        print(json.dumps(pcb_status(), indent=2))
+        return 0
+    if not args.design:
+        parser.error("a design.json path is required (or pass --status)")
+
+    design = Design.model_validate(json.loads(Path(args.design).read_text()))
+    try:
+        board = generate_kicad_pcb(design, default_library())
+    except PcbUnavailable as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        print("run with --status to see what's missing", file=sys.stderr)
+        return 2
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    out = Path(args.out) if args.out else Path(f"{design.id}.kicad_pcb")
+    out.write_text(board)
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Emits a directly-openable `.kicad_pcb` from `design.json` — the next step on the PCB-layout path toward 1.0 (the footprint gate in 0.13.0 was step 1). **Placement + nets only, no routing.**

## What lands
- **`wirestudio/kicad/netlist.py`** — shared reference-designator allocation + canonical net naming, extracted from the SKiDL generator. The schematic emitter now consumes it (byte-identical output), so the schematic and the board agree on `U1`/`D1`/`M1` and net names. Adds `build_netlist` (net → pads).
- **`wirestudio/kicad/pcb.py`** — `generate_kicad_pcb`: every board + component footprint embedded from the pinned `kicad-footprints` libraries and grid-placed, each pad bound to the net it shares in the design, plus an `Edge.Cuts` outline. Pad numbers resolve `role →(pin_map) symbol pin name →(symbol) pin number → footprint pad`; generic `Connector_Generic` parts bind positionally. Footprint geometry is preserved verbatim. CLI: `python -m wirestudio.kicad.pcb`.
- **API** — `GET /design/kicad/pcb/status` + `POST /design/kicad/pcb`, feature-gated on the footprint+symbol libs being present (503 when absent, 422 on an unresolvable footprint), mirroring the schematic render endpoints.
- **`pcb-layout` CI gate** — `scripts/check_pcb.py` emits every example's board against pinned `kicad-footprints` + `kicad-symbols @8.0.0` and asserts structure (footprints embed, parens balance, all pad nets declared).

## Verification
- Full suite **681 passed, 3 skipped**; ruff clean.
- `check_pcb.py`: **all 51 examples** emit a structurally sound board.
- Endpoints smoke-tested via `TestClient`.
- Verified against real cloned KiCad 8 libraries: BME280's `VCC→VDD/SDA→SDI/SCL→SCK` pin-map lands on the correct LGA pads; the HC-SR501 generic header binds positionally.

## Known limits (by design, step 2)
- The dev board's own pads aren't net-bound — the library models boards as generic headers with no GPIO-name→pad map, so the board footprint is placed but its pins float, exactly as in the schematic. Components sharing rails/buses/hub pins get a ratsnest.
- **KiCad-acceptance/DRC isn't checked locally** (no `kicad-cli` on the dev box). The structural gate is the PR-blocking bar; a `kicad-cli pcb drc` tier (installs KiCad) is a documented follow-up.

## Follow-ups
- Web "Download .kicad_pcb" button in the KiCad export dialog (next commit on this branch).
- Freerouting autoroute + Gerber/CPL/BOM export remain on the path to 1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)