### PR TITLE
⚡ Bolt: [performance improvement] capability picker visible matches useMemo optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - React Hooks and Early Returns
 **Learning:** When moving derived state computations into `useMemo` hooks inside components that had early returns (like `if (rows.length === 0)`), you must move the early return *after* the hooks to avoid violating React's rules of hooks (hooks cannot be called conditionally).
 **Action:** When adding hooks to an existing component, always check for early returns and ensure all hooks are called unconditionally before any early returns.
+
+## 2025-02-14 - Expensive Array Filtering in React Renders
+**Learning:** Although `useMemo` was used in `CapabilityPickerDialog.tsx`, it was incorrectly nested deeply inside conditional blocks (an early return path), which violates the Rule of Hooks. Fixing this also properly guarantees that the `.filter()` operation on potentially large capability matches lists memoizes predictably, avoiding unexpected render cascade behaviors and hook index misalignment issues in React's Fiber engine.
+**Action:** Lift array filtering and other `useMemo` uses to the top level of the component unconditionally, ensuring correct Rule of Hooks compliance and predictable memoization behavior.

--- a/web/src/components/CapabilityPickerDialog.tsx
+++ b/web/src/components/CapabilityPickerDialog.tsx
@@ -89,6 +89,17 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
 
   const debouncedQuery = useDebouncedValue(activeQuery, 300);
 
+  // ⚡ Bolt Optimization:
+  // Moved this filter out of the conditional render body and into a top-level useMemo.
+  // This correctly satisfies React's Rule of Hooks (hooks must be called unconditionally)
+  // while ensuring the filter (which can be an expensive operation over many matches)
+  // only runs when matches or passesBusFilter actually changes, preventing unnecessary
+  // array allocations and computations on every render loop.
+  const visibleMatches = useMemo(() => {
+    if (!matches) return [];
+    return matches.filter(passesBusFilter);
+  }, [matches, passesBusFilter]);
+
   // Run the recommender whenever the active query changes.
   useEffect(() => {
     if (!debouncedQuery) {
@@ -263,9 +274,9 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
                     </div>
                   );
                 }
-                const visible = useMemo(() => matches.filter(passesBusFilter), [matches, passesBusFilter]);
-                const hiddenByFilter = matches.length - visible.length;
-                if (visible.length === 0) {
+
+                const hiddenByFilter = matches.length - visibleMatches.length;
+                if (visibleMatches.length === 0) {
                   return (
                     <div className="text-xs text-zinc-500">
                       {hiddenByFilter} match{hiddenByFilter === 1 ? "" : "es"} hidden
@@ -281,10 +292,10 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
                       </div>
                     )}
                     <ul className="space-y-2">
-                      {visible.map((m, idx) => {
+                      {visibleMatches.map((m, idx) => {
                     const isAdded = added.has(m.library_id);
                     const isAdding = adding === m.library_id;
-                    const alternatives = visible.filter((alt) => alt.library_id !== m.library_id);
+                    const alternatives = visibleMatches.filter((alt) => alt.library_id !== m.library_id);
                     const altsOpen = expandedAlts === m.library_id;
                     return (
                       <li


### PR DESCRIPTION
💡 What: Extracting the `matches.filter()` operation into a top-level `useMemo` block called `visibleMatches`.
🎯 Why: The prior implementation incorrectly embedded this relatively expensive `filter` operation into an early return branch inside the component render body, breaking React's Rules of Hooks. The length access before actually computing visibility also led to logic being evaluated at render-time, needlessly triggering array allocations on components without changes.
📊 Impact: Fixes a React warning regarding Hooks while also guaranteeing proper memoization of match computations across renders, saving potentially hundreds of array iterations upon filtering input or capability selections.
🔬 Measurement: Verified with `vitest` unit tests `src/components/CapabilityPickerDialog.test.tsx` to verify standard UI flow stability and filters functioning exactly as previously modeled.

---
*PR created automatically by Jules for task [14029838327679017808](https://jules.google.com/task/14029838327679017808) started by @moellere*