### PR TITLE
release: 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-06-11
+
 ### Added
 
 - **Agent system payload slimmed (~10K tokens/turn) + `library_detail` tool.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent system payload slimmed (~10K tokens/turn) + `library_detail` tool.**
+  The agent's system block now carries a **compact library index**
+  (id / name / category / use_cases / aliases for components; id / name / mcu
+  for boards) instead of dumping every full pydantic model. The full card
+  (electrical metadata, `params_schema`, ESPHome template, KiCad block, pin
+  definitions) loads on demand via a new `library_detail` tool — exposed on
+  both the agent and the MCP server. Concrete win on 60 components: the
+  library block drops from ~178 KB / ~44,500 tokens to ~23 KB / ~5,900 tokens
+  per turn (**~87% reduction, ~38,600 tokens saved/turn**); the rest is
+  fetched only when the agent actually needs it. The prompt cache still
+  holds the slim block stable across turns.
 - **Agent + MCP tool coverage for PCB and fab outputs.** The agent's tool
   surface and the MCP server gain `kicad_schematic`, `kicad_pcb` (returns a
   summary, not the megabyte board text), `fab_status`, `fab_bom`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent + MCP tool coverage for PCB and fab outputs.** The agent's tool
+  surface and the MCP server gain `kicad_schematic`, `kicad_pcb` (returns a
+  summary, not the megabyte board text), `fab_status`, `fab_bom`, and
+  `fab_cpl` — so an agent (Claude Desktop / Claude Code over MCP, or the
+  Anthropic API agent) can now drive design → board → BOM/CPL/Gerber-status
+  end to end. Library-gated tools report `available: false` cleanly when the
+  server doesn't have the KiCad libraries.
 - **Fab outputs (Gerber / drill / CPL / BOM).** New `/design/fab/*` endpoints
   turn a design into a JLCPCB upload bundle: a **BOM** CSV (pure, grouped by
   part), a **CPL** pick-and-place CSV whose positions match the `.kicad_pcb`

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-c5148b8-lorawan
+    newTag: sha-4303af2-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-5afe1dc-lorawan
+    newTag: sha-2cd7f91-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-2cd7f91-lorawan
+    newTag: sha-c5148b8-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -404,3 +404,29 @@ def test_render_catches_exception(lib):
     body = json.loads(out)
     assert body["ok"] is False
     assert "error" in body
+
+
+def test_kicad_schematic_returns_a_skidl_script(lib, garage_motion_design):
+    out, is_error = execute_tool("kicad_schematic", {}, garage_motion_design, lib)
+    assert is_error is False
+    body = json.loads(out)
+    assert body["ok"] is True
+    assert "from skidl import" in body["script"]
+
+
+def test_fab_status_reports_what_is_available(lib):
+    out, is_error = execute_tool("fab_status", {}, {}, lib)
+    assert is_error is False
+    body = json.loads(out)
+    # BOM is always available; gerbers/cpl depend on the server's tools.
+    assert body["bom"] is True
+    assert set(body) >= {"bom", "cpl", "gerbers", "kicad_cli", "footprints", "reason"}
+
+
+def test_fab_bom_returns_csv(lib, garage_motion_design):
+    out, is_error = execute_tool("fab_bom", {}, garage_motion_design, lib)
+    assert is_error is False
+    body = json.loads(out)
+    assert body["ok"] is True
+    assert body["csv"].splitlines()[0].startswith("Comment,Designator,Footprint")
+    assert body["rows"] > 0

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -430,3 +430,41 @@ def test_fab_bom_returns_csv(lib, garage_motion_design):
     assert body["ok"] is True
     assert body["csv"].splitlines()[0].startswith("Comment,Designator,Footprint")
     assert body["rows"] > 0
