### PR TITLE
Promote dev → main: contributing branch/release workflow doc (#97)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,6 +244,73 @@ for f in examples/*.json; do
 done
 ```
 
+## Branching, PRs, and releases
+
+The repo uses a **two-tier flow** with a long-lived integration branch:
+
+```
+feature/fix branch ──PR──> dev ──promotion PR──> main ──tag vX.Y.Z──> release
+   (your work)         (integration)         (protected trunk)    (PyPI + images)
+```
+
+- **`main`** is the protected, always-releasable trunk. It requires a PR
+  with passing checks; never push to it directly. A self-authored PR lands
+  with `gh pr merge --admin` (owner privilege; review is a formality on this
+  solo repo).
+- **`dev`** is the permanent integration branch. Feature work merges here
+  first; both `dev` and `main` run the full gate set.
+
+### Working on a change
+
+```sh
+git fetch origin                      # ALWAYS sync first — main/dev drift fast
+git switch -c fix/short-description origin/dev
+# ...commit...
+git push -u origin fix/short-description
+gh pr create --base dev               # opens the PR; CI runs the gates
+gh pr merge --admin                   # when green
+```
+
+- One branch = one logical change = one PR. Keep them small and short-lived.
+- Name branches `feat/…`, `fix/…`, `docs/…`, `chore/…`, `release/…`.
+- The repo has **auto-delete-on-merge**, so merged PR branches clean
+  themselves up. Locally, `git fetch --prune` then delete the stale copy.
+- If `main`/`dev` moves under you, fold it in (`git merge origin/dev`) so
+  you test against current state and the merge stays clean.
+
+### Promoting `dev` → `main`
+
+Promote through a **throwaway branch**, not `dev` itself — auto-delete-on-merge
+would otherwise delete `dev` (it's the PR head), forcing a recreate:
+
+```sh
+git push origin origin/dev:refs/heads/promote/0.x   # ephemeral head off dev
+gh pr create --base main --head promote/0.x --title "Promote dev → main: ..."
+gh pr merge --admin                                  # promote/0.x auto-deletes; dev survives
+```
+
+Do **not** turn off repo-wide auto-delete to protect `dev` (you'd lose
+feature-branch cleanup), and do **not** add branch protection to `dev` (the
+`bump-dev` CI job pushes to it directly and protection would block that).
+
+### Cutting a release
+
+Version is single-sourced in `wirestudio/__init__.py` (`pyproject.toml` reads
+it dynamically — bump only `__init__.py`).
+
+```sh
+git switch -c release/X.Y.Z origin/dev
+# bump __version__ in wirestudio/__init__.py
+# move CHANGELOG [Unreleased] -> [X.Y.Z] — DATE, add a fresh empty [Unreleased]
+git commit -am "release: cut X.Y.Z"
+# PR -> dev, then promote dev -> main (above), then:
+gh release create vX.Y.Z --target main --title vX.Y.Z --notes "..."
+```
+
+The `vX.Y.Z` tag (must match the version) fires `release.yml` → PyPI
+(Trusted Publisher) and `docker.yml` → `:X.Y.Z` / `:latest` (+ `-lorawan`)
+images.
+
 ## Quick checklist before opening a PR
 
 - [ ] `python -m pytest` passes.

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: sha-a14e79f-lorawan
+    newTag: sha-b627dbe-lorawan
 
 # A LoRaWAN firmware build shells out to PlatformIO; the espressif32 link
 # step peaks well past the base 512Mi limit and OOMKills the pod. Give the


### PR DESCRIPTION
Ephemeral-promote of dev → main (dogfooding the documented flow). Head is the throwaway `promote/contributing-doc`, not `dev`, so `dev` survives the merge.

Contents: CONTRIBUTING 'Branching, PRs, and releases' section (#97).

🤖 Generated with [Claude Code](https://claude.com/claude-code)