### PR TITLE
feat(lorawan): getHaDeviceInfo codec for Home Assistant entities + GPS tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mapping to PlatformIO board `ttgo-lora32-v21`. Electrically identical to
   `ttgo-lora32-v1`; the distinct profile lets the most common "TTGO LoRa32"
   hardware select its matching board key.
+- **Home Assistant entities from the LoRaWAN codec.** The generated ChirpStack
+  codec now includes a `getHaDeviceInfo()` block alongside `decodeUplink`, so
+  the [chirp2mqtt](https://github.com/modrisb/chirp) HA integration publishes
+  MQTT-discovery entities for every payload field — temperature, humidity,
+  battery (mV→V), GPS, link quality (RSSI/SNR) — with proper `device_class`/
+  unit/`state_class`. GPS payloads (lat+lon) additionally emit a
+  `device_tracker` whose latitude/longitude attributes drive the HA map. Each
+  payload `Field` carries optional `ha_*` hints driving this. ChirpStack device
+  profiles are also created with `auto_detect_measurements` enabled for
+  ChirpStack's own metrics dashboards.
 
 ## [0.15.0] — 2026-06-11
 

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -80,3 +80,33 @@ def test_pack_cpp_matches_size_and_reads_sensors():
     assert f"payload[{codec.payload_size(fields) - 1}]" in cpp
     assert "gps.location.lat()" in cpp
     assert "batteryMv" in cpp
+
+
+def test_generate_codec_includes_decode_and_ha_device_info():
+    js = codec.generate_codec(_design("ttgo-t-beam"), default_library())
+    assert "function decodeUplink(input)" in js
+    assert "function getHaDeviceInfo()" in js
+
+
+def test_ha_device_info_entities_and_units():
+    lib = default_library()
+    js = codec.generate_codec(_design("ttgo-t-beam", dht22={"pin": "GPIO13"}), lib)
+    # payload fields become entities with proper templates/units
+    assert 'value_template: "{{ value_json.object.temp_c | float }}"' in js
+    assert 'device_class: "temperature"' in js
+    # battery is converted mV -> V in the HA template
+    assert "(value_json.object.batt_mv | float) / 1000" in js
+    assert 'device_class: "voltage"' in js
+    # link quality from rxInfo (not payload)
+    assert "value_json.rxInfo[-1].rssi | int" in js
+
+
+def test_ha_device_info_gps_emits_device_tracker():
+    lib = default_library()
+    gps_js = codec.generate_codec(_design("ttgo-t-beam"), lib)  # onboard GPS
+    assert 'integration: "device_tracker"' in gps_js
+    assert "'latitude': value_json.object.lat" in gps_js
+    assert 'json_attributes_topic: "{status_topic}"' in gps_js
+    # a non-GPS board gets no device_tracker
+    plain_js = codec.generate_codec(_design("ttgo-lora32-v1"), lib)
+    assert "device_tracker" not in plain_js

--- a/wirestudio/targets/lorawan/chirpstack.py
+++ b/wirestudio/targets/lorawan/chirpstack.py
@@ -215,6 +215,10 @@ class ChirpStackClient:
             adr_algorithm_id="default",
             supports_otaa=True,
             uplink_interval=3600,
+            # Let ChirpStack register decoded payload keys as measurements (for
+            # its own metrics dashboards). The chirp2mqtt HA integration reads
+            # entities from the codec's getHaDeviceInfo, independent of this.
+            auto_detect_measurements=True,
         )
         if codec is not None:
             profile.payload_codec_runtime = m.dp.CodecRuntime.JS

--- a/wirestudio/targets/lorawan/codec.py
+++ b/wirestudio/targets/lorawan/codec.py
@@ -22,12 +22,22 @@ class Field(TypedDict, total=False):
     cpp_expr: str  # C++ expression yielding the value (assigned to a temp, then packed)
     signed: bool   # default False; affects codec sign-extension
     scale: float   # default 1; codec divides the decoded int by this (e.g. 1e7 for degrees)
+    # Home Assistant entity hints, consumed by `getHaDeviceInfo` (the chirp2mqtt
+    # integration reads them to publish MQTT-discovery entities). All optional.
+    ha_device_class: str   # HA device_class (e.g. "temperature", "voltage")
+    ha_unit: str           # unit_of_measurement
+    ha_state_class: str    # e.g. "measurement"
+    ha_diagnostic: bool    # entity_category=diagnostic
+    ha_icon: str           # mdi icon
+    ha_divide: float       # divide the (already decoded) value in the HA template
 
 
 # Always present on every LoRaWAN build. Big-endian.
 BUILTIN_FIELDS: list[Field] = [
-    {"name": "uptime_s", "bytes": 4, "cpp_type": "uint32_t", "cpp_expr": "(uint32_t)(millis() / 1000UL)"},
-    {"name": "boot_count", "bytes": 2, "cpp_type": "uint16_t", "cpp_expr": "bootCount"},
+    {"name": "uptime_s", "bytes": 4, "cpp_type": "uint32_t", "cpp_expr": "(uint32_t)(millis() / 1000UL)",
+     "ha_device_class": "duration", "ha_unit": "s", "ha_diagnostic": True},
+    {"name": "boot_count", "bytes": 2, "cpp_type": "uint16_t", "cpp_expr": "bootCount",
+     "ha_state_class": "measurement", "ha_diagnostic": True, "ha_icon": "mdi:restart"},
 ]
 
 # Added when the board carries a `gps_neo6m` onboard peripheral. lat/lon are