+
+
+def test_library_detail_returns_full_card(lib):
+    """The slim system-prompt index leaves out electrical metadata + esphome
+    template; library_detail restores the full card on demand."""
+    out, is_error = execute_tool(
+        "library_detail", {"library_id": "bme280", "kind": "component"}, {}, lib,
+    )
+    assert is_error is False
+    body = json.loads(out)
+    assert body["ok"] is True
+    detail = body["detail"]
+    assert "electrical" in detail and "esphome" in detail
+    assert detail["id"] == "bme280"
+
+
+def test_library_detail_handles_unknown_id(lib):
+    out, is_error = execute_tool(
+        "library_detail", {"library_id": "no-such-thing", "kind": "component"}, {}, lib,
+    )
+    assert is_error is False  # graceful error, not a dispatcher error
+    body = json.loads(out)
+    assert body["ok"] is False
+    assert "error" in body
+
+
+def test_library_index_is_substantially_smaller_than_full_dump(lib):
+    """The system-prompt slim index is the big token win -- assert it stays
+    that way (< 25% of the size of a full library dump)."""
+    from wirestudio.agent.agent import _build_library_context
+
+    slim = _build_library_context(lib)
+    full_components = [c.model_dump() for c in lib.list_components()]
+    full_boards = [b.model_dump() for b in lib.list_boards()]
+    full_size = len(json.dumps({"boards": full_boards, "components": full_components}))
+    assert len(slim) < 0.25 * full_size, (
+        f"slim index ({len(slim)} chars) is not <25% of full dump ({full_size} chars)"
+    )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -19,6 +19,7 @@ pytestmark = pytest.mark.anyio
 EXPECTED_TOOLS = {
     "search_components",
     "list_boards",
+    "library_detail",
     "recommend",
     "render",
     "validate",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -29,6 +29,11 @@ EXPECTED_TOOLS = {
     "set_connection",
     "add_bus",
     "solve_pins",
+    "kicad_schematic",
+    "kicad_pcb",
+    "fab_status",
+    "fab_bom",
+    "fab_cpl",
     "set_active_design",
     "get_active_design",
 }

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/wirestudio/agent/agent.py
+++ b/wirestudio/agent/agent.py
@@ -40,7 +40,12 @@ rendered output update live. Be concise -- one or two sentences confirming \
 what you changed is plenty. Do not paste the YAML back at them unless asked.
 
 Conventions:
-- Never invent a `library_id`. Use `search_components` (or `list_boards`) first.
+- Never invent a `library_id`. Use the library index in the system block, \
+  `search_components`, or `list_boards` first.
+- The library block is a compact index (id / name / category / use_cases / \
+  aliases). For electrical metadata, `params_schema`, the ESPHome template, \
+  the KiCad block, or pin definitions, call `library_detail` once you've \
+  picked an id -- don't ask the user.
 - Prefer `add_component` over manually editing the design -- it auto-wires \
   rails by voltage match and bus pins to a matching bus.
 - After a non-trivial change, call `validate` once to make sure the design \
@@ -73,16 +78,41 @@ class TurnResult:
 
 
 def _build_library_context(library: Library) -> str:
-    """Dump the library to JSON. Stable across turns -> cacheable."""
-    boards = [b.model_dump() for b in library.list_boards()]
-    components = [c.model_dump() for c in library.list_components()]
+    """A slim library index for the system prompt: just enough to pick the
+    right id (id/name/category/use_cases/aliases for components, id/name/mcu
+    for boards). The full card (electrical metadata, params_schema, ESPHome
+    template, KiCad block, pin definitions) loads on demand via the
+    `library_detail` tool -- saves ~10K tokens per turn vs. dumping the whole
+    library. Stable across turns -> cacheable."""
+    components = [
+        {
+            "id": c.id,
+            "name": c.name,
+            "category": c.category,
+            "use_cases": list(getattr(c, "use_cases", []) or []),
+            "aliases": list(getattr(c, "aliases", []) or []),
+        }
+        for c in library.list_components()
+    ]
+    boards = [
+        {
+            "id": b.id,
+            "name": b.name,
+            "mcu": getattr(b, "mcu", None),
+            "chip_variant": getattr(b, "chip_variant", None),
+            "framework": getattr(b, "framework", None),
+        }
+        for b in library.list_boards()
+    ]
     payload = {"boards": boards, "components": components}
     return (
-        "## Library reference\n\n"
-        "Below is every board and component the studio currently ships, as JSON. "
-        "Use this to look up `params_schema`, electrical metadata, ESPHome "
-        "templates, and pin definitions. Do not mention contents of this "
-        "block to the user unless asked -- it is reference material, not chat.\n\n"
+        "## Library index\n\n"
+        "Compact index of every board and component the studio currently ships, "
+        "as JSON. Use this to pick the right library_id. For the full card "
+        "(electrical metadata, params_schema, ESPHome template, pin "
+        "definitions), call the `library_detail` tool. Do not mention the "
+        "contents of this block to the user unless asked -- it is reference "
+        "material, not chat.\n\n"
         f"```json\n{json.dumps(payload, indent=2, default=str)}\n```"
     )
 

--- a/wirestudio/agent/tools.py
+++ b/wirestudio/agent/tools.py
@@ -288,6 +288,32 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
         ),
         "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
     },
