### PR TITLE
⚡ Bolt: memoize designBusTypes and expanderLibIds

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - React Hooks and Early Returns
 **Learning:** When moving derived state computations into `useMemo` hooks inside components that had early returns (like `if (rows.length === 0)`), you must move the early return *after* the hooks to avoid violating React's rules of hooks (hooks cannot be called conditionally).
 **Action:** When adding hooks to an existing component, always check for early returns and ensure all hooks are called unconditionally before any early returns.
+
+## 2024-05-21 - Derived State Memoization Splitting
+**Learning:** In React components receiving high-frequency updates (e.g. `ConnectionForm.tsx` where `design` changes frequently during drag-and-drop), derived state that depends on *static* or *infrequent* data (like `libraryComponents`) mixed with frequent data (like `design`) in a single `useMemo` forces the expensive static computation to run on every frequent update.
+**Action:** When a computation has both static/infrequent dependencies and high-frequency dependencies, split it into two `useMemo` hooks. Compute the static/infrequent part first (e.g., building a `Set` from a large array), and then use that memoized result in the second `useMemo` that depends on the high-frequency data.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -107,6 +107,7 @@ export default function App() {
 
   const dirty = useMemo(() => isDirty(originalDesign, design), [originalDesign, design]);
   const debouncedDesign = useDebouncedValue(design, 250);
+  const designBusTypes = useMemo(() => (design ? Array.from(new Set(readBuses(design).map((b) => b.type))) : []), [design]);
 
   // Bootstrap.
   useEffect(() => {
@@ -760,7 +761,7 @@ export default function App() {
       {showCapabilityDialog && (
         <CapabilityPickerDialog
           designReady={!!design}
-          designBusTypes={Array.from(new Set(readBuses(design).map((b) => b.type)))}
+          designBusTypes={designBusTypes}
           onAdd={async (libraryId) => {
             await handleAddComponent(libraryId);
           }}

--- a/web/src/components/CapabilityPickerDialog.tsx
+++ b/web/src/components/CapabilityPickerDialog.tsx
@@ -263,7 +263,7 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
                     </div>
                   );
                 }
-                const visible = useMemo(() => matches.filter(passesBusFilter), [matches, passesBusFilter]);
+                const visible = matches.filter(passesBusFilter);
                 const hiddenByFilter = matches.length - visible.length;
                 if (visible.length === 0) {
                   return (

--- a/web/src/components/ConnectionForm.tsx
+++ b/web/src/components/ConnectionForm.tsx
@@ -45,7 +45,14 @@ export function ConnectionForm({
 
   const buses = useMemo(() => (design ? readBuses(design) : []), [design]);
 
-  const expanders = useMemo(() => (design ? expandersFromDesign(design, libraryComponents) : []), [design, libraryComponents]);
+  const expanderLibIds = useMemo(() => {
+    if (!libraryComponents) return new Set<string>();
+    return new Set(libraryComponents.filter((c) => c.category === "io_expander").map((c) => c.id));
+  }, [libraryComponents]);
+
+  const expanders = useMemo(() => {
+    return design ? readComponents(design).filter((c) => expanderLibIds.has(c.library_id)) : [];
+  }, [design, expanderLibIds]);
 
   const componentInstances = useMemo(() => {
     return (design ? readComponents(design) : []).map((c) => ({
@@ -341,14 +348,6 @@ function SelectInput({
       )}
     </div>
   );
-}
-
-function expandersFromDesign(d: Design, libraryComponents: ComponentSummary[] | null) {
-  if (!libraryComponents) return [];
-  const expanderLibIds = new Set(
-    libraryComponents.filter((c) => c.category === "io_expander").map((c) => c.id),
-  );
-  return readComponents(d).filter((c) => expanderLibIds.has(c.library_id));
 }
 
 function defaultTargetForKind(


### PR DESCRIPTION
💡 What: Split memoized logic in `ConnectionForm.tsx` to pre-calculate `expanderLibIds` and pulled `designBusTypes` in `App.tsx` into a `useMemo`.
🎯 Why: Frequent updates to `design` (e.g. during pin drag-and-drop) caused O(N) recreations of arrays and Sets from `libraryComponents` and `readBuses()`. 
📊 Impact: Eliminates expensive array mapping and Set creation on every render of `App.tsx` and on every `design` state update in `ConnectionForm.tsx`.
🔬 Measurement: Verify by running tests, linting, and checking that the UI performs smoothly during rapid pin assignments.

---
*PR created automatically by Jules for task [14669755278880672517](https://jules.google.com/task/14669755278880672517) started by @moellere*