### PR TITLE
feat(kicad): fab outputs — Gerber/drill + JLCPCB CPL + BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Fab outputs (Gerber / drill / CPL / BOM).** New `/design/fab/*` endpoints
+  turn a design into a JLCPCB upload bundle: a **BOM** CSV (pure, grouped by
+  part), a **CPL** pick-and-place CSV whose positions match the `.kicad_pcb`
+  placement, and **Gerber + drill** via `kicad-cli` (gated like the schematic
+  render). `POST /design/fab/package` zips all four. `GET /design/fab/status`
+  reports what's available. Boards are unrouted until the Freerouting step, so
+  the Gerbers carry pads but no traces — `is_routed`/status flag that. The
+  `pcb-drc` CI tier also smoke-tests the Gerber export path.
+
 ## [0.14.0] — 2026-05-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   render). `POST /design/fab/package` zips all four. `GET /design/fab/status`
   reports what's available. Boards are unrouted until the Freerouting step, so
   the Gerbers carry pads but no traces — `is_routed`/status flag that. The
-  `pcb-drc` CI tier also smoke-tests the Gerber export path.
+  KiCad export dialog gains a **Fab outputs** section (BOM / CPL / fab-package
+  buttons, each gated on what the server supports). The `pcb-drc` CI tier also
+  smoke-tests the Gerber export path.
 
 ## [0.14.0] — 2026-05-26
 

--- a/scripts/check_pcb_drc.py
+++ b/scripts/check_pcb_drc.py
@@ -118,6 +118,27 @@ def main() -> int:
         return 1
 
     print(f"all {ok} example boards open in KiCad and pass DRC (modulo unrouted).", file=sys.stderr)
