### PR TITLE
Promote dev → main: release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] — 2026-06-14
+
 ### Fixed
 
 - **LoRaWAN firmware boot-loop on TTGO LoRa32 (issue #80).** The TTGO

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-248a668-lorawan
+    newTag: sha-a14e79f-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-5a4d1c0-lorawan
+    newTag: sha-248a668-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"


### PR DESCRIPTION
Promotes the 0.16.0 release commit (#91) to `main` so it can be tagged.

Contents: TTGO LoRa32 OLED boot-loop fix (#80), `ttgo-lora32-v2` profile, `getHaDeviceInfo` HA codec (#87), README/discoverability refresh (#88), version bump to 0.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)