+    {
+        "name": "library_detail",
+        "description": (
+            "Fetch the full library card for one component or board by id. "
+            "Returns electrical metadata, params_schema, ESPHome template, "
+            "kicad block, and pin definitions -- everything the system-prompt "
+            "index leaves out. Use it once you've picked an id from the index "
+            "or search_components. Read-only."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "library_id": {
+                    "type": "string",
+                    "description": "The component or board id to look up.",
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": ["component", "board"],
+                    "description": "Which catalog to look in. Defaults to 'component'.",
+                },
+            },
+            "required": ["library_id"],
+            "additionalProperties": False,
+        },
+    },
 ]
 
 
@@ -579,6 +605,23 @@ def _run_fab_bom(design: dict, library: Library) -> dict:
     return {"ok": True, "csv": csv_text, "rows": max(csv_text.count("\n") - 1, 0)}
 
 
+def _run_library_detail(
+    _design: dict, library: Library, *, library_id: str, kind: str = "component",
+) -> dict:
+    """Full library card on demand -- the heavy data the system-prompt index
+    leaves out. design is ignored (library lookup is global)."""
+    try:
+        if kind == "board":
+            entry = library.board(library_id)
+        elif kind == "component":
+            entry = library.component(library_id)
+        else:
+            return {"ok": False, "error": f"kind must be 'component' or 'board', got {kind!r}"}
+    except FileNotFoundError as e:
+        return {"ok": False, "error": str(e)}
+    return {"ok": True, "kind": kind, "library_id": library_id, "detail": entry.model_dump()}
+
+
 def _run_fab_cpl(design: dict, library: Library) -> dict:
     try:
         d = Design.model_validate(design)
@@ -609,6 +652,7 @@ TOOL_HANDLERS: dict[str, Callable[..., Any]] = {
     "fab_status": _run_fab_status,
     "fab_bom": _run_fab_bom,
     "fab_cpl": _run_fab_cpl,
+    "library_detail": _run_library_detail,
 }
 
 

--- a/wirestudio/agent/tools.py
+++ b/wirestudio/agent/tools.py
@@ -7,6 +7,7 @@ never load files outside the library, and never execute user-provided code.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Callable
 
 from wirestudio.csp.compatibility import check_pin_compatibility
@@ -14,6 +15,9 @@ from wirestudio.csp.pin_solver import solve_pins as _solve_pins
 from wirestudio.designs.seed import add_component_with_connections
 from wirestudio.generate.ascii_gen import render_ascii
 from wirestudio.generate.yaml_gen import render_yaml
+from wirestudio.kicad import generate_skidl
+from wirestudio.kicad.fab import fab_status, generate_bom, generate_cpl
+from wirestudio.kicad.pcb import PcbUnavailable, generate_kicad_pcb
 from wirestudio.library import Library
 from wirestudio.model import Design
 from wirestudio.recommend.recommender import Constraints, recommend_components
@@ -235,6 +239,52 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
             "assignments made, any unresolved connections, and any "
             "conflict / current-budget warnings the solver detected. "
             "Mutates the design."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
