### PR TITLE
Promote dev → main: getHaDeviceInfo HA codec (#87) + README refresh (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mapping to PlatformIO board `ttgo-lora32-v21`. Electrically identical to
   `ttgo-lora32-v1`; the distinct profile lets the most common "TTGO LoRa32"
   hardware select its matching board key.
+- **Home Assistant entities from the LoRaWAN codec.** The generated ChirpStack
+  codec now includes a `getHaDeviceInfo()` block alongside `decodeUplink`, so
+  the [chirp2mqtt](https://github.com/modrisb/chirp) HA integration publishes
+  MQTT-discovery entities for every payload field — temperature, humidity,
+  battery (mV→V), GPS, link quality (RSSI/SNR) — with proper `device_class`/
+  unit/`state_class`. GPS payloads (lat+lon) additionally emit a
+  `device_tracker` whose latitude/longitude attributes drive the HA map. Each
+  payload `Field` carries optional `ha_*` hints driving this. ChirpStack device
+  profiles are also created with `auto_detect_measurements` enabled for
+  ChirpStack's own metrics dashboards.
 
 ## [0.15.0] — 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # wirestudio
 
+[![PyPI](https://img.shields.io/pypi/v/wirestudio)](https://pypi.org/project/wirestudio/)
+[![Python](https://img.shields.io/pypi/pyversions/wirestudio)](https://pypi.org/project/wirestudio/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 Agent-driven IoT device design tool. Describe a goal (or pick parts);
-get ESPHome YAML, an ASCII wiring diagram, and a BOM that compile
-under upstream ESPHome.
+get ESPHome YAML, an ASCII wiring diagram, a KiCad schematic + PCB, a
+3D-printable enclosure, and a BOM that compile under upstream ESPHome.
 
 A second generation target builds and flashes **LoRaWAN** firmware
 (RadioLib + LoRaWAN_ESP32) for US915 radio boards — TTGO T-Beam /
-LoRa32, Heltec WiFi LoRa 32 V2/V3 — over WebSerial from the browser, and
-provisions the device against ChirpStack.
+LoRa32, Heltec WiFi LoRa 32 V2/V3 — over WebSerial from the browser,
+provisions the device against ChirpStack, and surfaces each device's
+sensors + GPS as **Home Assistant** entities (per-field sensors and a
+GPS `device_tracker` for the map, via the chirp2mqtt integration).
 
 Produces ESPHome configs but is not affiliated with the ESPHome
 project — see [`weirded/fleet-for-esphome`](https://github.com/weirded/fleet-for-esphome)
@@ -28,7 +34,7 @@ Detailed docs live in [`docs/`](docs/):
 
 ## Status
 
-`v0.13.0` — on PyPI (`pip install wirestudio`). The studio has wide
+`v0.15.0` — on PyPI (`pip install wirestudio`). The studio has wide
 surface area (YAML, schematic, enclosure, agent, MCP server, fleet
 handoff, web UI, a LoRaWAN flash/provision target) and a set of things
 actually verified against upstream tools. Three of the four priority
@@ -46,11 +52,12 @@ Tiers, in priority order:
 | **Verified** | Fleet handoff | push YAML to `fleet-for-esphome` ha-addon, optional compile + log relay | round-trip tests in `tests/test_fleet.py` |
 | **Verified** | KiCad schematic | emit a SKiDL Python script the user runs locally to produce a `.kicad_sch` | every bundled example builds a KiCad netlist against the pinned upstream symbol libraries, every PR ([gate](.github/workflows/kicad-schematic.yml)) — no unresolved symbols or pins. Parts KiCad ships no symbol for (sensor/module breakouts) render as labeled generic headers |
 | **Verified** | Parametric enclosure | OpenSCAD `.scad` from board mount-hole metadata | every enclosure-capable board renders through real OpenSCAD to a non-empty, manifold (closed, printable) solid, every PR ([gate](.github/workflows/enclosure-render.yml)) |
-| **Works (hardware-validated)** | LoRaWAN target | build RadioLib + LoRaWAN_ESP32 firmware for US915 radio boards, flash over WebSerial, provision against ChirpStack | every radio board's firmware builds in CI ([gate](.github/workflows/lorawan-firmware.yml)); validated end-to-end on a TTGO T-Beam against live ChirpStack 4.17 — no automated live-device gate |
+| **Verified** | KiCad PCB layout + fab outputs | grid-placed `.kicad_pcb` (pads bound to nets, `Edge.Cuts` outline) + Gerber/drill/CPL/BOM bundle for JLCPCB | every bundled example emits a structurally sound board ([pcb-layout](.github/workflows/pcb-layout.yml)); each board opens in real KiCad and passes DRC, unrouted airwires aside ([pcb-drc](.github/workflows/pcb-drc.yml)) |
+| **Works (hardware-validated)** | LoRaWAN target | build RadioLib + LoRaWAN_ESP32 firmware for US915 radio boards, flash over WebSerial, provision against ChirpStack, expose sensors/GPS as Home Assistant entities | every radio board's firmware builds in CI ([gate](.github/workflows/lorawan-firmware.yml)); validated end-to-end on a TTGO T-Beam against live ChirpStack 4.17 — no automated live-device gate |
 | **Works (lighter checks)** | MCP server | drive the design tools from Claude Code / Desktop over the Model Context Protocol | tool / auth / resource tests in `tests/test_mcp_*.py`; not exercised against a live MCP client in CI |
 | **Experimental** | Thingiverse search relay | rank community models for a board | smoke-tested; depends on a third-party search API that ranks unevenly |
 | **Experimental** | Agent (Claude tool-using) | natural-language design driving | works in practice; tool surface is small; no auto-eval against task list yet |
-| **Deferred** | KiCad PCB layout | Freerouting + Gerber + JLCPCB CPL/BOM | 1.0+, not started |
+| **Deferred** | PCB autoroute | Freerouting traces | 1.0+; boards currently ship unrouted (pads + ratsnest, no traces) |
 
 The **Verified** tier is the bar the project is asking to be judged
 on. Everything else is offered with the caveat that's spelled out in
@@ -72,7 +79,7 @@ that pin moves, this line moves with it.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:v0.13.0
+  ghcr.io/moellere/wirestudio:v0.15.0
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +
@@ -115,7 +122,7 @@ The [User guide](docs/user_guide.md) walks the panes and header actions.
 ## Tests
 
 ```sh
-python -m pytest                          # ~680 cases
+python -m pytest                          # ~690 cases
 python -m ruff check .                    # lint
 cd web && npx vitest run                  # vitest + jsdom
 pip install 'esphome==2025.12.7'

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-2669987-lorawan
+    newTag: sha-4911313-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-3f35567-lorawan
+    newTag: sha-5a4d1c0-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-4911313-lorawan
+    newTag: sha-3f35567-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,26 @@ name = "wirestudio"
 # Single-sourced from wirestudio/__init__.py (see [tool.setuptools.dynamic]).
 # Bump __version__ there; the wheel + `python -m build` read it from the module.
 dynamic = ["version"]
-description = "Agent-driven IoT device design tool that produces ESPHome YAML."
+description = "Agent-driven IoT device design tool: ESPHome YAML, KiCad schematic/PCB, enclosures, and LoRaWAN firmware (ChirpStack + Home Assistant)."
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.11"
 authors = [{ name = "wirestudio contributors" }]
+keywords = [
+    "esphome", "esp32", "lorawan", "iot", "home-assistant", "chirpstack",
+    "kicad", "pcb", "platformio", "openscad", "enclosure", "mcp", "smart-home",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Home Automation",
+    "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+    "Topic :: System :: Hardware",
+]
 dependencies = [
     "pydantic>=2.6",
     "pyyaml>=6.0",

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -80,3 +80,33 @@ def test_pack_cpp_matches_size_and_reads_sensors():
     assert f"payload[{codec.payload_size(fields) - 1}]" in cpp
     assert "gps.location.lat()" in cpp
     assert "batteryMv" in cpp
+
+
+def test_generate_codec_includes_decode_and_ha_device_info():
+    js = codec.generate_codec(_design("ttgo-t-beam"), default_library())
+    assert "function decodeUplink(input)" in js
+    assert "function getHaDeviceInfo()" in js
+
+
+def test_ha_device_info_entities_and_units():
+    lib = default_library()
+    js = codec.generate_codec(_design("ttgo-t-beam", dht22={"pin": "GPIO13"}), lib)
+    # payload fields become entities with proper templates/units
+    assert 'value_template: "{{ value_json.object.temp_c | float }}"' in js
+    assert 'device_class: "temperature"' in js
+    # battery is converted mV -> V in the HA template
+    assert "(value_json.object.batt_mv | float) / 1000" in js
+    assert 'device_class: "voltage"' in js
+    # link quality from rxInfo (not payload)
+    assert "value_json.rxInfo[-1].rssi | int" in js
+
+
+def test_ha_device_info_gps_emits_device_tracker():
+    lib = default_library()
+    gps_js = codec.generate_codec(_design("ttgo-t-beam"), lib)  # onboard GPS
+    assert 'integration: "device_tracker"' in gps_js
+    assert "'latitude': value_json.object.lat" in gps_js
+    assert 'json_attributes_topic: "{status_topic}"' in gps_js
+    # a non-GPS board gets no device_tracker
+    plain_js = codec.generate_codec(_design("ttgo-lora32-v1"), lib)
+    assert "device_tracker" not in plain_js

--- a/wirestudio/targets/lorawan/chirpstack.py
+++ b/wirestudio/targets/lorawan/chirpstack.py
@@ -215,6 +215,10 @@ class ChirpStackClient:
             adr_algorithm_id="default",
             supports_otaa=True,
             uplink_interval=3600,
+            # Let ChirpStack register decoded payload keys as measurements (for
+            # its own metrics dashboards). The chirp2mqtt HA integration reads
+            # entities from the codec's getHaDeviceInfo, independent of this.
+            auto_detect_measurements=True,
         )
         if codec is not None:
             profile.payload_codec_runtime = m.dp.CodecRuntime.JS

--- a/wirestudio/targets/lorawan/codec.py
+++ b/wirestudio/targets/lorawan/codec.py
@@ -22,12 +22,22 @@ class Field(TypedDict, total=False):
     cpp_expr: str  # C++ expression yielding the value (assigned to a temp, then packed)
     signed: bool   # default False; affects codec sign-extension
     scale: float   # default 1; codec divides the decoded int by this (e.g. 1e7 for degrees)
+    # Home Assistant entity hints, consumed by `getHaDeviceInfo` (the chirp2mqtt
+    # integration reads them to publish MQTT-discovery entities). All optional.
+    ha_device_class: str   # HA device_class (e.g. "temperature", "voltage")
+    ha_unit: str           # unit_of_measurement
+    ha_state_class: str    # e.g. "measurement"
+    ha_diagnostic: bool    # entity_category=diagnostic
+    ha_icon: str           # mdi icon
+    ha_divide: float       # divide the (already decoded) value in the HA template
 
 
 # Always present on every LoRaWAN build. Big-endian.
 BUILTIN_FIELDS: list[Field] = [
-    {"name": "uptime_s", "bytes": 4, "cpp_type": "uint32_t", "cpp_expr": "(uint32_t)(millis() / 1000UL)"},
-    {"name": "boot_count", "bytes": 2, "cpp_type": "uint16_t", "cpp_expr": "bootCount"},
+    {"name": "uptime_s", "bytes": 4, "cpp_type": "uint32_t", "cpp_expr": "(uint32_t)(millis() / 1000UL)",
+     "ha_device_class": "duration", "ha_unit": "s", "ha_diagnostic": True},
+    {"name": "boot_count", "bytes": 2, "cpp_type": "uint16_t", "cpp_expr": "bootCount",
+     "ha_state_class": "measurement", "ha_diagnostic": True, "ha_icon": "mdi:restart"},
 ]
 
 # Added when the board carries a `gps_neo6m` onboard peripheral. lat/lon are
@@ -35,26 +45,34 @@ BUILTIN_FIELDS: list[Field] = [
 # TinyGPSPlus returns 0 -> sats=0 is the "no fix yet" indicator.
 GPS_FIELDS: list[Field] = [
     {"name": "lat", "bytes": 4, "cpp_type": "int32_t",
-     "cpp_expr": "(int32_t)(gps.location.lat() * 10000000.0)", "signed": True, "scale": 1e7},
+     "cpp_expr": "(int32_t)(gps.location.lat() * 10000000.0)", "signed": True, "scale": 1e7,
+     "ha_unit": "°", "ha_diagnostic": True, "ha_icon": "mdi:latitude"},
     {"name": "lon", "bytes": 4, "cpp_type": "int32_t",
-     "cpp_expr": "(int32_t)(gps.location.lng() * 10000000.0)", "signed": True, "scale": 1e7},
+     "cpp_expr": "(int32_t)(gps.location.lng() * 10000000.0)", "signed": True, "scale": 1e7,
+     "ha_unit": "°", "ha_diagnostic": True, "ha_icon": "mdi:longitude"},
     {"name": "alt_m", "bytes": 2, "cpp_type": "int16_t",
-     "cpp_expr": "(int16_t)gps.altitude.meters()", "signed": True},
+     "cpp_expr": "(int16_t)gps.altitude.meters()", "signed": True,
+     "ha_device_class": "distance", "ha_unit": "m", "ha_state_class": "measurement", "ha_diagnostic": True},
     {"name": "sats", "bytes": 1, "cpp_type": "uint8_t",
-     "cpp_expr": "(uint8_t)gps.satellites.value()"},
+     "cpp_expr": "(uint8_t)gps.satellites.value()",
+     "ha_state_class": "measurement", "ha_diagnostic": True, "ha_icon": "mdi:satellite-variant"},
 ]
 
 # Added when the board carries an `axp192` PMIC. batteryMv is read in the loop.
 BATTERY_FIELDS: list[Field] = [
-    {"name": "batt_mv", "bytes": 2, "cpp_type": "uint16_t", "cpp_expr": "batteryMv"},
+    {"name": "batt_mv", "bytes": 2, "cpp_type": "uint16_t", "cpp_expr": "batteryMv",
+     "ha_device_class": "voltage", "ha_unit": "V", "ha_state_class": "measurement",
+     "ha_diagnostic": True, "ha_divide": 1000},
 ]
 
 # Added when the design declares a `dht22`. Temperature signed int16 x100 (degC);
 # humidity uint8 (%). dhtTempC / dhtHumidity are read into globals in the loop.
 DHT_FIELDS: list[Field] = [
     {"name": "temp_c", "bytes": 2, "cpp_type": "int16_t",
-     "cpp_expr": "(int16_t)(dhtTempC * 100.0)", "signed": True, "scale": 100},
-    {"name": "humidity", "bytes": 1, "cpp_type": "uint8_t", "cpp_expr": "(uint8_t)dhtHumidity"},
+     "cpp_expr": "(int16_t)(dhtTempC * 100.0)", "signed": True, "scale": 100,
+     "ha_device_class": "temperature", "ha_unit": "°C", "ha_state_class": "measurement"},
+    {"name": "humidity", "bytes": 1, "cpp_type": "uint8_t", "cpp_expr": "(uint8_t)dhtHumidity",
+     "ha_device_class": "humidity", "ha_unit": "%", "ha_state_class": "measurement"},
 ]
 
 
@@ -136,9 +154,76 @@ def decode_js(fields: list[Field]) -> str:
     return "\n".join(lines)
 
 
+# Link-quality entities every device exposes, read from ChirpStack's rxInfo
+# (not the payload). Appended to every getHaDeviceInfo.
+_RX_ENTITIES: list[tuple[str, str, dict]] = [
+    ("rssi", "value_json.rxInfo[-1].rssi | int",
+     {"ha_device_class": "signal_strength", "ha_unit": "dBm", "ha_diagnostic": True}),
+    ("snr", "value_json.rxInfo[-1].snr | float",
+     {"ha_unit": "dB", "ha_diagnostic": True, "ha_icon": "mdi:wave"}),
+]
+
+
+def _ha_entity_conf(value_template: str, hints: dict) -> str:
+    """Render one chirp2mqtt `entity_conf` block from HA hints."""
+    lines = [f'        value_template: "{{{{ {value_template} }}}}"']
+    if hints.get("ha_diagnostic"):
+        lines.append('        entity_category: "diagnostic"')
+    if hints.get("ha_state_class"):
+        lines.append(f'        state_class: "{hints["ha_state_class"]}"')
+    if hints.get("ha_device_class"):
+        lines.append(f'        device_class: "{hints["ha_device_class"]}"')
+    if hints.get("ha_unit"):
+        lines.append(f'        unit_of_measurement: "{hints["ha_unit"]}"')
+    if hints.get("ha_icon"):
+        lines.append(f'        icon: "{hints["ha_icon"]}"')
+    return "{\n" + ",\n".join(lines) + "\n      }"
+
+
+def ha_device_info_js(fields: list[Field], *, model: str) -> str:
+    """ChirpStack-codec `getHaDeviceInfo` for the chirp2mqtt HA integration.
+
+    chirp2mqtt reads this function (not just `decodeUplink`) to publish HA
+    MQTT-discovery entities. Each payload field with HA hints becomes a sensor;
+    rssi/snr come from rxInfo; a GPS payload (lat+lon) also yields a
+    `device_tracker` whose latitude/longitude attributes drive the HA map.
+    """
+    blocks: list[str] = []
+    for fld in fields:
+        if not any(k.startswith("ha_") for k in fld):
+            continue
+        expr = f"value_json.object.{fld['name']} | {'float' if fld['cpp_type'].startswith(('int', 'float')) or fld.get('scale') else 'int'}"
+        if fld.get("ha_divide"):
+            expr = f"(value_json.object.{fld['name']} | float) / {fld['ha_divide']:.0f}"
+        blocks.append(f"    {fld['name']}: {{\n      entity_conf: {_ha_entity_conf(expr, fld)}\n    }}")
+    for name, expr, hints in _RX_ENTITIES:
+        blocks.append(f"    {name}: {{\n      entity_conf: {_ha_entity_conf(expr, hints)}\n    }}")
+    names = {f["name"] for f in fields}
+    if {"lat", "lon"} <= names:
+        blocks.append(
+            '    location: {\n'
+            '      integration: "device_tracker",\n'
+            '      entity_conf: {\n'
+            '        source_type: "gps",\n'
+            "        value_template: \"{{ 'home' if (value_json.object.sats | int) > 0 else 'not_home' }}\",\n"
+            '        json_attributes_topic: "{status_topic}",\n'
+            "        json_attributes_template: \"{{ {'latitude': value_json.object.lat, 'longitude': value_json.object.lon, 'gps_accuracy': 10} | tojson }}\"\n"
+            '      }\n'
+            '    }'
+        )
+    return (
+        "\nfunction getHaDeviceInfo() {\n  return {\n"
+        f'    device: {{ manufacturer: "wirestudio", model: "{model}" }},\n'
+        "    entities: {\n" + ",\n".join(blocks) + "\n    }\n  };\n}\n"
+    )
+
+
 def generate_codec(design=None, library=None) -> str:
-    """The ChirpStack codec for a design's payload."""
-    return decode_js(fields_for(design, library))
+    """The ChirpStack codec for a design's payload: `decodeUplink` plus the
+    `getHaDeviceInfo` block the chirp2mqtt HA integration reads to publish
+    MQTT-discovery entities."""
+    fields = fields_for(design, library)
+    return decode_js(fields) + ha_device_info_js(fields, model=profile_name(design, library))
 
 
 def profile_name(design=None, library=None) -> str:


### PR DESCRIPTION
Promotes `dev` to `main`.

- **#87** — `getHaDeviceInfo` in the LoRaWAN codec: chirp2mqtt HA entities (temp/humidity/battery/GPS, RSSI/SNR) + a GPS `device_tracker`; ChirpStack profiles created with `auto_detect_measurements`.
- **#88** — README refreshed to 0.15.0, corrected PCB/fab status, Home Assistant integration mentioned; PyPI keywords/classifiers/badges for discoverability.

All gates green on the `dev` HEAD. (GitHub repo description/homepage/topics already applied out-of-band.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)