### PR TITLE
feat(agent+mcp): tool coverage for KiCad PCB + fab outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent + MCP tool coverage for PCB and fab outputs.** The agent's tool
+  surface and the MCP server gain `kicad_schematic`, `kicad_pcb` (returns a
+  summary, not the megabyte board text), `fab_status`, `fab_bom`, and
+  `fab_cpl` — so an agent (Claude Desktop / Claude Code over MCP, or the
+  Anthropic API agent) can now drive design → board → BOM/CPL/Gerber-status
+  end to end. Library-gated tools report `available: false` cleanly when the
+  server doesn't have the KiCad libraries.
 - **Fab outputs (Gerber / drill / CPL / BOM).** New `/design/fab/*` endpoints
   turn a design into a JLCPCB upload bundle: a **BOM** CSV (pure, grouped by
   part), a **CPL** pick-and-place CSV whose positions match the `.kicad_pcb`

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -404,3 +404,29 @@ def test_render_catches_exception(lib):
     body = json.loads(out)
     assert body["ok"] is False
     assert "error" in body
+
+
+def test_kicad_schematic_returns_a_skidl_script(lib, garage_motion_design):
+    out, is_error = execute_tool("kicad_schematic", {}, garage_motion_design, lib)
+    assert is_error is False
+    body = json.loads(out)
+    assert body["ok"] is True
+    assert "from skidl import" in body["script"]
+
+
+def test_fab_status_reports_what_is_available(lib):
+    out, is_error = execute_tool("fab_status", {}, {}, lib)
+    assert is_error is False
+    body = json.loads(out)
+    # BOM is always available; gerbers/cpl depend on the server's tools.
+    assert body["bom"] is True
+    assert set(body) >= {"bom", "cpl", "gerbers", "kicad_cli", "footprints", "reason"}
+
+
+def test_fab_bom_returns_csv(lib, garage_motion_design):
+    out, is_error = execute_tool("fab_bom", {}, garage_motion_design, lib)
+    assert is_error is False
+    body = json.loads(out)
+    assert body["ok"] is True
+    assert body["csv"].splitlines()[0].startswith("Comment,Designator,Footprint")
+    assert body["rows"] > 0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -29,6 +29,11 @@ EXPECTED_TOOLS = {
     "set_connection",
     "add_bus",
     "solve_pins",
+    "kicad_schematic",
+    "kicad_pcb",
+    "fab_status",
+    "fab_bom",
+    "fab_cpl",
     "set_active_design",
     "get_active_design",
 }

--- a/wirestudio/agent/tools.py
+++ b/wirestudio/agent/tools.py
@@ -7,6 +7,7 @@ never load files outside the library, and never execute user-provided code.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Callable
 
 from wirestudio.csp.compatibility import check_pin_compatibility
@@ -14,6 +15,9 @@ from wirestudio.csp.pin_solver import solve_pins as _solve_pins
 from wirestudio.designs.seed import add_component_with_connections
 from wirestudio.generate.ascii_gen import render_ascii
 from wirestudio.generate.yaml_gen import render_yaml
+from wirestudio.kicad import generate_skidl
+from wirestudio.kicad.fab import fab_status, generate_bom, generate_cpl
+from wirestudio.kicad.pcb import PcbUnavailable, generate_kicad_pcb
 from wirestudio.library import Library
 from wirestudio.model import Design
 from wirestudio.recommend.recommender import Constraints, recommend_components
@@ -235,6 +239,52 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
             "assignments made, any unresolved connections, and any "
             "conflict / current-budget warnings the solver detected. "
             "Mutates the design."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
