### PR TITLE
release: cut 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] — 2026-06-14
+
 ### Fixed
 
 - **LoRaWAN firmware boot-loop on TTGO LoRa32 (issue #80).** The TTGO

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"


### PR DESCRIPTION
Cuts **0.16.0**: bumps `wirestudio/__init__.py` and rolls `[Unreleased]` → `[0.16.0] — 2026-06-14`.

Headline changes since 0.15.0:
- **Fix:** TTGO LoRa32 LoRaWAN boot-loop (#80) — GPIO16 OLED reset removed; I2C bring-up made non-blocking.
- **Add:** `ttgo-lora32-v2` board profile.
- **Add:** `getHaDeviceInfo` in the LoRaWAN codec → Home Assistant entities (temp/humidity/battery/GPS/RSSI/SNR) + GPS `device_tracker`; `auto_detect_measurements` on ChirpStack profiles.

After this merges and is promoted to `main`, I'll tag `v0.16.0` (triggers the PyPI Trusted-Publisher release + `:0.16.0`/`:latest` images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)