+
+    # Fab-export smoke: kicad-cli is here, so prove the Gerber/drill path runs
+    # and the package zips with the expected members for a representative board.
+    import io
+    import zipfile
+
+    from wirestudio.kicad.fab import export_fab_package
+
+    sample = Design.model_validate(json.loads((EXAMPLES_DIR / "garage-motion.json").read_text()))
+    try:
+        names = zipfile.ZipFile(io.BytesIO(export_fab_package(sample, lib))).namelist()
+    except Exception as exc:  # noqa: BLE001
+        print(f"fab package export failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    has_gerber = any(n.lower().endswith((".gbr", ".gm1", ".gbl", ".gtl")) for n in names)
+    has_drill = any(n.lower().endswith((".drl", ".xln")) for n in names)
+    has_csv = any(n.endswith("-cpl.csv") for n in names) and any(n.endswith("-bom.csv") for n in names)
+    if not (has_gerber and has_drill and has_csv):
+        print(f"fab package missing members: {names}", file=sys.stderr)
+        return 1
+    print(f"fab package OK ({len(names)} files: gerbers + drill + cpl + bom).", file=sys.stderr)
     return 0
 
 

--- a/tests/test_kicad_fab.py
+++ b/tests/test_kicad_fab.py
@@ -1,0 +1,102 @@
+"""Tests for fab-output export (CPL + BOM + routing status).
+
+BOM is pure and always runs. CPL + routing status reuse the board's placement
+plan, so they need the footprint libraries and skip without KICAD8_FOOTPRINT_DIR.
+Gerber export needs kicad-cli (validated in CI's pcb-drc env), so it isn't
+exercised here.
+"""
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from wirestudio.kicad.fab import (
+    fab_status,
+    generate_bom,
+    generate_cpl,
+    is_routed,
+)
+from wirestudio.kicad.netlist import assign_refs
+from wirestudio.kicad.pcb import generate_kicad_pcb, pcb_status, plan_placements
+from wirestudio.library import default_library
+from wirestudio.model import Design
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "wirestudio" / "examples"
+
+libs_required = pytest.mark.skipif(
+    not pcb_status()["available"],
+    reason="KiCad footprint/symbol libs not configured (KICAD8_FOOTPRINT_DIR / KICAD8_SYMBOL_DIR)",
+)
+
+
+@pytest.fixture
+def lib():
+    return default_library()
+
+
+def _design(name: str) -> Design:
+    return Design.model_validate(json.loads((EXAMPLES_DIR / f"{name}.json").read_text()))
+
+
+def _rows(csv_text: str) -> list[list[str]]:
+    return list(csv.reader(io.StringIO(csv_text)))
+
+
+# ---------------------------------------------------------------------------
+# BOM -- pure, always runs
+# ---------------------------------------------------------------------------
+
+def test_bom_header_and_board_and_designators(lib):
+    rows = _rows(generate_bom(_design("garage-motion"), lib))
+    assert rows[0] == ["Comment", "Designator", "Footprint", "JLCPCB Part #"]
+    refs = assign_refs(_design("garage-motion"), lib)
+    all_desigs = {d for r in rows[1:] for d in r[1].split(",")}
+    # The board (M1) and every mapped component appear.
+    assert refs["__board__"] in all_desigs
+    assert all(refs[c.id] in all_desigs for c in _design("garage-motion").components)
+    # Footprints are populated.
+    assert all(r[2] for r in rows[1:])
+
+
+def test_bom_groups_identical_parts(lib):
+    """multi-temp wires several identical DS18B20s; they collapse to one BOM
+    line with comma-joined designators."""
+    rows = _rows(generate_bom(_design("multi-temp"), lib))
+    multi = [r for r in rows[1:] if "," in r[1]]
+    assert multi, "expected at least one grouped (multi-designator) BOM line"
+
+
+# ---------------------------------------------------------------------------
+# CPL + routing -- need the footprint libraries
+# ---------------------------------------------------------------------------
+
+@libs_required
+def test_cpl_positions_match_the_board_plan(lib):
+    d = _design("garage-motion")
+    rows = _rows(generate_cpl(d, lib))
+    assert rows[0] == ["Designator", "Mid X", "Mid Y", "Layer", "Rotation"]
+    plan = {p.ref: (round(p.cx, 3), round(p.cy, 3)) for p in plan_placements(d, lib, _fp_dir())}
+    for ref, mx, my, layer, rot in rows[1:]:
+        assert layer == "top" and rot == "0"
+        assert (round(float(mx), 3), round(float(my), 3)) == plan[ref]
+
+
+@libs_required
+def test_emitted_board_is_unrouted(lib):
+    assert is_routed(generate_kicad_pcb(_design("garage-motion"), lib)) is False
+
+
+def test_fab_status_shape():
+    s = fab_status()
+    assert set(s) >= {"bom", "cpl", "gerbers", "kicad_cli", "footprints", "reason"}
+    assert s["bom"] is True  # BOM is always available
+
+
+def _fp_dir() -> Path:
+    from wirestudio.kicad.pcb import _resolve_footprint_dir
+    return _resolve_footprint_dir()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -14,6 +14,7 @@ import type {
   FleetStatus,
   InventoryEntry,
   InventoryCheckResponse,
+  FabStatus,
   KicadPcbStatus,
   KicadRenderStatus,
   LorawanCompileEvent,
@@ -73,6 +74,21 @@ async function requestText(path: string, init?: RequestInit): Promise<string> {
     throw new ApiError(res.status, `${init?.method ?? "GET"} ${path} -> ${res.status}`, body);
   }
   return await res.text();
+}
+
+/** Like `request` but expects a binary response (used for the fab-package
+ *  zip). Errors still come back as JSON. */
+async function requestBlob(path: string, init?: RequestInit): Promise<Blob> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    let body: unknown = undefined;
+    try { body = await res.json(); } catch { /* not json */ }
+    throw new ApiError(res.status, `${init?.method ?? "GET"} ${path} -> ${res.status}`, body);
+  }
+  return await res.blob();
 }
 
 export const api = {
@@ -151,6 +167,14 @@ export const api = {
     request<KicadPcbStatus>("/design/kicad/pcb/status"),
   kicadPcb: (design: Design) =>
     requestText("/design/kicad/pcb", { method: "POST", body: JSON.stringify(design) }),
+  fabStatus: () =>
+    request<FabStatus>("/design/fab/status"),
+  fabBom: (design: Design) =>
+    requestText("/design/fab/bom", { method: "POST", body: JSON.stringify(design) }),
+  fabCpl: (design: Design) =>
+    requestText("/design/fab/cpl", { method: "POST", body: JSON.stringify(design) }),
+  fabPackage: (design: Design) =>
+    requestBlob("/design/fab/package", { method: "POST", body: JSON.stringify(design) }),
   enclosureSearchStatus: () =>
     request<EnclosureSearchStatus>("/enclosure/search/status"),
   enclosureSearch: (params: { library_id: string; query?: string; limit?: number }) => {

--- a/web/src/components/SchematicDialog.test.tsx
+++ b/web/src/components/SchematicDialog.test.tsx
@@ -9,7 +9,7 @@ import userEvent from "@testing-library/user-event";
 
 import { SchematicDialog } from "./SchematicDialog";
 import { api } from "../api/client";
-import type { Design, KicadPcbStatus, KicadRenderStatus } from "../types/api";
+import type { Design, FabStatus, KicadPcbStatus, KicadRenderStatus } from "../types/api";
 
 vi.mock("../api/client", async () => {
   const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
@@ -22,6 +22,10 @@ vi.mock("../api/client", async () => {
       kicadRender: vi.fn(),
       kicadPcbStatus: vi.fn(),
       kicadPcb: vi.fn(),
+      fabStatus: vi.fn(),
+      fabBom: vi.fn(),
+      fabCpl: vi.fn(),
+      fabPackage: vi.fn(),
     },
   };
 });
@@ -32,6 +36,10 @@ const mockApi = api as unknown as {
   kicadRender: ReturnType<typeof vi.fn>;
   kicadPcbStatus: ReturnType<typeof vi.fn>;
   kicadPcb: ReturnType<typeof vi.fn>;
+  fabStatus: ReturnType<typeof vi.fn>;
+  fabBom: ReturnType<typeof vi.fn>;
+  fabCpl: ReturnType<typeof vi.fn>;
+  fabPackage: ReturnType<typeof vi.fn>;
 };
 
 const UNAVAILABLE: KicadRenderStatus = {
@@ -47,6 +55,13 @@ const PCB_UNAVAILABLE: KicadPcbStatus = {
 };
 const PCB_AVAILABLE: KicadPcbStatus = {
   available: true, footprints: true, symbols: true, reason: null,
+};
+const FAB_BOM_ONLY: FabStatus = {
+  bom: true, cpl: false, gerbers: false, kicad_cli: false, footprints: false,
+  reason: "kicad-cli not on PATH (needed for Gerbers)",
+};
+const FAB_FULL: FabStatus = {
+  bom: true, cpl: true, gerbers: true, kicad_cli: true, footprints: true, reason: null,
 };
 
 const design: Design = {
@@ -67,8 +82,13 @@ beforeEach(() => {
   mockApi.kicadRender.mockReset();
   mockApi.kicadPcbStatus.mockReset();
   mockApi.kicadPcb.mockReset();
+  mockApi.fabStatus.mockReset();
+  mockApi.fabBom.mockReset();
+  mockApi.fabCpl.mockReset();
+  mockApi.fabPackage.mockReset();
   mockApi.kicadRenderStatus.mockResolvedValue(UNAVAILABLE);
   mockApi.kicadPcbStatus.mockResolvedValue(PCB_UNAVAILABLE);
+  mockApi.fabStatus.mockResolvedValue(FAB_BOM_ONLY);
   (URL as unknown as { createObjectURL: () => string }).createObjectURL = vi.fn(() => "blob:fake");
   (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = vi.fn();
 });
@@ -174,5 +194,27 @@ describe("SchematicDialog — PCB board", () => {
     await userEvent.click(btn);
     await waitFor(() => expect(mockApi.kicadPcb).toHaveBeenCalledWith(design));
     await waitFor(() => screen.getByText(/Downloaded ✓/));
+  });
+});
+
+describe("SchematicDialog — fab outputs", () => {
+  it("downloads the BOM (always available) and gates the Gerber package on kicad-cli", async () => {
+    mockApi.fabBom.mockResolvedValue("Comment,Designator\n");
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    const bom = await screen.findByRole("button", { name: /BOM \.csv/ });
+    await userEvent.click(bom);
+    await waitFor(() => expect(mockApi.fabBom).toHaveBeenCalledWith(design));
+    // With BOM-only status, the Gerber package button is disabled.
+    expect(screen.getByRole("button", { name: /Fab package/ })).toBeDisabled();
+  });
+
+  it("enables the Gerber package when kicad-cli is available", async () => {
+    mockApi.fabStatus.mockResolvedValue(FAB_FULL);
+    mockApi.fabPackage.mockResolvedValue(new Blob(["zip"]));
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    const pkg = await screen.findByRole("button", { name: /Fab package/ });
+    await waitFor(() => expect(pkg).toBeEnabled());
+    await userEvent.click(pkg);
+    await waitFor(() => expect(mockApi.fabPackage).toHaveBeenCalledWith(design));
   });
 });

--- a/web/src/components/SchematicDialog.tsx
+++ b/web/src/components/SchematicDialog.tsx
@@ -9,7 +9,7 @@
  */
 import { useEffect, useState } from "react";
 import { api, ApiError } from "../api/client";
-import type { Design, KicadPcbStatus, KicadRenderStatus } from "../types/api";
+import type { Design, FabStatus, KicadPcbStatus, KicadRenderStatus } from "../types/api";
 
 interface Props {
   design: Design;
@@ -22,6 +22,17 @@ function formatError(e: unknown): string {
     return `${e.status}: ${typeof detail === "string" ? detail : e.message}`;
   }
   return e instanceof Error ? e.message : String(e);
+}
+
+function saveBlob(part: BlobPart, filename: string, type: string) {
+  const url = URL.createObjectURL(new Blob([part], { type }));
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }
 
 export function SchematicDialog({ design, onClose }: Props) {
@@ -39,6 +50,10 @@ export function SchematicDialog({ design, onClose }: Props) {
   const [pcbDownloaded, setPcbDownloaded] = useState(false);
   const [pcbError, setPcbError] = useState<string | null>(null);
 
+  const [fabStatus, setFabStatus] = useState<FabStatus | null>(null);
+  const [fabBusy, setFabBusy] = useState<string | null>(null);
+  const [fabError, setFabError] = useState<string | null>(null);
+
   useEffect(() => {
     let live = true;
     api
@@ -54,6 +69,13 @@ export function SchematicDialog({ design, onClose }: Props) {
       .catch(() => live && setPcbStatus({
         available: false, footprints: false, symbols: false,
         reason: "pcb status unavailable",
+      }));
+    api
+      .fabStatus()
+      .then((s) => live && setFabStatus(s))
+      .catch(() => live && setFabStatus({
+        bom: true, cpl: false, gerbers: false, kicad_cli: false,
+        footprints: false, reason: "fab status unavailable",
       }));
     return () => {
       live = false;
@@ -123,6 +145,25 @@ export function SchematicDialog({ design, onClose }: Props) {
       setPcbError(formatError(e));
     } finally {
       setPcbDownloading(false);
+    }
+  }
+
+  const id = design.id ?? "design";
+
+  async function handleFab(
+    kind: string,
+    fetcher: () => Promise<string | Blob>,
+    filename: string,
+    type: string,
+  ) {
+    setFabBusy(kind);
+    setFabError(null);
+    try {
+      saveBlob(await fetcher(), filename, type);
+    } catch (e) {
+      setFabError(formatError(e));
+    } finally {
+      setFabBusy(null);
     }
   }
 
@@ -277,6 +318,54 @@ python ${design.id ?? "design"}.skidl.py
             {pcbError && (
               <div className="rounded-md border border-rose-700/40 bg-rose-900/15 px-2 py-1.5 text-xs text-rose-200">
                 {pcbError}
+              </div>
+            )}
+          </section>
+
+          {/* --- Fab outputs (BOM / CPL / Gerbers) --------------------- */}
+          <section className="space-y-2 border-t border-zinc-800 pt-3">
+            <div className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
+              Fab outputs
+            </div>
+            <p className="text-xs leading-relaxed text-zinc-400">
+              BOM + pick-and-place (CPL) for assembly, and a Gerber/drill bundle
+              for a board house. The board isn't routed yet, so the Gerbers have
+              pads but no traces — useful once routing lands (1.0 roadmap).
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => handleFab("bom", () => api.fabBom(design), `${id}-bom.csv`, "text/csv")}
+                disabled={fabBusy !== null}
+                className="rounded-md bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 ring-1 ring-zinc-700 enabled:hover:bg-zinc-700 disabled:opacity-40"
+              >
+                {fabBusy === "bom" ? "…" : "BOM .csv"}
+              </button>
+              <button
+                onClick={() => handleFab("cpl", () => api.fabCpl(design), `${id}-cpl.csv`, "text/csv")}
+                disabled={fabBusy !== null || !fabStatus?.cpl}
+                title={fabStatus && !fabStatus.cpl ? "Needs the footprint libraries on the server" : undefined}
+                className="rounded-md bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 ring-1 ring-zinc-700 enabled:hover:bg-zinc-700 disabled:opacity-40"
+              >
+                {fabBusy === "cpl" ? "…" : "CPL .csv"}
+              </button>
+              <button
+                onClick={() => handleFab("package", () => api.fabPackage(design), `${id}-fab.zip`, "application/zip")}
+                disabled={fabBusy !== null || !fabStatus?.gerbers}
+                title={fabStatus && !fabStatus.gerbers ? "Needs kicad-cli + the libraries on the server" : undefined}
+                className="rounded-md bg-blue-500/20 px-3 py-1.5 text-sm text-blue-100 ring-1 ring-blue-400/40 enabled:hover:bg-blue-500/30 disabled:opacity-40"
+              >
+                {fabBusy === "package" ? "Generating…" : "Fab package .zip →"}
+              </button>
+            </div>
+            {fabStatus && !fabStatus.gerbers && (
+              <div className="text-[11px] text-zinc-500">
+                Gerbers need <code className="text-zinc-300">kicad-cli</code> on the server
+                {fabStatus.reason && <span> ({fabStatus.reason})</span>}. BOM is always available.
+              </div>
+            )}
+            {fabError && (
+              <div className="rounded-md border border-rose-700/40 bg-rose-900/15 px-2 py-1.5 text-xs text-rose-200">
+                {fabError}
               </div>
             )}
           </section>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -289,6 +289,15 @@ export interface KicadPcbStatus {
   reason: string | null;
 }
 
+export interface FabStatus {
+  bom: boolean;
+  cpl: boolean;
+  gerbers: boolean;
+  kicad_cli: boolean;
+  footprints: boolean;
+  reason: string | null;
+}
+
 export interface EnclosureHit {
   source: string;
   id: string;

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -83,6 +83,14 @@ from wirestudio.enclosure import (
     search_enclosures,
 )
 from wirestudio.kicad import generate_skidl
+from wirestudio.kicad.fab import (
+    GerberUnavailable,
+    export_fab_package,
+    export_gerbers,
+    fab_status,
+    generate_bom,
+    generate_cpl,
+)
 from wirestudio.kicad.pcb import PcbUnavailable, generate_kicad_pcb, pcb_status
 from wirestudio.kicad.render import (
     RenderError,
@@ -578,6 +586,70 @@ def create_app(
         return PlainTextResponse(
             content=board,
             headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    @app.get("/design/fab/status", tags=["design"])
+    def design_fab_status() -> dict:
+        """What fab outputs are available: BOM is always emittable, CPL needs
+        the footprint libraries, Gerbers also need kicad-cli."""
+        return fab_status()
+
+    @app.post("/design/fab/bom", tags=["design"])
+    def design_fab_bom(design: dict) -> PlainTextResponse:
+        """JLCPCB BOM CSV (grouped by part). Pure -- always available."""
+        d = _validate_design(design)
+        return PlainTextResponse(
+            content=generate_bom(d, lib), media_type="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{d.id}-bom.csv"'},
+        )
+
+    @app.post("/design/fab/cpl", tags=["design"])
+    def design_fab_cpl(design: dict) -> PlainTextResponse:
+        """JLCPCB CPL (pick-and-place) CSV; positions match the .kicad_pcb.
+        503 when the footprint libraries aren't on the server."""
+        d = _validate_design(design)
+        try:
+            cpl = generate_cpl(d, lib)
+        except PcbUnavailable as e:
+            raise HTTPException(status_code=503, detail=str(e)) from e
+        except (FileNotFoundError, ValueError) as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        return PlainTextResponse(
+            content=cpl, media_type="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{d.id}-cpl.csv"'},
+        )
+
+    @app.post("/design/fab/gerbers", tags=["design"])
+    def design_fab_gerbers(design: dict) -> Response:
+        """Gerber + drill files as a zip. 503 when kicad-cli / the libraries
+        are missing."""
+        d = _validate_design(design)
+        try:
+            data = export_gerbers(d, lib)
+        except (GerberUnavailable, PcbUnavailable) as e:
+            raise HTTPException(status_code=503, detail=str(e)) from e
+        except (FileNotFoundError, ValueError) as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        return Response(
+            content=data, media_type="application/zip",
+            headers={"Content-Disposition": f'attachment; filename="{d.id}-gerbers.zip"'},
+        )
+
+    @app.post("/design/fab/package", tags=["design"])
+    def design_fab_package(design: dict) -> Response:
+        """The JLCPCB upload bundle: Gerbers + drill + CPL + BOM in one zip.
+        Boards are unrouted until the routing step lands, so the Gerbers carry
+        pads but no traces. 503 when kicad-cli / the libraries are missing."""
+        d = _validate_design(design)
+        try:
+            data = export_fab_package(d, lib)
+        except (GerberUnavailable, PcbUnavailable) as e:
+            raise HTTPException(status_code=503, detail=str(e)) from e
+        except (FileNotFoundError, ValueError) as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        return Response(
+            content=data, media_type="application/zip",
+            headers={"Content-Disposition": f'attachment; filename="{d.id}-fab.zip"'},
         )
 
     @app.get("/design/jlcpcb/status", tags=["design"])

--- a/wirestudio/kicad/fab.py
+++ b/wirestudio/kicad/fab.py
@@ -1,0 +1,176 @@
+"""Fab-output export: JLCPCB CPL + BOM, and Gerber/drill via kicad-cli.
+
+CPL (pick-and-place) and BOM are pure functions of ``design.json`` + the
+library; CPL reuses the board's placement plan so positions match exactly.
+Gerber + drill need ``kicad-cli`` and are gated the same way the schematic
+render is. ``export_fab_package`` zips Gerbers + drill + CPL + BOM into the
+JLCPCB upload bundle.
+
+The boards are unrouted until the Freerouting step lands, so Gerbers carry
+pads but no copper traces -- ``routing_status`` flags that so a caller can warn
+before someone sends an unroutable board to a fab.
+"""
+from __future__ import annotations
+
+import csv
+import io
+import re
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+from wirestudio.kicad.netlist import BOARD_KEY, assign_refs
+from wirestudio.kicad.pcb import (
+    PcbUnavailable,
+    _resolve_footprint_dir,
+    generate_kicad_pcb,
+    pcb_status,
+    plan_placements,
+)
+from wirestudio.library import Library
+from wirestudio.model import Design
+
+_TIMEOUT = 180  # seconds per kicad-cli call
+
+
+class GerberUnavailable(RuntimeError):
+    """kicad-cli (or the libraries) needed for Gerber export isn't available."""
+
+
+def _kicad_cli() -> Optional[str]:
+    return shutil.which("kicad-cli")
+
+
+def is_routed(board_text: str) -> bool:
+    """True once a board carries copper traces (track segments or vias). The
+    emitter produces a placed but unrouted board, so this is False until
+    routing lands. Word-boundaried so footprint keepout settings like
+    ``(vias not_allowed)`` don't count as routing."""
+    return bool(re.search(r"\((?:segment|via)\b", board_text))
+
+
+def fab_status(*, footprint_dir: Optional[Path] = None) -> dict:
+    """What fab outputs are available here. BOM is always pure; CPL needs the
+    footprint libraries (for placement); Gerbers also need kicad-cli."""
+    fp = Path(footprint_dir) if footprint_dir else _resolve_footprint_dir()
+    cli = _kicad_cli()
+    reason = None
+    if fp is None or cli is None:
+        missing = []
+        if fp is None:
+            missing.append("footprint libraries not found (set KICAD8_FOOTPRINT_DIR)")
+        if cli is None:
+            missing.append("kicad-cli not on PATH (needed for Gerbers)")
+        reason = "; ".join(missing)
+    return {
+        "bom": True,
+        "cpl": fp is not None,
+        "gerbers": fp is not None and cli is not None,
+        "kicad_cli": cli is not None,
+        "footprints": fp is not None,
+        "reason": reason,
+    }
+
+
+def generate_cpl(design: Design, library: Library, *,
+                 footprint_dir: Optional[Path] = None) -> str:
+    """JLCPCB CPL (pick-and-place) CSV. Positions come from the board's
+    placement plan, so they match the .kicad_pcb. Needs the footprint
+    libraries (placement measures footprint extents)."""
+    fp_dir = Path(footprint_dir) if footprint_dir else _resolve_footprint_dir()
+    if fp_dir is None:
+        raise PcbUnavailable(pcb_status()["reason"])
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(["Designator", "Mid X", "Mid Y", "Layer", "Rotation"])
+    for p in plan_placements(design, library, fp_dir):
+        w.writerow([p.ref, f"{p.cx:.3f}", f"{p.cy:.3f}", "top", "0"])
+    return buf.getvalue()
+
+
+def generate_bom(design: Design, library: Library) -> str:
+    """JLCPCB BOM CSV, grouped by part (value + footprint). The JLCPCB/LCSC
+    part column is left blank for the user to fill. Pure."""
+    refs = assign_refs(design, library)
+    groups: dict[tuple[str, str], list[str]] = {}
+    try:
+        board = library.board(design.board.library_id)
+    except FileNotFoundError:
+        board = None
+    if board is not None and board.kicad is not None:
+        key = (board.kicad.value or board.name or board.id, board.kicad.footprint or "")
+        groups.setdefault(key, []).append(refs[BOARD_KEY])
+    for c in design.components:
+        lib_comp = library.component(c.library_id)
+        if lib_comp.kicad is None:
+            continue
+        comment = lib_comp.kicad.value or lib_comp.name or c.library_id
+        key = (comment, lib_comp.kicad.footprint or "")
+        groups.setdefault(key, []).append(refs[c.id])
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(["Comment", "Designator", "Footprint", "JLCPCB Part #"])
+    for (comment, footprint), desigs in sorted(groups.items()):
+        w.writerow([comment, ",".join(sorted(desigs)), footprint, ""])
+    return buf.getvalue()
+
+
+def _gerbers_into(out_dir: Path, board_text: str) -> None:
+    """Run kicad-cli gerbers + drill export for ``board_text`` into ``out_dir``.
+    Raises GerberUnavailable on a missing tool or a failed step."""
+    if _kicad_cli() is None:
+        raise GerberUnavailable("kicad-cli not found on PATH")
+    with tempfile.TemporaryDirectory(prefix="wirestudio-gerber-") as td:
+        board = Path(td) / "board.kicad_pcb"
+        board.write_text(board_text)
+        for sub in ("gerbers", "drill"):
+            proc = subprocess.run(
+                ["kicad-cli", "pcb", "export", sub, "--output", f"{out_dir}/", str(board)],
+                capture_output=True, text=True, timeout=_TIMEOUT,
+            )
+            if proc.returncode != 0:
+                raise GerberUnavailable(
+                    f"kicad-cli pcb export {sub} failed: {(proc.stderr or proc.stdout or '')[-500:]}"
+                )
+
+
+def _zip(files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        for name, data in files.items():
+            z.writestr(name, data)
+    return buf.getvalue()
+
+
+def export_gerbers(design: Design, library: Library, *,
+                   footprint_dir: Optional[Path] = None,
+                   symbol_dir: Optional[Path] = None) -> bytes:
+    """Zip of Gerber + drill files. Needs kicad-cli + the libraries."""
+    board = generate_kicad_pcb(
+        design, library, footprint_dir=footprint_dir, symbol_dir=symbol_dir,
+    )
+    with tempfile.TemporaryDirectory(prefix="wirestudio-fab-") as td:
+        out = Path(td)
+        _gerbers_into(out, board)
+        return _zip({f.name: f.read_bytes() for f in sorted(out.iterdir())})
+
+
+def export_fab_package(design: Design, library: Library, *,
+                       footprint_dir: Optional[Path] = None,
+                       symbol_dir: Optional[Path] = None) -> bytes:
+    """The JLCPCB upload bundle: Gerbers + drill + CPL + BOM in one zip."""
+    board = generate_kicad_pcb(
+        design, library, footprint_dir=footprint_dir, symbol_dir=symbol_dir,
+    )
+    with tempfile.TemporaryDirectory(prefix="wirestudio-fab-") as td:
+        out = Path(td)
+        _gerbers_into(out, board)
+        files = {f.name: f.read_bytes() for f in sorted(out.iterdir())}
+    files[f"{design.id}-cpl.csv"] = generate_cpl(
+        design, library, footprint_dir=footprint_dir,
+    ).encode()
+    files[f"{design.id}-bom.csv"] = generate_bom(design, library).encode()
+    return _zip(files)

--- a/wirestudio/kicad/pcb.py
+++ b/wirestudio/kicad/pcb.py
@@ -29,6 +29,7 @@ import math
 import os
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -226,6 +227,76 @@ def _indent(block: str, level: int) -> str:
     return "\n".join(pad + line if line else line for line in block.splitlines())
 
 
+@dataclass
+class Placement:
+    """One placed footprint: where it lands and what it is. Shared by the board
+    emitter and the CPL export so their positions agree."""
+    ref: str
+    footprint_ref: str
+    value: str
+    cx: float
+    cy: float
+    half_w: float
+    half_h: float
+    is_board: bool
+    mod_text: str
+
+
+def plan_placements(design: Design, library: Library, fp_dir: Path) -> list[Placement]:
+    """Resolve + shelf-pack the design's footprints (board first, then
+    components in design order) into non-overlapping cells. Raises ValueError
+    listing any footprint that doesn't resolve to a ``.kicad_mod``."""
+    refs = assign_refs(design, library)
+    entries: list[tuple[str, str, str, bool]] = []
+    try:
+        board = library.board(design.board.library_id)
+    except FileNotFoundError:
+        board = None
+    if board is not None and board.kicad is not None and board.kicad.footprint:
+        entries.append(
+            (refs[BOARD_KEY], board.kicad.footprint, board.kicad.value or board.id, True)
+        )
+    for c in design.components:
+        lib_comp = library.component(c.library_id)
+        if lib_comp.kicad is not None and lib_comp.kicad.footprint:
+            entries.append(
+                (refs[c.id], lib_comp.kicad.footprint, lib_comp.kicad.value or c.library_id, False)
+            )
+
+    loaded: list[tuple[str, str, str, bool, str, float, float]] = []
+    unresolved: list[str] = []
+    for ref, footprint_ref, value, is_board in entries:
+        mod = _mod_path(footprint_ref, fp_dir)
+        if not mod.is_file():
+            unresolved.append(f"{ref}: {footprint_ref}")
+            continue
+        text = mod.read_text()
+        hw, hh = _footprint_extent(text)
+        loaded.append((ref, footprint_ref, value, is_board, text, hw, hh))
+    if unresolved:
+        raise ValueError("footprints not found in the library: " + "; ".join(unresolved))
+
+    cols = max(1, math.ceil(math.sqrt(len(loaded))))
+    out: list[Placement] = []
+    cursor_x = _ORIGIN_MM
+    row_y = _ORIGIN_MM
+    row_max_h = 0.0
+    col = 0
+    for ref, footprint_ref, value, is_board, text, hw, hh in loaded:
+        if col >= cols:
+            cursor_x = _ORIGIN_MM
+            row_y += row_max_h + _GAP_MM
+            row_max_h = 0.0
+            col = 0
+        out.append(Placement(
+            ref, footprint_ref, value, cursor_x + hw, row_y + hh, hw, hh, is_board, text,
+        ))
+        cursor_x += 2 * hw + _GAP_MM
+        row_max_h = max(row_max_h, 2 * hh)
+        col += 1
+    return out
+
+
 def generate_kicad_pcb(
     design: Design, library: Library, *,
     footprint_dir: Optional[Path] = None, symbol_dir: Optional[Path] = None,
@@ -240,7 +311,6 @@ def generate_kicad_pcb(
     if fp_dir is None or sym_dir is None:
         raise PcbUnavailable(pcb_status()["reason"])
 
-    refs = assign_refs(design, library)
     nets = build_netlist(design, library)
     net_index = {net.name: i + 1 for i, net in enumerate(nets)}
 
@@ -260,64 +330,17 @@ def generate_kicad_pcb(
                     net_index[net.name], net.name,
                 )
 
-    # The placement order: board (M1) first, then components in design order.
-    placements: list[tuple[str, str, str]] = []  # (ref, footprint_ref, value)
-    try:
-        board = library.board(design.board.library_id)
-    except FileNotFoundError:
-        board = None
-    if board is not None and board.kicad is not None and board.kicad.footprint:
-        placements.append((
-            refs[BOARD_KEY], board.kicad.footprint, board.kicad.value or board.id,
-        ))
-    for c in design.components:
-        lib_comp = library.component(c.library_id)
-        if lib_comp.kicad is not None and lib_comp.kicad.footprint:
-            placements.append((
-                refs[c.id], lib_comp.kicad.footprint,
-                lib_comp.kicad.value or c.library_id,
-            ))
-
-    # Read footprints + measure them, surfacing any that don't resolve.
-    loaded: list[tuple[str, str, str, str, float, float]] = []
-    unresolved: list[str] = []
-    for ref, footprint_ref, value in placements:
-        mod = _mod_path(footprint_ref, fp_dir)
-        if not mod.is_file():
-            unresolved.append(f"{ref}: {footprint_ref}")
-            continue
-        text = mod.read_text()
-        hw, hh = _footprint_extent(text)
-        loaded.append((ref, footprint_ref, value, text, hw, hh))
-    if unresolved:
-        raise ValueError(
-            "footprints not found in the library: " + "; ".join(unresolved)
-        )
-
-    # Shelf-pack into rows sized to each footprint's bounding box + a gap, so
-    # nothing overlaps. Track the true extent for the board outline.
-    cols = max(1, math.ceil(math.sqrt(len(loaded))))
+    # Footprints, placed (board first) into non-overlapping cells.
+    placements = plan_placements(design, library, fp_dir)
     fp_blocks: list[str] = []
-    cursor_x = _ORIGIN_MM
-    row_y = _ORIGIN_MM
-    row_max_h = 0.0
-    col = 0
     bb_x = bb_y = 0.0
-    for ref, footprint_ref, value, text, hw, hh in loaded:
-        if col >= cols:
-            cursor_x = _ORIGIN_MM
-            row_y += row_max_h + _GAP_MM
-            row_max_h = 0.0
-            col = 0
-        cx, cy = cursor_x + hw, row_y + hh
+    for p in placements:
         fp_blocks.append(_embed_footprint(
-            text, footprint_ref, ref, value, cx, cy, pad_nets_by_ref.get(ref, {}),
+            p.mod_text, p.footprint_ref, p.ref, p.value, p.cx, p.cy,
+            pad_nets_by_ref.get(p.ref, {}),
         ))
-        bb_x = max(bb_x, cx + hw)
-        bb_y = max(bb_y, cy + hh)
-        cursor_x += 2 * hw + _GAP_MM
-        row_max_h = max(row_max_h, 2 * hh)
-        col += 1
+        bb_x = max(bb_x, p.cx + p.half_w)
+        bb_y = max(bb_y, p.cy + p.half_h)
 
     net_decls = '\t(net 0 "")\n' + "\n".join(
         f'\t(net {net_index[net.name]} "{net.name}")' for net in nets


### PR DESCRIPTION
The next 1.0 piece per your call ("Gerber/CPL/BOM export first"). Boards are still unrouted (Freerouting comes in its own focused PR after), but the fab plumbing + routing-status warning ship now so the JLCPCB upload path is in place.

## What lands
- **`wirestudio/kicad/fab.py`** — `generate_bom` (pure, grouped by part), `generate_cpl` (pick-and-place; reuses the board's placement plan so positions match the `.kicad_pcb`), `export_gerbers` and `export_fab_package` (Gerbers + drill via `kicad-cli`, gated like the schematic render), `is_routed` / `fab_status` so callers can warn that traces aren't there yet.
- **Refactor in `pcb.py`** — placement extracted into a shared `plan_placements`; the board emit and the CPL consume it, so they can't drift.
- **API** — `GET /design/fab/status` + `POST /design/fab/{bom,cpl,gerbers,package}`.
- **CI** — the `pcb-drc` tier already has `kicad-cli`, so it now also smoke-tests `export_fab_package` (assert the zip carries Gerbers + drill + CPL + BOM).
- **Web** — a **Fab outputs** section in the KiCad export dialog with BOM / CPL / fab-package buttons, each gated on what the server can produce.

## Verification
- Suite **686 passed**; ruff clean; CPL positions match `plan_placements` exactly; BOM groups identical parts.
- Web tsc + production build clean; dialog tests 12/12.
- Local API smoke: status reports `gerbers: false` cleanly with no local `kicad-cli`; BOM/CPL emit.
- KiCad-side Gerber export is what CI's `pcb-drc` smoke validates.

## Known limit (by design, until routing lands)
The placed boards have pads but no copper traces, so the Gerbers represent an unrouted board. `is_routed` returns false and the dialog text says so. Freerouting + a routed Gerber path are the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)