### PR TITLE
⚡ Bolt: Fix Rules of Hooks violation in CapabilityPickerDialog

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-20 - React Hooks and Early Returns
 **Learning:** When moving derived state computations into `useMemo` hooks inside components that had early returns (like `if (rows.length === 0)`), you must move the early return *after* the hooks to avoid violating React's rules of hooks (hooks cannot be called conditionally).
 **Action:** When adding hooks to an existing component, always check for early returns and ensure all hooks are called unconditionally before any early returns.
+## 2024-05-23 - Rules of Hooks Violation inside JSX IIFE
+**Learning:** Found a case in `CapabilityPickerDialog.tsx` where a `useMemo` was placed inside an immediately invoked function expression (IIFE) within the JSX return block. This IIFE had conditional early returns (e.g. `if (!activeQuery) return null;`) before the hook, causing a violation of the Rules of Hooks ("Rendered more hooks than during the previous render").
+**Action:** Never place React hooks inside inline functions, IIFEs, conditionals, or loops. Always keep hooks unconditionally at the top level of the component and use ternary fallbacks (like `matches ? matches.filter(...) : []`) to safely handle data dependencies that might be undefined or null early in the render cycle.

--- a/web/src/components/CapabilityPickerDialog.tsx
+++ b/web/src/components/CapabilityPickerDialog.tsx
@@ -126,6 +126,8 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
       setAdding(null);
     }
   }
+  const visible = useMemo(() => matches ? matches.filter(passesBusFilter) : [], [matches, passesBusFilter]);
+
 
   return (
     <div
@@ -263,7 +265,6 @@ export function CapabilityPickerDialog({ designReady, designBusTypes, onAdd, onC
                     </div>
                   );
                 }
-                const visible = useMemo(() => matches.filter(passesBusFilter), [matches, passesBusFilter]);
                 const hiddenByFilter = matches.length - visible.length;
                 if (visible.length === 0) {
                   return (


### PR DESCRIPTION
💡 What: Moved the `useMemo` call for the `visible` variable out of an IIFE in the JSX return block to the top level of the component.
🎯 Why: The `useMemo` call inside the IIFE had conditional early returns before it, which violated the Rules of Hooks and caused "Rendered more hooks than during the previous render" errors when conditionally triggered.
📊 Impact: Fixes test failures and prevents potential runtime crashes due to hook mismatch errors.
🔬 Measurement: Run `cd web && npm run test` and verify that the `CapabilityPickerDialog.test.tsx` tests now pass.

---
*PR created automatically by Jules for task [6549156961766096189](https://jules.google.com/task/6549156961766096189) started by @moellere*