+        "name": "kicad_schematic",
+        "description": (
+            "Emit the design's KiCad schematic as a SKiDL Python script. The "
+            "caller runs it locally (pip install skidl; python <design>.skidl.py) "
+            "to produce a .kicad_sch. Read-only."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
+        "name": "kicad_pcb",
+        "description": (
+            "Emit the design's KiCad .kicad_pcb board (footprints placed + nets "
+            "bound, no routing). Returns a summary (size_bytes, footprints, nets, "
+            "routed); the actual board file is downloaded via the "
+            "POST /design/kicad/pcb endpoint. Needs the KiCad libraries on the "
+            "server -- returns ok=false, available=false otherwise. Read-only."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
+        "name": "fab_status",
+        "description": (
+            "What fab outputs the server can produce: BOM is always available, "
+            "CPL needs the footprint libraries, Gerbers need kicad-cli. "
+            "Read-only."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
+        "name": "fab_bom",
+        "description": (
+            "Emit the design's JLCPCB BOM (CSV; grouped by part). Pure -- always "
+            "works. Returns the CSV text + row count. Read-only."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
+        "name": "fab_cpl",
+        "description": (
+            "Emit the design's JLCPCB CPL (pick-and-place, CSV); positions match "
+            "the .kicad_pcb. Needs the footprint libraries -- returns ok=false, "
+            "available=false otherwise. Read-only."
         ),
         "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
     },
@@ -483,6 +533,64 @@ def _run_validate(design: dict, library: Library) -> dict:
     }
 
 
+def _run_kicad_schematic(design: dict, library: Library) -> dict:
+    try:
+        d = Design.model_validate(design)
+    except Exception as e:
+        return {"ok": False, "error": f"design failed validation: {e}"}
+    try:
+        return {"ok": True, "script": generate_skidl(d, library)}
+    except (FileNotFoundError, ValueError) as e:
+        return {"ok": False, "error": str(e)}
+
+
+def _run_kicad_pcb(design: dict, library: Library) -> dict:
+    """Return a summary of the emitted board, not the megabyte board text."""
+    try:
+        d = Design.model_validate(design)
+    except Exception as e:
+        return {"ok": False, "error": f"design failed validation: {e}"}
+    try:
+        board = generate_kicad_pcb(d, library)
+    except PcbUnavailable as e:
+        return {"ok": False, "available": False, "error": str(e)}
+    except (FileNotFoundError, ValueError) as e:
+        return {"ok": False, "error": str(e)}
+    return {
+        "ok": True,
+        "size_bytes": len(board),
+        "footprints": board.count('(footprint "'),
+        "nets": len(re.findall(r'^\t\(net \d+ "', board, re.M)),
+        "routed": bool(re.search(r"\((?:segment|via)\b", board)),
+    }
+
+
+def _run_fab_status(_design: dict, _library: Library) -> dict:
+    """Server-side capability probe; the design/library are ignored."""
+    return fab_status()
+
+
+def _run_fab_bom(design: dict, library: Library) -> dict:
+    try:
+        d = Design.model_validate(design)
+    except Exception as e:
+        return {"ok": False, "error": f"design failed validation: {e}"}
+    csv_text = generate_bom(d, library)
+    return {"ok": True, "csv": csv_text, "rows": max(csv_text.count("\n") - 1, 0)}
+
+
+def _run_fab_cpl(design: dict, library: Library) -> dict:
+    try:
+        d = Design.model_validate(design)
+    except Exception as e:
+        return {"ok": False, "error": f"design failed validation: {e}"}
+    try:
+        csv_text = generate_cpl(d, library)
+    except PcbUnavailable as e:
+        return {"ok": False, "available": False, "error": str(e)}
+    return {"ok": True, "csv": csv_text, "rows": max(csv_text.count("\n") - 1, 0)}
+
+
 TOOL_HANDLERS: dict[str, Callable[..., Any]] = {
     "search_components": _run_search_components,
     "list_boards": _run_list_boards,
@@ -496,6 +604,11 @@ TOOL_HANDLERS: dict[str, Callable[..., Any]] = {
     "validate": _run_validate,
     "recommend": _run_recommend,
     "solve_pins": _run_solve_pins,
+    "kicad_schematic": _run_kicad_schematic,
+    "kicad_pcb": _run_kicad_pcb,
+    "fab_status": _run_fab_status,
+    "fab_bom": _run_fab_bom,
+    "fab_cpl": _run_fab_cpl,
 }
 
 

--- a/wirestudio/mcp/server.py
+++ b/wirestudio/mcp/server.py
@@ -23,6 +23,11 @@ from mcp.server.fastmcp import FastMCP
 from wirestudio.agent.tools import (
     _run_add_bus,
     _run_add_component,
+    _run_fab_bom,
+    _run_fab_cpl,
+    _run_fab_status,
+    _run_kicad_pcb,
+    _run_kicad_schematic,
     _run_list_boards,
     _run_recommend,
     _run_remove_component,
@@ -350,6 +355,71 @@ def _register_design_tools(
         result = _run_solve_pins(design, library)
         _save(rid, design)
         return result
+
+    @mcp.tool(
+        name="kicad_schematic",
+        description=(
+            "Emit the named design's KiCad schematic as a SKiDL Python script. "
+            "Read-only." + _DESIGN_ID_HINT
+        ),
+    )
+    def kicad_schematic(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
+        return _run_kicad_schematic(design, library)
+
+    @mcp.tool(
+        name="kicad_pcb",
+        description=(
+            "Emit the named design's KiCad .kicad_pcb and return a summary "
+            "(size, footprints, nets, routed). The actual board file is "
+            "downloaded via POST /design/kicad/pcb. Needs the KiCad libraries "
+            "on the server. Read-only." + _DESIGN_ID_HINT
+        ),
+    )
+    def kicad_pcb(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
+        return _run_kicad_pcb(design, library)
+
+    @mcp.tool(
+        name="fab_status",
+        description=(
+            "What fab outputs the server can produce: BOM always; CPL needs "
+            "the footprint libraries; Gerbers need kicad-cli. Read-only."
+        ),
+    )
+    def fab_status_tool() -> dict:
+        return _run_fab_status({}, library)
+
+    @mcp.tool(
+        name="fab_bom",
+        description=(
+            "Emit the named design's JLCPCB BOM (CSV, grouped by part). "
+            "Read-only." + _DESIGN_ID_HINT
+        ),
+    )
+    def fab_bom(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
+        return _run_fab_bom(design, library)
+
+    @mcp.tool(
+        name="fab_cpl",
+        description=(
+            "Emit the named design's JLCPCB CPL (pick-and-place, CSV). "
+            "Positions match the .kicad_pcb. Needs the footprint libraries. "
+            "Read-only." + _DESIGN_ID_HINT
+        ),
+    )
+    def fab_cpl(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
+        return _run_fab_cpl(design, library)
 
 
 def _register_active_tools(


### PR DESCRIPTION
Per the redirect to **Agent + MCP polish**: extends both the in-process agent and the MCP server with coverage for the PCB + fab work that landed in 0.14.0 + the fab-outputs PR. An LLM agent (Anthropic API via `wirestudio.agent`, or Claude Desktop / Claude Code over MCP) can now drive **design → board → BOM / CPL / Gerber-status** end to end without falling back to the HTTP API.

## What lands
Five new shared `_run_*` helpers + Anthropic tool definitions in `wirestudio/agent/tools.py`, mirrored as `@mcp.tool` wrappers in `wirestudio/mcp/server.py`:

- `kicad_schematic` — emits the SKiDL Python script (small text, returned inline).
- `kicad_pcb` — emits the board and returns a **summary** (`footprints`, `nets`, `routed`, `size_bytes`) rather than the megabyte board text. The file still comes from `POST /design/kicad/pcb`.
- `fab_status` — server-side capability probe.
- `fab_bom` — pure JLCPCB BOM CSV.
- `fab_cpl` — JLCPCB CPL CSV (libs-gated).

Library-gated tools (`kicad_pcb`, `fab_cpl`) return `{ok: false, available: false, error: …}` cleanly when the server lacks the KiCad libraries — same pattern as render / `/design/kicad/pcb`.

## Verification
- 46 tests on `tests/test_agent.py` + `tests/test_mcp_server.py` (43 prior + 3 new always-on coverage tests).
- `kicad_pcb` smoke against `garage-motion` with libs: `{ok: true, footprints: 3, nets: 6, routed: false, size_bytes: 28347}`.
- Ruff clean.

## Out of scope (follow-up polish PRs)
- Agent system-prompt / payload trimming.
- Recommender quality pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)