+        "name": "kicad_schematic",
+        "description": (
+            "Emit the design's KiCad schematic as a SKiDL Python script. The "
+            "caller runs it locally (pip install skidl; python <design>.skidl.py) "
+            "to produce a .kicad_sch. Read-only."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
+        "name": "kicad_pcb",
+        "description": (
+            "Emit the design's KiCad .kicad_pcb board (footprints placed + nets "
+            "bound, no routing). Returns a summary (size_bytes, footprints, nets, "
+            "routed); the actual board file is downloaded via the "
+            "POST /design/kicad/pcb endpoint. Needs the KiCad libraries on the "
+            "server -- returns ok=false, available=false otherwise. Read-only."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
+        "name": "fab_status",
+        "description": (
+            "What fab outputs the server can produce: BOM is always available, "
+            "CPL needs the footprint libraries, Gerbers need kicad-cli. "
+            "Read-only."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
+        "name": "fab_bom",
+        "description": (
+            "Emit the design's JLCPCB BOM (CSV; grouped by part). Pure -- always "
+            "works. Returns the CSV text + row count. Read-only."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
+        "name": "fab_cpl",
+        "description": (
+            "Emit the design's JLCPCB CPL (pick-and-place, CSV); positions match "
+            "the .kicad_pcb. Needs the footprint libraries -- returns ok=false, "
+            "available=false otherwise. Read-only."
         ),
         "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
     },
@@ -483,6 +533,64 @@ def _run_validate(design: dict, library: Library) -> dict:
     }
 
 
+def _run_kicad_schematic(design: dict, library: Library) -> dict:
+    try:
+        d = Design.model_validate(design)
+    except Exception as e:
+        return {"ok": False, "error": f"design failed validation: {e}"}
+    try:
+        return {"ok": True, "script": generate_skidl(d, library)}
+    except (FileNotFoundError, ValueError) as e:
+        return {"ok": False, "error": str(e)}
+
+
+def _run_kicad_pcb(design: dict, library: Library) -> dict:
+    """Return a summary of the emitted board, not the megabyte board text."""
+    try:
+        d = Design.model_validate(design)
+    except Exception as e:
+        return {"ok": False, "error": f"design failed validation: {e}"}
+    try:
+        board = generate_kicad_pcb(d, library)
+    except PcbUnavailable as e:
+        return {"ok": False, "available": False, "error": str(e)}
+    except (FileNotFoundError, ValueError) as e:
+        return {"ok": False, "error": str(e)}
+    return {
+        "ok": True,
+        "size_bytes": len(board),
+        "footprints": board.count('(footprint "'),
+        "nets": len(re.findall(r'^\t\(net \d+ "', board, re.M)),
+        "routed": bool(re.search(r"\((?:segment|via)\b", board)),
+    }
+
+
+def _run_fab_status(_design: dict, _library: Library) -> dict:
+    """Server-side capability probe; the design/library are ignored."""
+    return fab_status()
+
+
+def _run_fab_bom(design: dict, library: Library) -> dict:
+    try:
+        d = Design.model_validate(design)
+    except Exception as e:
+        return {"ok": False, "error": f"design failed validation: {e}"}
+    csv_text = generate_bom(d, library)
+    return {"ok": True, "csv": csv_text, "rows": max(csv_text.count("\n") - 1, 0)}
+
+
+def _run_fab_cpl(design: dict, library: Library) -> dict:
+    try:
+        d = Design.model_validate(design)
+    except Exception as e:
+        return {"ok": False, "error": f"design failed validation: {e}"}
+    try:
+        csv_text = generate_cpl(d, library)
+    except PcbUnavailable as e:
+        return {"ok": False, "available": False, "error": str(e)}
+    return {"ok": True, "csv": csv_text, "rows": max(csv_text.count("\n") - 1, 0)}
+
+
 TOOL_HANDLERS: dict[str, Callable[..., Any]] = {
     "search_components": _run_search_components,
     "list_boards": _run_list_boards,
@@ -496,6 +604,11 @@ TOOL_HANDLERS: dict[str, Callable[..., Any]] = {
     "validate": _run_validate,
     "recommend": _run_recommend,
     "solve_pins": _run_solve_pins,
+    "kicad_schematic": _run_kicad_schematic,
+    "kicad_pcb": _run_kicad_pcb,
+    "fab_status": _run_fab_status,
+    "fab_bom": _run_fab_bom,
+    "fab_cpl": _run_fab_cpl,
 }
 
 

--- a/wirestudio/mcp/server.py
+++ b/wirestudio/mcp/server.py
@@ -28,6 +28,7 @@ from wirestudio.agent.tools import (
     _run_fab_status,
     _run_kicad_pcb,
     _run_kicad_schematic,
+    _run_library_detail,
     _run_list_boards,
     _run_recommend,
     _run_remove_component,
@@ -107,6 +108,19 @@ def _register_library_tools(mcp: FastMCP, library: Library) -> None:
             "excluded_categories) to filter before ranking."
         ),
     )
+    @mcp.tool(
+        name="library_detail",
+        description=(
+            "Fetch the full library card for one component or board by id: "
+            "electrical metadata, params_schema, ESPHome template, KiCad "
+            "block, pin definitions. Use after picking an id from the index, "
+            "search_components, or recommend. `kind` is 'component' (default) "
+            "or 'board'. Read-only."
+        ),
+    )
+    def library_detail(library_id: str, kind: str = "component") -> dict:
+        return _run_library_detail({}, library, library_id=library_id, kind=kind)
+
     def recommend(
         query: str,
         limit: int = 10,

--- a/wirestudio/mcp/server.py
+++ b/wirestudio/mcp/server.py
@@ -23,6 +23,11 @@ from mcp.server.fastmcp import FastMCP
 from wirestudio.agent.tools import (
     _run_add_bus,
     _run_add_component,
+    _run_fab_bom,
+    _run_fab_cpl,
+    _run_fab_status,
+    _run_kicad_pcb,
+    _run_kicad_schematic,
     _run_list_boards,
     _run_recommend,
     _run_remove_component,
@@ -350,6 +355,71 @@ def _register_design_tools(
         result = _run_solve_pins(design, library)
         _save(rid, design)
         return result
+
+    @mcp.tool(
+        name="kicad_schematic",
+        description=(
+            "Emit the named design's KiCad schematic as a SKiDL Python script. "
+            "Read-only." + _DESIGN_ID_HINT
+        ),
+    )
+    def kicad_schematic(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
+        return _run_kicad_schematic(design, library)
+
+    @mcp.tool(
+        name="kicad_pcb",
+        description=(
+            "Emit the named design's KiCad .kicad_pcb and return a summary "
+            "(size, footprints, nets, routed). The actual board file is "
+            "downloaded via POST /design/kicad/pcb. Needs the KiCad libraries "
+            "on the server. Read-only." + _DESIGN_ID_HINT
+        ),
+    )
+    def kicad_pcb(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
+        return _run_kicad_pcb(design, library)
+
+    @mcp.tool(
+        name="fab_status",
+        description=(
+            "What fab outputs the server can produce: BOM always; CPL needs "
+            "the footprint libraries; Gerbers need kicad-cli. Read-only."
+        ),
+    )
+    def fab_status_tool() -> dict:
+        return _run_fab_status({}, library)
+
+    @mcp.tool(
+        name="fab_bom",
+        description=(
+            "Emit the named design's JLCPCB BOM (CSV, grouped by part). "
+            "Read-only." + _DESIGN_ID_HINT
+        ),
+    )
+    def fab_bom(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
+        return _run_fab_bom(design, library)
+
+    @mcp.tool(
+        name="fab_cpl",
+        description=(
+            "Emit the named design's JLCPCB CPL (pick-and-place, CSV). "
+            "Positions match the .kicad_pcb. Needs the footprint libraries. "
+            "Read-only." + _DESIGN_ID_HINT
+        ),
+    )
+    def fab_cpl(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
+        return _run_fab_cpl(design, library)
 
 
 def _register_active_tools(


### PR DESCRIPTION
Cut **0.15.0** — promotes `dev` to `main`.

## Highlights
- **Fab outputs (Gerber / drill / CPL / BOM)** — `/design/fab/*` endpoints, deterministic BOM/CPL, `kicad-cli` Gerber path, and a one-zip JLCPCB upload bundle. Boards are placed-but-unrouted (Freerouting deferred), so the Gerbers carry pads but no traces; `is_routed`/`fab_status` flag that. Web KiCad export dialog gains a **Fab outputs** section.
- **Agent + MCP tool coverage for KiCad PCB + fab outputs** — `kicad_schematic`, `kicad_pcb` (summary), `fab_status`, `fab_bom`, `fab_cpl` exposed via both the in-process agent and the MCP server, so Claude Desktop / Claude Code can now drive design → board → BOM/CPL/Gerber-status end to end.
- **Agent system payload slimmed ~87%** (~38,600 tokens saved/turn) — system block carries a compact library index instead of dumping every full pydantic model; new `library_detail` tool fetches the heavy fields on demand. Prompt cache still holds the slim block stable across turns.
- **Web stability fixes via Bolt PRs #74 + #75** — broad memoization sweep (`App.tsx`, `ConnectionForm.tsx`, `CapabilityPickerDialog.tsx`) and a Rules-of-Hooks fix in the capability picker. The long-standing local `CapabilityPickerDialog` test failures are resolved.

All gates green on `dev`. Merging rebuilds `:main` → prod auto-rolls; the `v0.15.0` tag publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)