### PR TITLE
fix(lorawan): drop GPIO16 OLED reset on TTGO LoRa32 (real #80 root cause)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **LoRaWAN firmware no longer boot-loops on a misbehaving onboard OLED**
-  (issue #80). The generated `main.cpp` bounds each I2C transaction
-  (`Wire.setTimeOut`) and probes for an SSD1306 ACK before calling
-  `display.begin()`, so an absent or differently-wired OLED (seen on some
-  TTGO LoRa32 T3 v1.6.1 units) is treated as best-effort instead of wedging
-  the bus until the interrupt watchdog (`TG1WDT`) reboots the board. The
-  `loop()` display refresh is gated on an `oledReady` flag so it doesn't
-  retry a missing panel every iteration.
+- **LoRaWAN firmware boot-loop on TTGO LoRa32 (issue #80).** The TTGO
+  `ttgo-lora32-v1`/`-v2` profiles declared the onboard SSD1306 reset on
+  GPIO16. On these boards driving GPIO16 in the reset pulse wedges the chip
+  at boot — *before* `Wire.begin()` — so the interrupt watchdog reboots it in
+  a loop (`TG1WDT`), confirmed on hardware by serial bisection. The reset pin
+  is dropped from both profiles (the template already skips the pulse when no
+  reset pin is set; the SSD1306 self-resets on power-up). Heltec profiles keep
+  their GPIO reset, which is correct there. The generated `main.cpp` also
+  bounds the I2C bring-up (`Wire.setTimeOut` + ACK probe before
+  `display.begin()`, `loop()` gated on `oledReady`) so an absent or
+  differently-wired panel degrades gracefully rather than hanging.
 
 ### Added
 

--- a/tests/test_firmware_gen.py
+++ b/tests/test_firmware_gen.py
@@ -78,6 +78,20 @@ def test_oled_init_is_probed_and_non_blocking(lib):
     assert "if (oledReady) {" in cpp
 
 
+def test_ttgo_omits_gpio16_oled_reset_pulse(lib):
+    # issue #80 root cause: driving GPIO16 as the OLED reset wedges the chip at
+    # boot on TTGO LoRa32, before Wire.begin(). The TTGO profiles carry no OLED
+    # reset pin, so no reset pulse is emitted -- but the OLED is still used.
+    for board in ("ttgo-lora32-v1", "ttgo-lora32-v2"):
+        cpp = generate_firmware(_design(board), lib)["src/main.cpp"]
+        assert "pinMode(16, OUTPUT)" not in cpp, board
+        assert "explicit reset pulse" not in cpp, board
+        assert "display.begin(" in cpp, board  # OLED still driven, just no reset
+    # Heltec keeps its GPIO16 reset -- correct/required on that board.
+    heltec = generate_firmware(_design("heltec-wifi-lora32-v2"), lib)["src/main.cpp"]
+    assert "pinMode(16, OUTPUT)" in heltec
+
+
 def test_ttgo_v2_uses_v21_platformio_board(lib):
     # v2.1 (T3 v1.6.1) is electrically identical to v1 but maps to its own
     # PlatformIO board key.

--- a/wirestudio/library/boards/ttgo-lora32-v1.yaml
+++ b/wirestudio/library/boards/ttgo-lora32-v1.yaml
@@ -19,7 +19,12 @@ default_buses:
 
 onboard_peripherals:
   lora_sx1276: {cs: GPIO18, rst: GPIO23, dio0: GPIO26}
-  oled_ssd1306: {address: "0x3C", reset: GPIO16}
+  # No OLED reset pin. GPIO16 is not a safe reset line on these TTGO LoRa32
+  # boards: driving it in the reset pulse wedges the chip at boot (hangs before
+  # Wire.begin, so the watchdog reboots -> TG1WDT loop). The SSD1306 self-resets
+  # on power-up and works without it. (Heltec boards DO need their GPIO reset;
+  # this is TTGO-specific.)
+  oled_ssd1306: {address: "0x3C"}
   battery_adc:  {pin: GPIO35, divider: 2.0}
   led:          {pin: GPIO25}
 

--- a/wirestudio/library/boards/ttgo-lora32-v2.yaml
+++ b/wirestudio/library/boards/ttgo-lora32-v2.yaml
@@ -22,7 +22,12 @@ default_buses:
 
 onboard_peripherals:
   lora_sx1276: {cs: GPIO18, rst: GPIO23, dio0: GPIO26}
-  oled_ssd1306: {address: "0x3C", reset: GPIO16}
+  # No OLED reset pin. GPIO16 is not a safe reset line on the T3 v1.6.1: driving
+  # it in the reset pulse wedges the chip at boot (hangs before Wire.begin, so
+  # the watchdog reboots -> TG1WDT loop). The SSD1306 self-resets on power-up
+  # and works without it. (Heltec boards DO need their GPIO reset; this is
+  # TTGO-specific.)
+  oled_ssd1306: {address: "0x3C"}
   battery_adc:  {pin: GPIO35, divider: 2.0}
   led:          {pin: GPIO25}
 


### PR DESCRIPTION
## Root cause (follow-up to #80 / #81)
#81 hardened `display.begin()` with a bus probe + I2C timeout, but the T3 v1.6.1 boot-loop survived it. Per-line serial markers localized the hang **earlier in the OLED block** — the device prints `oled-enter` and never reaches `pre-wire-begin`. The only code there is the **OLED reset pulse driving GPIO16**:

```cpp
pinMode(16, OUTPUT);
digitalWrite(16, HIGH); delay(1);
digitalWrite(16, LOW);  delay(20);
digitalWrite(16, HIGH);
```

Driving GPIO16 wedges the chip *before* `Wire.begin()`/`display.begin()` ever run → interrupt watchdog reboot (`rst:0x8 TG1WDT_SYS_RESET`) → loop. That's why the `display.begin()`-focused fix couldn't help.

## Fix
GPIO16 is not a safe OLED-reset line on these TTGO LoRa32 boards, and the SSD1306 self-resets on power-up, so the pulse is unnecessary. **Remove the `reset:` pin from the `ttgo-lora32-v1` and `ttgo-lora32-v2` onboard OLED**, so the template's `{% if oled_reset is not none %}` reset block is skipped. The rest of the OLED init (probe + bounded `display.begin()`) is unchanged and still best-effort.

Heltec profiles (`heltec-wifi-lora32-v2/v3`) keep their GPIO reset — it's correct and required there. This is TTGO-specific.

## Verification
Confirmed on hardware (T3 v1.6.1): with the reset pulse skipped, the device boots through the OLED block and reaches LoRaWAN serial provisioning + ChirpStack join. No more TG1WDT loop.

Reopens the real fix for #80.