@@ -35,26 +45,34 @@ BUILTIN_FIELDS: list[Field] = [
 # TinyGPSPlus returns 0 -> sats=0 is the "no fix yet" indicator.
 GPS_FIELDS: list[Field] = [
     {"name": "lat", "bytes": 4, "cpp_type": "int32_t",
-     "cpp_expr": "(int32_t)(gps.location.lat() * 10000000.0)", "signed": True, "scale": 1e7},
+     "cpp_expr": "(int32_t)(gps.location.lat() * 10000000.0)", "signed": True, "scale": 1e7,
+     "ha_unit": "°", "ha_diagnostic": True, "ha_icon": "mdi:latitude"},
     {"name": "lon", "bytes": 4, "cpp_type": "int32_t",
-     "cpp_expr": "(int32_t)(gps.location.lng() * 10000000.0)", "signed": True, "scale": 1e7},
+     "cpp_expr": "(int32_t)(gps.location.lng() * 10000000.0)", "signed": True, "scale": 1e7,
+     "ha_unit": "°", "ha_diagnostic": True, "ha_icon": "mdi:longitude"},
     {"name": "alt_m", "bytes": 2, "cpp_type": "int16_t",
-     "cpp_expr": "(int16_t)gps.altitude.meters()", "signed": True},
+     "cpp_expr": "(int16_t)gps.altitude.meters()", "signed": True,
+     "ha_device_class": "distance", "ha_unit": "m", "ha_state_class": "measurement", "ha_diagnostic": True},
     {"name": "sats", "bytes": 1, "cpp_type": "uint8_t",
-     "cpp_expr": "(uint8_t)gps.satellites.value()"},
+     "cpp_expr": "(uint8_t)gps.satellites.value()",
+     "ha_state_class": "measurement", "ha_diagnostic": True, "ha_icon": "mdi:satellite-variant"},
 ]
 
 # Added when the board carries an `axp192` PMIC. batteryMv is read in the loop.
 BATTERY_FIELDS: list[Field] = [
-    {"name": "batt_mv", "bytes": 2, "cpp_type": "uint16_t", "cpp_expr": "batteryMv"},
+    {"name": "batt_mv", "bytes": 2, "cpp_type": "uint16_t", "cpp_expr": "batteryMv",
+     "ha_device_class": "voltage", "ha_unit": "V", "ha_state_class": "measurement",
+     "ha_diagnostic": True, "ha_divide": 1000},
 ]
 
 # Added when the design declares a `dht22`. Temperature signed int16 x100 (degC);
 # humidity uint8 (%). dhtTempC / dhtHumidity are read into globals in the loop.
 DHT_FIELDS: list[Field] = [
     {"name": "temp_c", "bytes": 2, "cpp_type": "int16_t",
-     "cpp_expr": "(int16_t)(dhtTempC * 100.0)", "signed": True, "scale": 100},
-    {"name": "humidity", "bytes": 1, "cpp_type": "uint8_t", "cpp_expr": "(uint8_t)dhtHumidity"},
+     "cpp_expr": "(int16_t)(dhtTempC * 100.0)", "signed": True, "scale": 100,
+     "ha_device_class": "temperature", "ha_unit": "°C", "ha_state_class": "measurement"},
+    {"name": "humidity", "bytes": 1, "cpp_type": "uint8_t", "cpp_expr": "(uint8_t)dhtHumidity",
+     "ha_device_class": "humidity", "ha_unit": "%", "ha_state_class": "measurement"},
 ]
 
 
@@ -136,9 +154,76 @@ def decode_js(fields: list[Field]) -> str:
     return "\n".join(lines)
 
 
