### PR TITLE
Promote dev → main: LoRaWAN OLED boot-loop fix + ttgo-lora32-v2 (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **LoRaWAN firmware no longer boot-loops on a misbehaving onboard OLED**
+  (issue #80). The generated `main.cpp` bounds each I2C transaction
+  (`Wire.setTimeOut`) and probes for an SSD1306 ACK before calling
+  `display.begin()`, so an absent or differently-wired OLED (seen on some
+  TTGO LoRa32 T3 v1.6.1 units) is treated as best-effort instead of wedging
+  the bus until the interrupt watchdog (`TG1WDT`) reboots the board. The
+  `loop()` display refresh is gated on an `oledReady` flag so it doesn't
+  retry a missing panel every iteration.
+
+### Added
+
+- **`ttgo-lora32-v2` board profile** (LilyGO LoRa32 V2.1 / "T3 v1.6.1"),
+  mapping to PlatformIO board `ttgo-lora32-v21`. Electrically identical to
+  `ttgo-lora32-v1`; the distinct profile lets the most common "TTGO LoRa32"
+  hardware select its matching board key.
+
 ## [0.15.0] — 2026-06-11
 
 ### Added

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-4303af2-lorawan
+    newTag: sha-0a0bb99-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-0a0bb99-lorawan
+    newTag: sha-3fa2d4b-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-3fa2d4b-lorawan
+    newTag: sha-c49e979-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/tests/test_firmware_gen.py
+++ b/tests/test_firmware_gen.py
@@ -68,6 +68,24 @@ def test_join_eui_substituted(lib):
     assert "0x70b3d57ed0000000ULL" in cpp
 
 
+def test_oled_init_is_probed_and_non_blocking(lib):
+    # The onboard SSD1306 must not be able to wedge boot: probe for an I2C
+    # ACK before display.begin(), and gate the loop() refresh on readiness
+    # (issue #80 -- a held-low SDA hung begin() into a TG1WDT reboot).
+    cpp = generate_firmware(_design("ttgo-lora32-v1"), lib)["src/main.cpp"]
+    assert "Wire.setTimeOut(50);" in cpp
+    assert "Wire.endTransmission() == 0 && display.begin(" in cpp
+    assert "if (oledReady) {" in cpp
+
+
+def test_ttgo_v2_uses_v21_platformio_board(lib):
+    # v2.1 (T3 v1.6.1) is electrically identical to v1 but maps to its own
+    # PlatformIO board key.
+    out = generate_firmware(_design("ttgo-lora32-v2"), lib)
+    assert "board = ttgo-lora32-v21" in out["platformio.ini"]
+    assert "SX1276 radio = new Module(18, 26, 23, RADIOLIB_NC);" in out["src/main.cpp"]
+
+
 def test_non_radio_board_raises(lib):
     with pytest.raises(ValueError, match="no radio"):
         generate_firmware(_design("esp32-devkitc-v4"), lib)

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -10,7 +10,8 @@ from wirestudio.targets import get_target, register, target_ids
 from wirestudio.targets.esphome import EsphomeTarget
 
 RADIO_BOARD_IDS = {
-    "ttgo-lora32-v1", "ttgo-t-beam", "heltec-wifi-lora32-v2", "heltec-wifi-lora32-v3",
+    "ttgo-lora32-v1", "ttgo-lora32-v2", "ttgo-t-beam",
+    "heltec-wifi-lora32-v2", "heltec-wifi-lora32-v3",
 }
 
 

--- a/wirestudio/library/boards/ttgo-lora32-v2.yaml
+++ b/wirestudio/library/boards/ttgo-lora32-v2.yaml
@@ -1,0 +1,101 @@
+id: ttgo-lora32-v2
+name: TTGO LoRa32 V2.1 (T3 v1.6.1)
+mcu: esp32
+chip_variant: esp32
+framework: arduino
+platformio_board: ttgo-lora32-v21
+flash_size_mb: 4
+
+rails:
+  - {name: "5V",  voltage: 5.0, source: usb}
+  - {name: "3V3", voltage: 3.3, source: onboard_regulator}
+  - {name: "GND", voltage: 0.0}
+
+# LilyGO LoRa32 V2.1 (silkscreen "T3 v1.6.1"). Onboard SX1276 LoRa radio +
+# SSD1306 OLED + LiPo charger. The radio + OLED pins are identical to the V1
+# (T3 v1.6); the distinct profile exists so the most common "TTGO LoRa32"
+# hardware maps to its matching PlatformIO board key (`ttgo-lora32-v21`)
+# rather than the V1 key. See issue #80 (OLED I2C init hang on this board).
+default_buses:
+  spi: {clk: GPIO5, miso: GPIO19, mosi: GPIO27}
+  i2c: {sda: GPIO21, scl: GPIO22}
+
+onboard_peripherals:
+  lora_sx1276: {cs: GPIO18, rst: GPIO23, dio0: GPIO26}
+  oled_ssd1306: {address: "0x3C", reset: GPIO16}
+  battery_adc:  {pin: GPIO35, divider: 2.0}
+  led:          {pin: GPIO25}
+
+# SX1276 on the shared SPI bus (clk/miso/mosi in default_buses). SX127x
+# uses dio0 for the TX-done/RX-done interrupt; no busy line.
+radio:
+  chip: sx1276
+  radiolib_class: SX1276
+  pins: {cs: GPIO18, rst: GPIO23, dio0: GPIO26}
+
+# Same ESP32 strap pin rules as the WROOM-32 boards. Note GPIO5 is also the
+# LoRa SCK on this board -- the boot_high requirement is satisfied at boot
+# before SPI takes over the line, so the design works in practice but
+# remains a fragile pattern worth surfacing.
+# ADC unit tags (`adc1` / `adc2`): see the legend in esp32-devkitc-v4.yaml.
+gpio_capabilities:
+  GPIO0:  [boot, strap, boot_high, adc, adc2]
+  GPIO1:  [gpio, uart_tx, serial_tx]
+  GPIO2:  [strap, gpio, boot_low, adc, adc2]
+  GPIO3:  [gpio, uart_rx, serial_rx]
+  GPIO4:  [gpio, adc, adc2, pwm]
+  GPIO5:  [gpio, spi_clk, boot_high]
+  GPIO12: [gpio, adc, adc2, strap, boot_low]
+  GPIO13: [gpio, adc, adc2, pwm]
+  GPIO14: [gpio, adc, adc2, pwm]
+  GPIO15: [gpio, adc, adc2, strap, boot_high]
+  GPIO16: [gpio, oled_reset]
+  GPIO17: [gpio]
+  GPIO18: [gpio, lora_cs]
+  GPIO19: [gpio, spi_miso]
+  GPIO21: [gpio, i2c_sda]
+  GPIO22: [gpio, i2c_scl]
+  GPIO23: [gpio, lora_rst]
+  GPIO25: [gpio, led, adc, adc2]
+  GPIO26: [gpio, lora_dio0, adc, adc2]
+  GPIO27: [gpio, spi_mosi, adc, adc2]
+  GPIO34: [gpio, adc, adc1, input_only, no_pull_internal]
+  GPIO35: [gpio, adc, adc1, input_only, battery_sense, no_pull_internal]
+  GPIO36: [gpio, adc, adc1, input_only, no_pull_internal]
+  GPIO39: [gpio, adc, adc1, input_only, no_pull_internal]
+
+# Enclosure geometry (mm). LilyGO LoRa32 V2.1 (T3 v1.6.1) -- same PCB
+# outline + mount-hole + port layout as the V1, with the onboard SSD1306
+# OLED on top and an SMA antenna on short_b (x=length).
+enclosure:
+  pcb:
+    length_mm: 50.5
+    width_mm: 25.5
+    thickness_mm: 1.6
+  mount_holes:
+    - {x_mm:  2.5,  y_mm:  2.5,  hole_diameter_mm: 3.2}
+    - {x_mm:  2.5,  y_mm: 23.0,  hole_diameter_mm: 3.2}
+    - {x_mm: 48.0,  y_mm:  2.5,  hole_diameter_mm: 3.2}
+    - {x_mm: 48.0,  y_mm: 23.0,  hole_diameter_mm: 3.2}
+  ports:
+    - kind: usb_micro
+      edge: short_a
+      offset_mm: 8.75
+      width_mm: 8.0
+      height_mm: 3.0
+      height_above_pcb_mm: 1.5
+    - kind: sma
+      edge: short_b
+      offset_mm: 12.75          # SMA centred on short_b
+      width_mm: 7.0             # SMA jack body
+      height_mm: 7.0
+      height_above_pcb_mm: 0.0  # rooted at PCB level
+  component_height_max_mm: 9.0
+# KiCad symbol mapping (0.9 schematic export). No dedicated TTGO LoRa32
+# symbol in kicad-symbols today; the user will likely want to replace
+# the generic header with a manufacturer footprint after import.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_02x18_Odd_Even
+  footprint: Connector_PinHeader_2.54mm:PinHeader_2x18_P2.54mm_Vertical
+  value: TTGO_LoRa32_V2

--- a/wirestudio/targets/lorawan/templates/main.cpp.j2
+++ b/wirestudio/targets/lorawan/templates/main.cpp.j2
@@ -51,6 +51,7 @@ float dhtHumidity = 0.0;
 {% if has_oled %}
 // Reset is pulsed explicitly in setup() (after Vext power-on), so pass -1 here.
 Adafruit_SSD1306 display(128, 64, &Wire, -1);
+bool oledReady = false;     // false when the OLED is absent/wedged; loop() skips it then
 {% endif %}
 
 // Pinned LoRaWAN parameters. The gateway is US915 sub-band 2; a mismatch makes
@@ -94,7 +95,15 @@ void setup() {
   digitalWrite({{ oled_reset }}, HIGH);
 {% endif %}
   Wire.begin({{ oled_sda }}, {{ oled_scl }});
-  if (display.begin(SSD1306_SWITCHCAPVCC, {{ oled_addr }})) {
+  Wire.setClock(400000);
+  Wire.setTimeOut(50);                  // ms; bound each I2C transaction (ESP32 core)
+  // A floating / held-low SDA (absent or differently-wired OLED, e.g. some
+  // TTGO LoRa32 T3 v1.6.1 units) would otherwise let display.begin() spin
+  // until the interrupt watchdog reboots the board (TG1WDT). Probe for an ACK
+  // first and only init when the OLED answers, so it's best-effort like radio.
+  Wire.beginTransmission({{ oled_addr }});
+  if (Wire.endTransmission() == 0 && display.begin(SSD1306_SWITCHCAPVCC, {{ oled_addr }})) {
+    oledReady = true;
     display.clearDisplay();
     display.setTextSize(1);
     display.setTextColor(SSD1306_WHITE);
@@ -102,7 +111,7 @@ void setup() {
     display.println("wirestudio");
     display.display();
   } else {
-    Serial.println("OLED init failed");
+    Serial.println("OLED absent or init failed; continuing without display");
   }
 {% endif %}
 
@@ -149,22 +158,24 @@ void loop() {
   while (GPSSerial.available()) gps.encode(GPSSerial.read());  // keep the fix current
 {% endif %}
 {% if has_oled %}
-  display.clearDisplay();
-  display.setCursor(0, 0);
+  if (oledReady) {
+    display.clearDisplay();
+    display.setCursor(0, 0);
 {% if has_gps %}
-  display.printf("Sats:%lu %s\n", (unsigned long) gps.satellites.value(),
-                 gps.location.isValid() ? "FIX" : "...");
-  display.printf("Lat: %.5f\n", gps.location.lat());
-  display.printf("Lon: %.5f\n", gps.location.lng());
+    display.printf("Sats:%lu %s\n", (unsigned long) gps.satellites.value(),
+                   gps.location.isValid() ? "FIX" : "...");
+    display.printf("Lat: %.5f\n", gps.location.lat());
+    display.printf("Lon: %.5f\n", gps.location.lng());
 {% endif %}
 {% if has_axp %}
-  display.printf("Batt: %u mV\n", batteryMv);
+    display.printf("Batt: %u mV\n", batteryMv);
 {% endif %}
 {% if has_dht %}
-  display.printf("Temp: %.1f C\n", dhtTempC);
+    display.printf("Temp: %.1f C\n", dhtTempC);
 {% endif %}
-  display.printf("LoRa: %s\n", node->isActivated() ? "joined" : "no join");
-  display.display();
+    display.printf("LoRa: %s\n", node->isActivated() ? "joined" : "no join");
+    display.display();
+  }
 {% endif %}
 
   static unsigned long lastTx = 0;


### PR DESCRIPTION
Promotes `dev` to `main`. Sole functional change since the last promotion is the LoRaWAN OLED fix (#80, PR #81):

- **Non-blocking onboard OLED init** — generated firmware bounds I2C transactions and probes for an SSD1306 ACK before `display.begin()`, so a wedged/absent OLED can no longer watchdog-reboot (`TG1WDT`) the board before LoRaWAN provisioning. Fixes the TTGO LoRa32 T3 v1.6.1 boot-loop.
- **`ttgo-lora32-v2` board profile** (PlatformIO `ttgo-lora32-v21`), OLED/radio wiring verified identical to the existing v1 profile.

All gates passed on PR #81. The `deploy/overlays/dev` line is the dev-only image-sha bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)