### PR TITLE
docs: add social-preview source image

### DIFF
--- a/docs/assets/social-preview.svg
+++ b/docs/assets/social-preview.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <!-- GitHub social preview, 1280x640. Render to PNG and upload via
+       Settings > General > Social preview. -->
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="1" stop-color="#111a2e"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#22d3ee"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1280" height="640" fill="url(#bg)"/>
+  <rect x="0" y="0" width="1280" height="8" fill="url(#accent)"/>
+
+  <!-- faint circuit traces -->
+  <g stroke="#1e3a5f" stroke-width="3" fill="none" opacity="0.55">
+    <path d="M120 470 H320 V540 H520"/>
+    <path d="M120 510 H260 V470"/>
+    <path d="M980 130 H1120 V210 H1180"/>
+    <circle cx="320" cy="470" r="6" fill="#1e3a5f" stroke="none"/>
+    <circle cx="1120" cy="210" r="6" fill="#1e3a5f" stroke="none"/>
+  </g>
+
+  <text x="100" y="250" font-size="120" font-weight="800" fill="#f8fafc" letter-spacing="-2">wirestudio</text>
+  <text x="104" y="320" font-size="36" font-weight="500" fill="#94a3b8">Agent-driven IoT device design</text>
+  <text x="104" y="372" font-size="30" font-weight="400" fill="#cbd5e1">ESPHome YAML · KiCad schematic + PCB · enclosures · LoRaWAN firmware</text>
+
+  <!-- domain chips -->
+  <g font-size="26" font-weight="600">
+    <g>
+      <rect x="104" y="436" width="180" height="56" rx="28" fill="#0e2a3a" stroke="#22d3ee" stroke-width="1.5"/>
+      <text x="194" y="472" fill="#7dd3fc" text-anchor="middle">ESPHome</text>
+    </g>
+    <g>
+      <rect x="300" y="436" width="180" height="56" rx="28" fill="#0e2a3a" stroke="#22d3ee" stroke-width="1.5"/>
+      <text x="390" y="472" fill="#7dd3fc" text-anchor="middle">LoRaWAN</text>
+    </g>
+    <g>
+      <rect x="496" y="436" width="270" height="56" rx="28" fill="#0e2a3a" stroke="#22d3ee" stroke-width="1.5"/>
+      <text x="631" y="472" fill="#7dd3fc" text-anchor="middle">Home Assistant</text>
+    </g>
+    <g>
+      <rect x="782" y="436" width="140" height="56" rx="28" fill="#0e2a3a" stroke="#22d3ee" stroke-width="1.5"/>
+      <text x="852" y="472" fill="#7dd3fc" text-anchor="middle">KiCad</text>
+    </g>
+    <g>
+      <rect x="938" y="436" width="120" height="56" rx="28" fill="#0e2a3a" stroke="#22d3ee" stroke-width="1.5"/>
+      <text x="998" y="472" fill="#7dd3fc" text-anchor="middle">MCP</text>
+    </g>
+  </g>
+
+  <text x="104" y="566" font-size="24" fill="#64748b">pip install wirestudio  ·  wirestudio.io  ·  MIT</text>
+</svg>


### PR DESCRIPTION
Adds `docs/assets/social-preview.svg` (1280×640) as the source for the GitHub social-preview card. Render to PNG and upload via **Settings → General → Social preview** (web-only — GitHub has no API for it). No `wirestudio/` code touched.