+# Link-quality entities every device exposes, read from ChirpStack's rxInfo
+# (not the payload). Appended to every getHaDeviceInfo.
+_RX_ENTITIES: list[tuple[str, str, dict]] = [
+    ("rssi", "value_json.rxInfo[-1].rssi | int",
+     {"ha_device_class": "signal_strength", "ha_unit": "dBm", "ha_diagnostic": True}),
+    ("snr", "value_json.rxInfo[-1].snr | float",
+     {"ha_unit": "dB", "ha_diagnostic": True, "ha_icon": "mdi:wave"}),
+]
+
+
+def _ha_entity_conf(value_template: str, hints: dict) -> str:
+    """Render one chirp2mqtt `entity_conf` block from HA hints."""
+    lines = [f'        value_template: "{{{{ {value_template} }}}}"']
+    if hints.get("ha_diagnostic"):
+        lines.append('        entity_category: "diagnostic"')
+    if hints.get("ha_state_class"):
+        lines.append(f'        state_class: "{hints["ha_state_class"]}"')
+    if hints.get("ha_device_class"):
+        lines.append(f'        device_class: "{hints["ha_device_class"]}"')
+    if hints.get("ha_unit"):
+        lines.append(f'        unit_of_measurement: "{hints["ha_unit"]}"')
+    if hints.get("ha_icon"):
+        lines.append(f'        icon: "{hints["ha_icon"]}"')
+    return "{\n" + ",\n".join(lines) + "\n      }"
+
+
+def ha_device_info_js(fields: list[Field], *, model: str) -> str:
+    """ChirpStack-codec `getHaDeviceInfo` for the chirp2mqtt HA integration.
+
+    chirp2mqtt reads this function (not just `decodeUplink`) to publish HA
+    MQTT-discovery entities. Each payload field with HA hints becomes a sensor;
+    rssi/snr come from rxInfo; a GPS payload (lat+lon) also yields a
+    `device_tracker` whose latitude/longitude attributes drive the HA map.
+    """
+    blocks: list[str] = []
+    for fld in fields:
+        if not any(k.startswith("ha_") for k in fld):
+            continue
+        expr = f"value_json.object.{fld['name']} | {'float' if fld['cpp_type'].startswith(('int', 'float')) or fld.get('scale') else 'int'}"
+        if fld.get("ha_divide"):
+            expr = f"(value_json.object.{fld['name']} | float) / {fld['ha_divide']:.0f}"
+        blocks.append(f"    {fld['name']}: {{\n      entity_conf: {_ha_entity_conf(expr, fld)}\n    }}")
+    for name, expr, hints in _RX_ENTITIES:
+        blocks.append(f"    {name}: {{\n      entity_conf: {_ha_entity_conf(expr, hints)}\n    }}")
+    names = {f["name"] for f in fields}
+    if {"lat", "lon"} <= names:
+        blocks.append(
+            '    location: {\n'
+            '      integration: "device_tracker",\n'
+            '      entity_conf: {\n'
+            '        source_type: "gps",\n'
+            "        value_template: \"{{ 'home' if (value_json.object.sats | int) > 0 else 'not_home' }}\",\n"
+            '        json_attributes_topic: "{status_topic}",\n'
+            "        json_attributes_template: \"{{ {'latitude': value_json.object.lat, 'longitude': value_json.object.lon, 'gps_accuracy': 10} | tojson }}\"\n"
+            '      }\n'
+            '    }'
+        )
+    return (
+        "\nfunction getHaDeviceInfo() {\n  return {\n"
+        f'    device: {{ manufacturer: "wirestudio", model: "{model}" }},\n'
+        "    entities: {\n" + ",\n".join(blocks) + "\n    }\n  };\n}\n"
+    )
+
+
 def generate_codec(design=None, library=None) -> str:
-    """The ChirpStack codec for a design's payload."""
-    return decode_js(fields_for(design, library))
+    """The ChirpStack codec for a design's payload: `decodeUplink` plus the
+    `getHaDeviceInfo` block the chirp2mqtt HA integration reads to publish
+    MQTT-discovery entities."""
+    fields = fields_for(design, library)
+    return decode_js(fields) + ha_device_info_js(fields, model=profile_name(design, library))
 
 
 def profile_name(design=None, library=None) -> str:


### PR DESCRIPTION
Makes the chirp2mqtt → Home Assistant integration a first-class generated output.

## Why
chirp2mqtt builds HA MQTT-discovery entities from a `getHaDeviceInfo()` function inside the ChirpStack device-profile codec. wirestudio only generated `decodeUplink`, so provisioned devices showed up in HA with no field sensors (only chirp's default rssi/battery). This was diagnosed live and patched onto the running profiles by hand; this PR productizes it.

## Changes
- `codec.py`: `generate_codec()` now emits `decodeUplink` **+** `getHaDeviceInfo()`. Each payload `Field` gains optional `ha_*` hints (`ha_device_class`, `ha_unit`, `ha_state_class`, `ha_diagnostic`, `ha_icon`, `ha_divide`) that render into chirp2mqtt `entity_conf` blocks.
  - Sensors: `temp_c`, `humidity`, `batt_mv` (mV→V via `ha_divide`), `alt_m`, `sats`, `uptime_s`, `boot_count`, `lat`, `lon`, with proper device_class/unit/state_class.
  - `rssi`/`snr` from `rxInfo` (always present).
  - GPS payloads (lat+lon) also emit a **`device_tracker`** with `source_type: gps` and a `json_attributes_template` exposing latitude/longitude (`{status_topic}` placeholder) → shows on the HA map.
- `chirpstack.py`: device profiles created with `auto_detect_measurements=True` (ChirpStack's own metrics; independent of the HA path).

## Tests / gates
- `test_codec.py`: assert `generate_codec` contains both functions; entity templates/units/device_classes; mV→V battery conversion; GPS design emits a `device_tracker` while a non-GPS board does not.
- Generated JS validated through `node` (parses; `getHaDeviceInfo()` returns all entities incl. the tracker).
- Full suite: 691 passed, 11 skipped. `ruff` clean. `coverage_matrix.py --strict` OK.

Matches the codec already pushed live to the user's ChirpStack profiles, so repo and deployment stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)