### PR TITLE
fix(lorawan): I2C bus recovery for onboard OLED + no-OLED board (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **LoRaWAN firmware no longer boot-loops on a misbehaving onboard OLED**
-  (issue #80). The generated `main.cpp` bounds each I2C transaction
-  (`Wire.setTimeOut`) and probes for an SSD1306 ACK before calling
-  `display.begin()`, so an absent or differently-wired OLED (seen on some
-  TTGO LoRa32 T3 v1.6.1 units) is treated as best-effort instead of wedging
-  the bus until the interrupt watchdog (`TG1WDT`) reboots the board. The
-  `loop()` display refresh is gated on an `oledReady` flag so it doesn't
-  retry a missing panel every iteration.
+  (issue #80). On some TTGO LoRa32 T3 v1.6.1 units the onboard SSD1306 holds
+  SDA low at boot, wedging I2C bring-up until the interrupt watchdog
+  (`TG1WDT`) reboots the board before LoRaWAN provisioning can run — and a
+  transaction timeout does not rescue a bus already stuck low. The generated
+  `main.cpp` now performs **I2C bus recovery** before `Wire.begin()` (clocks
+  SCL up to 9 times to release a stuck SDA, then issues a STOP), runs the
+  OLED bus at 100 kHz, probes for an ACK before `display.begin()`, and gates
+  the `loop()` display refresh on an `oledReady` flag. Bring-up emits flushed
+  serial breadcrumbs (`WS_OLED_DEBUG`) so any residual hang is pinpointable.
 
 ### Added
 
@@ -24,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mapping to PlatformIO board `ttgo-lora32-v21`. Electrically identical to
   `ttgo-lora32-v1`; the distinct profile lets the most common "TTGO LoRa32"
   hardware select its matching board key.
+- **`ttgo-lora32-v2-nooled` board profile** — same board with the onboard
+  OLED omitted, so the generator emits no display bring-up at all. A
+  guaranteed-boot escape hatch for units whose OLED wedges the I2C bus.
 
 ## [0.15.0] — 2026-06-11
 

--- a/tests/test_firmware_gen.py
+++ b/tests/test_firmware_gen.py
@@ -68,14 +68,27 @@ def test_join_eui_substituted(lib):
     assert "0x70b3d57ed0000000ULL" in cpp
 
 
-def test_oled_init_is_probed_and_non_blocking(lib):
-    # The onboard SSD1306 must not be able to wedge boot: probe for an I2C
-    # ACK before display.begin(), and gate the loop() refresh on readiness
-    # (issue #80 -- a held-low SDA hung begin() into a TG1WDT reboot).
+def test_oled_init_recovers_bus_and_is_non_blocking(lib):
+    # The onboard SSD1306 must not be able to wedge boot. A held-low SDA
+    # survives a transaction timeout, so recover the bus (clock SCL to release
+    # the slave) BEFORE Wire.begin(), then probe for an ACK before display
+    # init, and gate the loop() refresh on readiness (issue #80).
     cpp = generate_firmware(_design("ttgo-lora32-v1"), lib)["src/main.cpp"]
-    assert "Wire.setTimeOut(50);" in cpp
-    assert "Wire.endTransmission() == 0 && display.begin(" in cpp
+    assert "digitalRead(21) == LOW" in cpp  # bus-recovery checks a stuck SDA
+    assert "oledPresent = (Wire.endTransmission() == 0)" in cpp
+    assert "if (oledPresent && display.begin(" in cpp
     assert "if (oledReady) {" in cpp
+
+
+def test_nooled_board_emits_no_oled_code(lib):
+    # The OLED-disabled board profile must generate firmware with no display
+    # bring-up at all (issue #80 escape hatch).
+    out = generate_firmware(_design("ttgo-lora32-v2-nooled"), lib)
+    cpp = out["src/main.cpp"]
+    assert "display.begin(" not in cpp
+    assert "Adafruit_SSD1306" not in cpp
+    assert "board = ttgo-lora32-v21" in out["platformio.ini"]
+    assert "Adafruit SSD1306" not in out["platformio.ini"]  # lib dep dropped too
 
 
 def test_ttgo_v2_uses_v21_platformio_board(lib):

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -10,7 +10,7 @@ from wirestudio.targets import get_target, register, target_ids
 from wirestudio.targets.esphome import EsphomeTarget
 
 RADIO_BOARD_IDS = {
-    "ttgo-lora32-v1", "ttgo-lora32-v2", "ttgo-t-beam",
+    "ttgo-lora32-v1", "ttgo-lora32-v2", "ttgo-lora32-v2-nooled", "ttgo-t-beam",
     "heltec-wifi-lora32-v2", "heltec-wifi-lora32-v3",
 }
 

--- a/wirestudio/library/boards/ttgo-lora32-v2-nooled.yaml
+++ b/wirestudio/library/boards/ttgo-lora32-v2-nooled.yaml
@@ -1,0 +1,98 @@
+id: ttgo-lora32-v2-nooled
+name: TTGO LoRa32 V2.1 (T3 v1.6.1, OLED disabled)
+mcu: esp32
+chip_variant: esp32
+framework: arduino
+platformio_board: ttgo-lora32-v21
+flash_size_mb: 4
+
+rails:
+  - {name: "5V",  voltage: 5.0, source: usb}
+  - {name: "3V3", voltage: 3.3, source: onboard_regulator}
+  - {name: "GND", voltage: 0.0}
+
+# Same LilyGO LoRa32 V2.1 / T3 v1.6.1 as ttgo-lora32-v2, but with the onboard
+# SSD1306 OLED deliberately NOT declared, so the lorawan generator emits no
+# OLED bring-up at all (has_oled is false). Escape hatch for units whose OLED
+# wedges the I2C bus at boot and watchdog-reboots the device (issue #80): the
+# radio + provisioning path is unaffected, you just lose the on-board display.
+default_buses:
+  spi: {clk: GPIO5, miso: GPIO19, mosi: GPIO27}
+  i2c: {sda: GPIO21, scl: GPIO22}
+
+onboard_peripherals:
+  lora_sx1276: {cs: GPIO18, rst: GPIO23, dio0: GPIO26}
+  battery_adc:  {pin: GPIO35, divider: 2.0}
+  led:          {pin: GPIO25}
+
+# SX1276 on the shared SPI bus (clk/miso/mosi in default_buses). SX127x
+# uses dio0 for the TX-done/RX-done interrupt; no busy line.
+radio:
+  chip: sx1276
+  radiolib_class: SX1276
+  pins: {cs: GPIO18, rst: GPIO23, dio0: GPIO26}
+
+# Same ESP32 strap pin rules as the WROOM-32 boards. Note GPIO5 is also the
+# LoRa SCK on this board -- the boot_high requirement is satisfied at boot
+# before SPI takes over the line, so the design works in practice but
+# remains a fragile pattern worth surfacing.
+# ADC unit tags (`adc1` / `adc2`): see the legend in esp32-devkitc-v4.yaml.
+gpio_capabilities:
+  GPIO0:  [boot, strap, boot_high, adc, adc2]
+  GPIO1:  [gpio, uart_tx, serial_tx]
+  GPIO2:  [strap, gpio, boot_low, adc, adc2]
+  GPIO3:  [gpio, uart_rx, serial_rx]
+  GPIO4:  [gpio, adc, adc2, pwm]
+  GPIO5:  [gpio, spi_clk, boot_high]
+  GPIO12: [gpio, adc, adc2, strap, boot_low]
+  GPIO13: [gpio, adc, adc2, pwm]
+  GPIO14: [gpio, adc, adc2, pwm]
+  GPIO15: [gpio, adc, adc2, strap, boot_high]
+  GPIO16: [gpio]
+  GPIO17: [gpio]
+  GPIO18: [gpio, lora_cs]
+  GPIO19: [gpio, spi_miso]
+  GPIO21: [gpio, i2c_sda]
+  GPIO22: [gpio, i2c_scl]
+  GPIO23: [gpio, lora_rst]
+  GPIO25: [gpio, led, adc, adc2]
+  GPIO26: [gpio, lora_dio0, adc, adc2]
+  GPIO27: [gpio, spi_mosi, adc, adc2]
+  GPIO34: [gpio, adc, adc1, input_only, no_pull_internal]
+  GPIO35: [gpio, adc, adc1, input_only, battery_sense, no_pull_internal]
+  GPIO36: [gpio, adc, adc1, input_only, no_pull_internal]
+  GPIO39: [gpio, adc, adc1, input_only, no_pull_internal]
+
+# Enclosure geometry (mm). Same PCB outline as ttgo-lora32-v2.
+enclosure:
+  pcb:
+    length_mm: 50.5
+    width_mm: 25.5
+    thickness_mm: 1.6
+  mount_holes:
+    - {x_mm:  2.5,  y_mm:  2.5,  hole_diameter_mm: 3.2}
+    - {x_mm:  2.5,  y_mm: 23.0,  hole_diameter_mm: 3.2}
+    - {x_mm: 48.0,  y_mm:  2.5,  hole_diameter_mm: 3.2}
+    - {x_mm: 48.0,  y_mm: 23.0,  hole_diameter_mm: 3.2}
+  ports:
+    - kind: usb_micro
+      edge: short_a
+      offset_mm: 8.75
+      width_mm: 8.0
+      height_mm: 3.0
+      height_above_pcb_mm: 1.5
+    - kind: sma
+      edge: short_b
+      offset_mm: 12.75          # SMA centred on short_b
+      width_mm: 7.0             # SMA jack body
+      height_mm: 7.0
+      height_above_pcb_mm: 0.0  # rooted at PCB level
+  component_height_max_mm: 9.0
+# KiCad symbol mapping (0.9 schematic export). No dedicated TTGO LoRa32
+# symbol in kicad-symbols today; the user will likely want to replace
+# the generic header with a manufacturer footprint after import.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_02x18_Odd_Even
+  footprint: Connector_PinHeader_2.54mm:PinHeader_2x18_P2.54mm_Vertical
+  value: TTGO_LoRa32_V2_NoOLED

--- a/wirestudio/targets/lorawan/templates/main.cpp.j2
+++ b/wirestudio/targets/lorawan/templates/main.cpp.j2
@@ -52,6 +52,15 @@ float dhtHumidity = 0.0;
 // Reset is pulsed explicitly in setup() (after Vext power-on), so pass -1 here.
 Adafruit_SSD1306 display(128, 64, &Wire, -1);
 bool oledReady = false;     // false when the OLED is absent/wedged; loop() skips it then
+// Serial breadcrumbs through OLED bring-up: each step prints + flushes before it
+// runs, so a hang shows up as "the last line you saw". Flip to 0 once the
+// bus-recovery path is confirmed on the target hardware.
+#define WS_OLED_DEBUG 1
+#if WS_OLED_DEBUG
+#define WSDBG(msg) do { Serial.println(msg); Serial.flush(); delay(5); } while (0)
+#else
+#define WSDBG(msg) do {} while (0)
+#endif
 {% endif %}
 
 // Pinned LoRaWAN parameters. The gateway is US915 sub-band 2; a mismatch makes
@@ -94,15 +103,38 @@ void setup() {
   digitalWrite({{ oled_reset }}, LOW);  delay(20);
   digitalWrite({{ oled_reset }}, HIGH);
 {% endif %}
+  // I2C bus recovery BEFORE handing the pins to Wire. An onboard SSD1306 that
+  // came up half-initialised can hold SDA low; that wedges Wire.begin() / the
+  // first transaction long enough to trip the interrupt watchdog (TG1WDT), and
+  // a transaction timeout does NOT rescue a bus already stuck low (this is why
+  // the earlier probe-with-timeout still boot-looped). Clock SCL up to 9 times
+  // to let the slave finish its byte and release SDA, then issue a STOP.
+  WSDBG("oled: bus-recover");
+  pinMode({{ oled_sda }}, INPUT_PULLUP);
+  pinMode({{ oled_scl }}, INPUT_PULLUP);
+  delay(1);
+  if (digitalRead({{ oled_sda }}) == LOW) {
+    pinMode({{ oled_scl }}, OUTPUT);
+    for (int i = 0; i < 9 && digitalRead({{ oled_sda }}) == LOW; i++) {
+      digitalWrite({{ oled_scl }}, LOW);  delayMicroseconds(5);
+      digitalWrite({{ oled_scl }}, HIGH); delayMicroseconds(5);
+    }
+    pinMode({{ oled_sda }}, OUTPUT);        // STOP: SDA low->high while SCL high
+    digitalWrite({{ oled_sda }}, LOW);  delayMicroseconds(5);
+    digitalWrite({{ oled_scl }}, HIGH); delayMicroseconds(5);
+    digitalWrite({{ oled_sda }}, HIGH); delayMicroseconds(5);
+    pinMode({{ oled_sda }}, INPUT_PULLUP);
+    pinMode({{ oled_scl }}, INPUT_PULLUP);
+  }
+  WSDBG("oled: wire-begin");
   Wire.begin({{ oled_sda }}, {{ oled_scl }});
-  Wire.setClock(400000);
-  Wire.setTimeOut(50);                  // ms; bound each I2C transaction (ESP32 core)
-  // A floating / held-low SDA (absent or differently-wired OLED, e.g. some
-  // TTGO LoRa32 T3 v1.6.1 units) would otherwise let display.begin() spin
-  // until the interrupt watchdog reboots the board (TG1WDT). Probe for an ACK
-  // first and only init when the OLED answers, so it's best-effort like radio.
+  Wire.setClock(100000);                 // 100 kHz: most tolerant of marginal onboard wiring
+  Wire.setTimeOut(50);                   // ms; bound each I2C transaction (ESP32 core)
+  WSDBG("oled: probe");
   Wire.beginTransmission({{ oled_addr }});
-  if (Wire.endTransmission() == 0 && display.begin(SSD1306_SWITCHCAPVCC, {{ oled_addr }})) {
+  bool oledPresent = (Wire.endTransmission() == 0);
+  WSDBG(oledPresent ? "oled: present" : "oled: absent");
+  if (oledPresent && display.begin(SSD1306_SWITCHCAPVCC, {{ oled_addr }})) {
     oledReady = true;
     display.clearDisplay();
     display.setTextSize(1);
@@ -113,6 +145,7 @@ void setup() {
   } else {
     Serial.println("OLED absent or init failed; continuing without display");
   }
+  WSDBG("oled: done");
 {% endif %}
 
   int16_t state = radio.begin();


### PR DESCRIPTION
Follow-up to #81. That fix (probe + `Wire.setTimeOut`) was verified deployed to dev (the compiled binary in the pod's firmware cache contained the new code path), but the TTGO LoRa32 T3 v1.6.1 **still boot-looped** — resetting right after the banner *without* printing "OLED absent…". The probe transaction itself wedged: a transaction timeout does not rescue an I2C bus an onboard SSD1306 is holding **low** at boot.

## Changes

- **I2C bus recovery before `Wire.begin()`** in `main.cpp.j2`: clock SCL up to 9 times to let a slave release a stuck SDA, then issue a STOP. This is the standard remedy for the ESP32 "stuck I2C bus" boot hang.
- OLED bus dropped to **100 kHz**, probe + `oledReady` gating retained.
- **Serial breadcrumbs** (`WS_OLED_DEBUG`, on by default): each bring-up step prints + flushes before it runs, so a residual hang is identifiable as "the last line you saw" (`oled: bus-recover` → `wire-begin` → `probe` → `present`/`absent` → `done`).
- **`ttgo-lora32-v2-nooled` board profile**: same V2.1 board with the OLED omitted → `has_oled` false → no display bring-up generated. Guaranteed-boot escape hatch.

## Tests / gates (local)
- `test_firmware_gen.py`: assert bus-recovery (`digitalRead(21) == LOW`), probe, and `oledReady` gating render; assert the no-OLED board emits no `display.begin`/`Adafruit_SSD1306` and drops the SSD1306 lib dep.
- `test_targets.py`: no-OLED board added to the lorawan radio-board set.
- `coverage_matrix.py --strict` OK; `ruff` clean.

After merge, dev rebuilds `:dev-lorawan`; flashing the **v2** board exercises the recovery path (keeps the display if it works; markers pinpoint it if not), and **v2-nooled** is the guaranteed-boot fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)