### PR TITLE
Promote dev → main: real TTGO LoRa32 OLED boot-loop fix (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **LoRaWAN firmware no longer boot-loops on a misbehaving onboard OLED**
-  (issue #80). The generated `main.cpp` bounds each I2C transaction
-  (`Wire.setTimeOut`) and probes for an SSD1306 ACK before calling
-  `display.begin()`, so an absent or differently-wired OLED (seen on some
-  TTGO LoRa32 T3 v1.6.1 units) is treated as best-effort instead of wedging
-  the bus until the interrupt watchdog (`TG1WDT`) reboots the board. The
-  `loop()` display refresh is gated on an `oledReady` flag so it doesn't
-  retry a missing panel every iteration.
+- **LoRaWAN firmware boot-loop on TTGO LoRa32 (issue #80).** The TTGO
+  `ttgo-lora32-v1`/`-v2` profiles declared the onboard SSD1306 reset on
+  GPIO16. On these boards driving GPIO16 in the reset pulse wedges the chip
+  at boot — *before* `Wire.begin()` — so the interrupt watchdog reboots it in
+  a loop (`TG1WDT`), confirmed on hardware by serial bisection. The reset pin
+  is dropped from both profiles (the template already skips the pulse when no
+  reset pin is set; the SSD1306 self-resets on power-up). Heltec profiles keep
+  their GPIO reset, which is correct there. The generated `main.cpp` also
+  bounds the I2C bring-up (`Wire.setTimeOut` + ACK probe before
+  `display.begin()`, `loop()` gated on `oledReady`) so an absent or
+  differently-wired panel degrades gracefully rather than hanging.
 
 ### Added
 

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-c49e979-lorawan
+    newTag: sha-748f84c-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-748f84c-lorawan
+    newTag: sha-2669987-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/tests/test_firmware_gen.py
+++ b/tests/test_firmware_gen.py
@@ -78,6 +78,20 @@ def test_oled_init_is_probed_and_non_blocking(lib):
     assert "if (oledReady) {" in cpp
 
 
+def test_ttgo_omits_gpio16_oled_reset_pulse(lib):
+    # issue #80 root cause: driving GPIO16 as the OLED reset wedges the chip at
+    # boot on TTGO LoRa32, before Wire.begin(). The TTGO profiles carry no OLED
+    # reset pin, so no reset pulse is emitted -- but the OLED is still used.
+    for board in ("ttgo-lora32-v1", "ttgo-lora32-v2"):
+        cpp = generate_firmware(_design(board), lib)["src/main.cpp"]
+        assert "pinMode(16, OUTPUT)" not in cpp, board
+        assert "explicit reset pulse" not in cpp, board
+        assert "display.begin(" in cpp, board  # OLED still driven, just no reset
+    # Heltec keeps its GPIO16 reset -- correct/required on that board.
+    heltec = generate_firmware(_design("heltec-wifi-lora32-v2"), lib)["src/main.cpp"]
+    assert "pinMode(16, OUTPUT)" in heltec
+
+
 def test_ttgo_v2_uses_v21_platformio_board(lib):
     # v2.1 (T3 v1.6.1) is electrically identical to v1 but maps to its own
     # PlatformIO board key.

--- a/wirestudio/library/boards/ttgo-lora32-v1.yaml
+++ b/wirestudio/library/boards/ttgo-lora32-v1.yaml
@@ -19,7 +19,12 @@ default_buses:
 
 onboard_peripherals:
   lora_sx1276: {cs: GPIO18, rst: GPIO23, dio0: GPIO26}
-  oled_ssd1306: {address: "0x3C", reset: GPIO16}
+  # No OLED reset pin. GPIO16 is not a safe reset line on these TTGO LoRa32
+  # boards: driving it in the reset pulse wedges the chip at boot (hangs before
+  # Wire.begin, so the watchdog reboots -> TG1WDT loop). The SSD1306 self-resets
+  # on power-up and works without it. (Heltec boards DO need their GPIO reset;
+  # this is TTGO-specific.)
+  oled_ssd1306: {address: "0x3C"}
   battery_adc:  {pin: GPIO35, divider: 2.0}
   led:          {pin: GPIO25}
 

--- a/wirestudio/library/boards/ttgo-lora32-v2.yaml
+++ b/wirestudio/library/boards/ttgo-lora32-v2.yaml
@@ -22,7 +22,12 @@ default_buses:
 
 onboard_peripherals:
   lora_sx1276: {cs: GPIO18, rst: GPIO23, dio0: GPIO26}
-  oled_ssd1306: {address: "0x3C", reset: GPIO16}
+  # No OLED reset pin. GPIO16 is not a safe reset line on the T3 v1.6.1: driving
+  # it in the reset pulse wedges the chip at boot (hangs before Wire.begin, so
+  # the watchdog reboots -> TG1WDT loop). The SSD1306 self-resets on power-up
+  # and works without it. (Heltec boards DO need their GPIO reset; this is
+  # TTGO-specific.)
+  oled_ssd1306: {address: "0x3C"}
   battery_adc:  {pin: GPIO35, divider: 2.0}
   led:          {pin: GPIO25}
 


### PR DESCRIPTION
Promotes `dev` to `main` (parity, per the #82 flow). Brings the hardware-verified root-cause fix for the TTGO LoRa32 LoRaWAN boot-loop (#80) into `main`:

- **#84** — drop the GPIO16 OLED `reset:` pin from `ttgo-lora32-v1`/`-v2`. Driving GPIO16 in the reset pulse wedges the chip at boot, *before* `Wire.begin()` (`TG1WDT` loop), confirmed on hardware by serial bisection. The SSD1306 self-resets on power-up; Heltec keeps its reset (correct there). Regression test added.
- Earlier in this cycle (#81): I2C bring-up hardened (`Wire.setTimeOut` + ACK probe + `oledReady` gating) for graceful degradation, and the `ttgo-lora32-v2` profile (`ttgo-lora32-v21`).

Note: prod runs the lean `:main` image (no PlatformIO), so this lands the corrected board profiles/codegen in `main` but does not by itself make prod able to *compile/flash* — that remains the separate lean-vs-worker image decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)