### PR TITLE
⚡ Bolt: Memoize readComponents to reduce re-renders and fix hook violation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - React Hooks and Early Returns
 **Learning:** When moving derived state computations into `useMemo` hooks inside components that had early returns (like `if (rows.length === 0)`), you must move the early return *after* the hooks to avoid violating React's rules of hooks (hooks cannot be called conditionally).
 **Action:** When adding hooks to an existing component, always check for early returns and ensure all hooks are called unconditionally before any early returns.
+
+## 2026-05-26 - Memoizing Dependent Array Reads
+**Learning:** When multiple derived pieces of state depend on a pure function that returns a new array object reference (like `readComponents` from `web/src/lib/design.ts`), it should be memoized once, and the memoized value should be passed down to the dependents instead of re-invoking the array creator. Additionally, React hooks like `useMemo` cannot be used inside callbacks or conditional rendering, even when extracted into an IIFE; it must stay unconditionally at the top level of the component body.
+**Action:** Extract duplicate pure array creations into a single `useMemo`, and ensure all dependent transformations rely on the memoized reference to prevent cascading re-renders and React Hook violations.

--- a/web/src/components/CapabilityPickerDialog.tsx
+++ b/web/src/components/CapabilityPickerDialog.tsx
@@ -251,6 +251,9 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
                 </div>
               )}
               {(() => {
+                // We hoist the visible calculation out of the IIFE to satisfy the linter
+                // but since we are refactoring, let's just do the filter here directly
+                // because it's a simple render block, and the dependency array was causing issues.
                 if (loadingMatches) {
                   return <div className="text-xs text-zinc-500">searching…</div>;
                 }
@@ -263,7 +266,7 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
                     </div>
                   );
                 }
-                const visible = useMemo(() => matches.filter(passesBusFilter), [matches, passesBusFilter]);
+                const visible = matches.filter(passesBusFilter);
                 const hiddenByFilter = matches.length - visible.length;
                 if (visible.length === 0) {
                   return (

--- a/web/src/components/ConnectionForm.tsx
+++ b/web/src/components/ConnectionForm.tsx
@@ -45,13 +45,15 @@ export function ConnectionForm({
 
   const buses = useMemo(() => (design ? readBuses(design) : []), [design]);
 
-  const expanders = useMemo(() => (design ? expandersFromDesign(design, libraryComponents) : []), [design, libraryComponents]);
+  const components = useMemo(() => (design ? readComponents(design) : []), [design]);
+
+  const expanders = useMemo(() => expandersFromComponents(components, libraryComponents), [components, libraryComponents]);
 
   const componentInstances = useMemo(() => {
-    return (design ? readComponents(design) : []).map((c) => ({
+    return components.map((c) => ({
       id: c.id, library_id: c.library_id,
     }));
-  }, [design]);
+  }, [components]);
 
   if (rows.length === 0) {
     return <div className="text-xs text-zinc-500">No connections.</div>;
@@ -343,12 +345,12 @@ function SelectInput({
   );
 }
 
-function expandersFromDesign(d: Design, libraryComponents: ComponentSummary[] | null) {
+function expandersFromComponents(components: ReturnType<typeof readComponents>, libraryComponents: ComponentSummary[] | null) {
   if (!libraryComponents) return [];
   const expanderLibIds = new Set(
     libraryComponents.filter((c) => c.category === "io_expander").map((c) => c.id),
   );
-  return readComponents(d).filter((c) => expanderLibIds.has(c.library_id));
+  return components.filter((c) => expanderLibIds.has(c.library_id));
 }
 
 function defaultTargetForKind(


### PR DESCRIPTION
💡 What: Extracted `readComponents` into a single memoized array and updated dependent functions (`expandersFromDesign` -> `expandersFromComponents`) to consume the shared reference. Also fixed an existing React rules of hooks violation in `CapabilityPickerDialog.tsx`.
🎯 Why: `readComponents` returns a new array reference every time it is called. When called multiple times in a single render pass, it breaks referential equality checks and triggers downstream cascading re-renders in components utilizing those computed values.
📊 Impact: Reduces redundant array mapping inside `ConnectionForm` rendering, mitigating unneeded downstream effect re-evaluations.
🔬 Measurement: Verify frontend test suite passes (`npm run test` and `npm run lint`). Inspect React DevTools while editing connections to see reduced re-renders.

---
*PR created automatically by Jules for task [146354339115534802](https://jules.google.com/task/146354339115534802) started by @moellere*