### PR TITLE
⚡ Bolt: Fix hook rule violation in CapabilityPickerDialog

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,4 @@
 ## 2024-05-20 - React Hooks and Early Returns
 **Learning:** When moving derived state computations into `useMemo` hooks inside components that had early returns (like `if (rows.length === 0)`), you must move the early return *after* the hooks to avoid violating React's rules of hooks (hooks cannot be called conditionally).
 **Action:** When adding hooks to an existing component, always check for early returns and ensure all hooks are called unconditionally before any early returns.
+## 2026-05-30 - Hooks and UseMemo\n**Learning:** When moving derived state computations into `useMemo` hooks inside components that had early returns, ensure all hooks are called unconditionally before any early returns to avoid violating React's rules of hooks.\n**Action:** Always check for early returns when adding hooks.

--- a/web/src/components/CapabilityPickerDialog.tsx
+++ b/web/src/components/CapabilityPickerDialog.tsx
@@ -89,6 +89,12 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
 
   const debouncedQuery = useDebouncedValue(activeQuery, 300);
 
+  // Derive visible matches unconditionally at the top level
+  const visibleMatches = useMemo(() => {
+    if (!matches) return [];
+    return matches.filter(passesBusFilter);
+  }, [matches, passesBusFilter]);
+
   // Run the recommender whenever the active query changes.
   useEffect(() => {
     if (!debouncedQuery) {
@@ -263,9 +269,8 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
                     </div>
                   );
                 }
-                const visible = useMemo(() => matches.filter(passesBusFilter), [matches, passesBusFilter]);
-                const hiddenByFilter = matches.length - visible.length;
-                if (visible.length === 0) {
+                const hiddenByFilter = matches.length - visibleMatches.length;
+                if (visibleMatches.length === 0) {
                   return (
                     <div className="text-xs text-zinc-500">
                       {hiddenByFilter} match{hiddenByFilter === 1 ? "" : "es"} hidden
@@ -281,10 +286,10 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
                       </div>
                     )}
                     <ul className="space-y-2">
-                      {visible.map((m, idx) => {
+                      {visibleMatches.map((m, idx) => {
                     const isAdded = added.has(m.library_id);
                     const isAdding = adding === m.library_id;
-                    const alternatives = visible.filter((alt) => alt.library_id !== m.library_id);
+                    const alternatives = visibleMatches.filter((alt) => alt.library_id !== m.library_id);
                     const altsOpen = expandedAlts === m.library_id;
                     return (
                       <li


### PR DESCRIPTION
💡 What: Moved a `useMemo` call for `visibleMatches` to the top level of the component `CapabilityPickerDialog`.
🎯 Why: The `useMemo` was previously called conditionally (inside an IIFE and after multiple early returns). This caused a React hook rule violation ("Rendered more hooks than during the previous render"), breaking tests and potentially crashing the component.
📊 Impact: Fixes a severe runtime bug (hook rule violation) and ensures `useMemo` correctly caches the filtered results without crashing.
🔬 Measurement: Run `cd web && npm run test` to verify `src/components/CapabilityPickerDialog.test.tsx` passes without hook errors.

---
*PR created automatically by Jules for task [13617768178952464169](https://jules.google.com/task/13617768178952464169) started by @moellere*