### PR TITLE
feat(targets): build-backend seam for the LoRaWAN compile path (phase C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Build-backend seam (framework axis, phase C — structural).** A
+  `BuildBackend` protocol (`status` / `enqueue` / `stream` / `artifact`) now
+  sits behind the LoRaWAN compile + firmware-download routes, with the in-pod
+  PlatformIO worker wrapped as `LocalCompileBackend` and exposed via
+  `LorawanTarget.build_backend()`. The endpoints no longer import the compile
+  worker directly, so a *remote* LoRaWAN build worker (a build-agent pool, the
+  way fleet-for-esphome pools esphome builds) drops in later as a second
+  backend without touching the API — proven by a fake poll-style backend in the
+  tests. No wire-API, frontend, or behavior change: one-at-a-time WebSerial
+  flashing still streams the in-pod build exactly as before. (The job-id route
+  guard is now backend-agnostic instead of hex-only, so a remote worker's
+  handle addresses its artifact through the same `/lorawan/firmware/{id}`
+  route.)
+
 ### Changed
 
 - **LoRaWAN target: framework axis + library codegen blocks (phases A & B).**

--- a/START.md
+++ b/START.md
@@ -1350,12 +1350,25 @@ immediate way in and the agent (when it arrives) lands in a working surface.
     framework capability (a component appears iff it carries a block for the
     selected framework).
 
-  - **C — Build-backend protocol.** Extract a build-backend `Protocol`
-    (enqueue → poll log → fetch artifact, mirroring `FleetClient`'s shape)
-    with the in-pod `targets/lorawan/compile.py` behind a *local* impl and
-    the fleet-for-esphome handoff behind a *remote* impl for esphome. Remote
-    LoRaWAN build agents slot in here later as a second impl (deferred per
-    the locked decision above).
+  - **C — Build-backend protocol.** 🚧 Structural seam shipped. A
+    `BuildBackend` `Protocol` (`status` / `enqueue` / `stream` / `artifact`,
+    the worker shape so a remote agent is id-first) sits behind the LoRaWAN
+    compile + firmware routes, with `targets/lorawan/compile.py` wrapped as the
+    *local* impl (`LocalCompileBackend`, exposed by `LorawanTarget.build_backend()`).
+    The endpoints are backend-agnostic, so a remote LoRaWAN build worker drops
+    in as a second impl without an endpoint change (proven by a fake poll-style
+    backend in tests).
+
+    Deliberately **not** done, because the use cases differ and forcing them
+    together buys nothing yet: LoRaWAN flashing is one-at-a-time (in-pod build +
+    WebSerial), so it keeps its single-shot compile stream; the esphome path
+    pushes firmware fleet-wide on a schedule, which is why fleet-for-esphome's
+    build-worker *pool* (submit → run_id → poll) is the right shape there. So
+    the two wire APIs stay distinct (no unified `/design/build/*`), the
+    fleet/`/fleet/*` routes are left as-is rather than refactored behind the
+    protocol, and the remote LoRaWAN backend itself is deferred until a build
+    pool is actually wanted — at which point it's a new `BuildBackend` impl, not
+    a rewrite.
 
   - **D — Network-server backends.** Put ChirpStack + TTN behind one
     provision/codec interface under the lorawan framework; region support

--- a/tests/test_build_backend.py
+++ b/tests/test_build_backend.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from wirestudio.library import default_library
+from wirestudio.model import Design
+from wirestudio.targets import get_target
+from wirestudio.targets.build_backend import BuildBackend, BuildUnavailable
+from wirestudio.targets.lorawan import compile as compile_mod
+from wirestudio.targets.lorawan.api import build_router
+from wirestudio.targets.lorawan.build_local import LocalCompileBackend
+
+
+def _design(board_id: str = "ttgo-t-beam") -> Design:
+    return Design(
+        schema_version="0.1", id="d", name="D", target="lorawan",
+        board={"library_id": board_id, "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+    )
+
+
+# --- the local backend satisfies the Protocol + delegates correctly ----------
+
+def test_local_backend_is_a_build_backend():
+    # runtime_checkable Protocol: the local impl structurally conforms.
+    assert isinstance(LocalCompileBackend(), BuildBackend)
+
+
+def test_lorawan_target_exposes_the_local_backend():
+    b = get_target("lorawan").build_backend()
+    assert isinstance(b, LocalCompileBackend)
+    assert get_target("esphome").build_backend() is None  # esphome hands off to fleet
+
+
+def test_local_enqueue_is_the_cache_key():
+    lib = default_library()
+    d = _design()
+    assert LocalCompileBackend().enqueue(d, lib) == compile_mod.cache_key(d, lib)
+
+
+def test_local_artifact_reads_the_cache_by_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("WIRESTUDIO_FW_CACHE", str(tmp_path))
+    key = "abc123"
+    (tmp_path / key).mkdir()
+    (tmp_path / key / "firmware.bin").write_bytes(b"\x00\x01BIN")
+    b = LocalCompileBackend()
+    assert b.artifact(key) == b"\x00\x01BIN"
+    assert b.artifact(key, "factory.bin") is None       # absent -> None
+    assert b.artifact("nope") is None                   # unknown id -> None
+
+
+def test_local_stream_cache_hit_replays_without_a_toolchain(tmp_path, monkeypatch):
+    monkeypatch.setenv("WIRESTUDIO_FW_CACHE", str(tmp_path))
+    lib = default_library()
+    d = _design()
+    b = LocalCompileBackend()
+    key = b.enqueue(d, lib)
+    (tmp_path / key).mkdir()
+    (tmp_path / key / "firmware.bin").write_bytes(b"BIN")
+    (tmp_path / key / "build.log").write_text("cached build output")
+    # No PlatformIO available, but a warm cache must not need it.
+    monkeypatch.setattr(compile_mod, "_pio_cmd", lambda: None)
+
+    events = list(b.stream(key, d, lib))
+    done = [e for e in events if e["type"] == "done"]
+    assert done and done[0]["ok"] is True and done[0]["cache_hit"] is True
+    assert any(e["type"] == "log" and "cached build output" in e["data"] for e in events)
+
+
+def test_local_stream_raises_build_unavailable_on_cache_miss_without_pio(tmp_path, monkeypatch):
+    monkeypatch.setenv("WIRESTUDIO_FW_CACHE", str(tmp_path))
+    monkeypatch.setattr(compile_mod, "_pio_cmd", lambda: None)
+    lib = default_library()
+    d = _design()
+    b = LocalCompileBackend()
+    with pytest.raises(BuildUnavailable):
+        list(b.stream(b.enqueue(d, lib), d, lib))
+
+
+# --- the endpoints are backend-agnostic: a remote worker drops in ------------
+
+class _FakeRemoteBackend:
+    """A poll-style build worker (the shape a remote LoRaWAN agent would take):
+    its job id is a worker handle, not a content hash, and the artifact lives on
+    the worker, not the local cache. Used to prove the lorawan endpoints don't
+    care which backend they drive."""
+
+    id = "fake-remote"
+
+    def __init__(self, *, available: bool = True) -> None:
+        self._available = available
+        self._store: dict[str, dict[str, bytes]] = {}
+
+    def status(self) -> dict:
+        return {"available": self._available,
+                "reason": None if self._available else "build worker unreachable"}
+
+    def enqueue(self, design, library) -> str:
+        return "remote-job-7f3a"
+
+    def stream(self, job_id, design, library):
+        if not self._available:
+            raise BuildUnavailable("build worker unreachable")
+        yield {"type": "log", "data": "remote worker: compiling...\n"}
+        self._store.setdefault(job_id, {})["firmware.bin"] = b"REMOTE_BIN"
+        yield {"type": "done", "ok": True, "cache_key": job_id, "cache_hit": False,
+               "env": "ttgo-t-beam", "bin": "remote", "factory": None}
+
+    def artifact(self, job_id, name="firmware.bin"):
+        return self._store.get(job_id, {}).get(name)
+
+
+def _client_for(backend) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_router(default_library(), backend), prefix="/lorawan")
+    return TestClient(app)
+
+
+def test_fake_remote_backend_conforms():
+    assert isinstance(_FakeRemoteBackend(), BuildBackend)
+
+
+def test_endpoints_drive_a_remote_backend_unchanged():
+    backend = _FakeRemoteBackend()
+    client = _client_for(backend)
+
+    assert client.get("/lorawan/compile/status").json() == {
+        "available": True, "reason": None,
+    }
+
+    r = client.post("/lorawan/compile", json=json.loads(_design().model_dump_json()))
+    assert r.status_code == 200
+    events = [json.loads(line[len("data: "):])
+              for line in r.text.splitlines() if line.startswith("data: ")]
+    done = [e for e in events if e["type"] == "done"]
+    assert done and done[0]["cache_key"] == "remote-job-7f3a"
+
+    # The done event's id addresses the artifact through the same /firmware route.
+    fw = client.get("/lorawan/firmware/remote-job-7f3a")
+    assert fw.status_code == 200 and fw.content == b"REMOTE_BIN"
+
+
+def test_endpoint_surfaces_backend_unavailable_as_sse_error():
+    client = _client_for(_FakeRemoteBackend(available=False))
+    r = client.post("/lorawan/compile", json=json.loads(_design().model_dump_json()))
+    assert r.status_code == 200  # the stream opens, then carries the error frame
+    assert "event: error" in r.text
+    assert "build worker unreachable" in r.text

--- a/wirestudio/targets/base.py
+++ b/wirestudio/targets/base.py
@@ -9,6 +9,8 @@ from wirestudio.model import Design, DesignWarning
 if TYPE_CHECKING:
     from fastapi import APIRouter
 
+    from wirestudio.targets.build_backend import BuildBackend
+
 
 class TargetPlugin(ABC):
     """A generation target: the kind of artifact a design compiles to.
@@ -48,6 +50,17 @@ class TargetPlugin(ABC):
 
         Default None: esphome's endpoints are the existing top-level routes.
         lorawan returns a router for compile/flash/provision.
+        """
+        return None
+
+    def build_backend(self) -> "Optional[BuildBackend]":
+        """The build path that turns this target's generated firmware into a
+        flashable artifact (probe / enqueue / stream / fetch).
+
+        Default None: not every target builds in-studio (esphome hands off to
+        fleet-for-esphome via the /fleet/* routes). lorawan returns the in-pod
+        PlatformIO backend; a remote LoRaWAN build worker would slot in here as
+        a second implementation without touching the endpoints.
         """
         return None
 

--- a/wirestudio/targets/build_backend.py
+++ b/wirestudio/targets/build_backend.py
@@ -1,0 +1,73 @@
+"""Build-backend seam: how a design's generated firmware becomes a binary.
+
+A *generate* step (``TargetPlugin.generate``) is pure text. A *build* step runs
+a toolchain over that text to produce a flashable artifact -- slow, stateful,
+with a streamed log that can fail. Today there's exactly one build path per
+target (in-pod PlatformIO for lorawan; the fleet-for-esphome handoff for
+esphome), but they share a shape: probe availability, enqueue a job, stream its
+log, fetch the artifact.
+
+``BuildBackend`` is that shape. The lorawan API routes through
+``LorawanTarget.build_backend()`` instead of importing the compile worker
+directly, so a *remote* LoRaWAN build worker (a build-agent pool, the way
+fleet-for-esphome pools esphome builds) drops in later as a second backend
+without touching the endpoint -- the same way a new sensor is a new library
+block, not a generator edit. There's no remote LoRaWAN backend today; the seam
+just keeps adding one additive.
+
+The shape is deliberately the worker shape (``enqueue -> job_id``, then stream /
+fetch by id) even though the local backend builds synchronously inside
+``stream`` -- a remote worker pool needs the id-first split, and the local
+backend satisfies it trivially (its id is the content-addressed cache key,
+computable without building).
+"""
+from __future__ import annotations
+
+from typing import Iterator, Optional, Protocol, runtime_checkable
+
+from wirestudio.library import Library
+from wirestudio.model import Design
+
+
+class BuildUnavailable(RuntimeError):
+    """The backend's toolchain / service isn't available (e.g. no PlatformIO on
+    a cache-miss, or an unreachable build worker). Mirrors RenderUnavailable /
+    CompileUnavailable: the API turns it into a 503 / SSE error frame."""
+
+
+@runtime_checkable
+class BuildBackend(Protocol):
+    """A build path for a target's generated firmware.
+
+    Implementations are cheap to construct and hold no per-build state between
+    calls -- everything needed to resume is addressed by ``job_id``, so a build
+    survives across requests (a remote worker keeps building; the local cache
+    keeps the artifact).
+    """
+
+    id: str
+
+    def status(self) -> dict:
+        """Availability probe. Shape mirrors the other feature gates:
+        ``{"available": bool, "reason": str | None, ...}``."""
+        ...
+
+    def enqueue(self, design: Design, library: Library) -> str:
+        """Return the job id for building ``design``. Cheap and idempotent: the
+        local backend returns the content-addressed cache key (no build yet); a
+        remote worker submits the job and returns its handle."""
+        ...
+
+    def stream(self, job_id: str, design: Design, library: Library) -> Iterator[dict]:
+        """Yield ``{"type": "log", "data": ...}`` events for the build, then a
+        final ``{"type": "done", "ok": bool, "job_id": str, ...}``. The local
+        backend runs the toolchain here (a warm cache replays the stored log);
+        a remote worker polls and re-emits. Raises ``BuildUnavailable`` when the
+        toolchain/service is missing on a cache miss."""
+        ...
+
+    def artifact(self, job_id: str, name: str = "firmware.bin") -> Optional[bytes]:
+        """The built artifact bytes for ``job_id`` (``firmware.bin`` /
+        ``factory.bin``), or None when absent (not built yet, or an OTA backend
+        that installs rather than returns a file)."""
+        ...

--- a/wirestudio/targets/lorawan/__init__.py
+++ b/wirestudio/targets/lorawan/__init__.py
@@ -41,7 +41,13 @@ class LorawanTarget(TargetPlugin):
         # Lazy: keeps the firmware/compile imports out of the target's import path.
         from wirestudio.targets.lorawan.api import build_router
 
-        return build_router(library)
+        return build_router(library, self.build_backend())
+
+    def build_backend(self):
+        # Lazy: keeps the PlatformIO worker imports off the target's import path.
+        from wirestudio.targets.lorawan.build_local import LocalCompileBackend
+
+        return LocalCompileBackend()
 
     def validate(self, design: Design, library: Library) -> list[DesignWarning]:
         warnings: list[DesignWarning] = []

--- a/wirestudio/targets/lorawan/api.py
+++ b/wirestudio/targets/lorawan/api.py
@@ -32,26 +32,28 @@ from pydantic import ValidationError
 
 from wirestudio.library import Library
 from wirestudio.model import Design
-from wirestudio.targets.lorawan.compile import (
-    CompileUnavailable,
-    _default_cache_dir,
-    compile_firmware_events,
-    platformio_status,
-)
+from wirestudio.targets.build_backend import BuildBackend, BuildUnavailable
 from wirestudio.targets.lorawan.firmware_gen import generate_firmware
 
-_KEY_RE = re.compile(r"^[0-9a-f]{1,64}$")
+# A build job id, used as a single path segment to address the artifact. The
+# local backend's id is a hex cache key; a remote worker's is its own handle, so
+# this stays format-agnostic -- alphanumeric start, then word/.-_ chars, no '/'
+# and can't begin with '.', which blocks path traversal.
+_KEY_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$")
 _EUI_RE = re.compile(r"^[0-9a-fA-F]{16}$")
 _ZERO_EUI = "0000000000000000"
 _SSE_HEADERS = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
 
 
-def build_router(library: Library) -> APIRouter:
+def build_router(library: Library, backend: BuildBackend) -> APIRouter:
+    """`backend` is the build path the compile/firmware routes drive. The
+    endpoints know nothing about PlatformIO -- swapping in a remote build worker
+    is a different `backend`, not an endpoint change."""
     router = APIRouter(tags=["lorawan"])
 
     @router.get("/compile/status")
     def compile_status() -> dict:
-        return platformio_status()
+        return backend.status()
 
     @router.post("/compile")
     def compile(design: dict) -> StreamingResponse:
@@ -71,11 +73,13 @@ def build_router(library: Library) -> APIRouter:
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
+        job_id = backend.enqueue(d, library)
+
         def events():
             try:
-                for event in compile_firmware_events(d, library):
+                for event in backend.stream(job_id, d, library):
                     yield f"data: {json.dumps(event)}\n\n"
-            except CompileUnavailable as exc:
+            except BuildUnavailable as exc:
                 yield f"event: error\ndata: {json.dumps({'message': str(exc)})}\n\n"
 
         return StreamingResponse(events(), media_type="text/event-stream", headers=_SSE_HEADERS)
@@ -209,11 +213,11 @@ def build_router(library: Library) -> APIRouter:
     def firmware(cache_key: str) -> Response:
         if not _KEY_RE.match(cache_key):
             raise HTTPException(status_code=404, detail="unknown firmware")
-        bin_path = _default_cache_dir() / cache_key / "firmware.bin"
-        if not bin_path.exists():
+        data = backend.artifact(cache_key)
+        if data is None:
             raise HTTPException(status_code=404, detail="firmware not built; POST /lorawan/compile first")
         return Response(
-            content=bin_path.read_bytes(),
+            content=data,
             media_type="application/octet-stream",
             headers={"Content-Disposition": f'attachment; filename="{cache_key}.bin"'},
         )
@@ -225,11 +229,11 @@ def build_router(library: Library) -> APIRouter:
         on a cache-hit-only worker) -- the app-region path is the fallback."""
         if not _KEY_RE.match(cache_key):
             raise HTTPException(status_code=404, detail="unknown firmware")
-        factory = _default_cache_dir() / cache_key / "factory.bin"
-        if not factory.exists():
+        data = backend.artifact(cache_key, "factory.bin")
+        if data is None:
             raise HTTPException(status_code=404, detail="no factory image for this build")
         return Response(
-            content=factory.read_bytes(),
+            content=data,
             media_type="application/octet-stream",
             headers={"Content-Disposition": f'attachment; filename="{cache_key}-factory.bin"'},
         )

--- a/wirestudio/targets/lorawan/build_local.py
+++ b/wirestudio/targets/lorawan/build_local.py
@@ -1,0 +1,48 @@
+"""Local in-pod PlatformIO build backend for the LoRaWAN target.
+
+Wraps ``compile.py`` (the content-addressed PlatformIO worker) in the
+``BuildBackend`` shape so the lorawan API routes through the seam rather than
+the worker directly. The job id is the cache key, so ``enqueue`` is a pure hash
+(no build) and ``artifact`` reads the cached bin by id without needing the
+design back.
+"""
+from __future__ import annotations
+
+from typing import Iterator, Optional
+
+from wirestudio.library import Library
+from wirestudio.model import Design
+from wirestudio.targets.build_backend import BuildUnavailable
+from wirestudio.targets.lorawan.compile import (
+    CompileUnavailable,
+    _default_cache_dir,
+    cache_key,
+    compile_firmware_events,
+    platformio_status,
+)
+
+
+class LocalCompileBackend:
+    """In-pod PlatformIO build. One build at a time, content-addressed cache."""
+
+    id = "local-platformio"
+
+    def status(self) -> dict:
+        return platformio_status()
+
+    def enqueue(self, design: Design, library: Library) -> str:
+        # The cache key folds in board + region + sub-band + template version,
+        # so it both identifies the job and addresses the cached artifact.
+        return cache_key(design, library)
+
+    def stream(self, job_id: str, design: Design, library: Library) -> Iterator[dict]:
+        # job_id is recomputed from the design by the worker; it's threaded
+        # through so the signature matches a remote backend that polls by id.
+        try:
+            yield from compile_firmware_events(design, library)
+        except CompileUnavailable as exc:
+            raise BuildUnavailable(str(exc)) from exc
+
+    def artifact(self, job_id: str, name: str = "firmware.bin") -> Optional[bytes]:
+        path = _default_cache_dir() / job_id / name
+        return path.read_bytes() if path.exists() else None


### PR DESCRIPTION
## Summary

Phase C of the framework axis: introduces a `BuildBackend` `Protocol` (`status` / `enqueue` / `stream` / `artifact`) behind the LoRaWAN compile + firmware-download routes, with the in-pod PlatformIO worker wrapped as `LocalCompileBackend` and exposed via `LorawanTarget.build_backend()`.

**Purpose.** Structure the framework so a remote LoRaWAN build worker (a build-agent pool, the way fleet-for-esphome pools esphome builds) can be added later as a second backend without touching the API endpoints. A fake poll-style backend in the tests drives the unchanged endpoints end to end, proving the drop-in.

## Scope

Deliberately minimal — no wire-API change, no frontend change, no new concurrency. The two build paths are kept distinct **on purpose**:

- **LoRaWAN flashing is one-at-a-time** (in-pod build + WebSerial), so it keeps its single-shot compile stream.
- **The esphome / fleet path pushes firmware fleet-wide on a schedule**, which is why fleet-for-esphome's submit→`run_id`→poll worker-pool shape is the right one there. Left as-is.

So the seam exists, the fleet routes don't move, and the remote LoRaWAN backend itself is deferred until a build pool is actually wanted — at which point it's a new `BuildBackend` impl, not a rewrite.

## What changed

- **New** `wirestudio/targets/build_backend.py` — `BuildBackend` Protocol + `BuildUnavailable`.
- **New** `wirestudio/targets/lorawan/build_local.py` — `LocalCompileBackend` wrapping `compile.py`.
- **Edit** `wirestudio/targets/base.py` — adds `build_backend() -> BuildBackend | None` (default `None`).
- **Edit** `wirestudio/targets/lorawan/__init__.py` — wires the lorawan target to the local backend; passes it into `build_router`.
- **Edit** `wirestudio/targets/lorawan/api.py` — `/compile/status`, `/compile`, `/firmware/{id}`, `/firmware/{id}/factory` route through `backend.status()` / `enqueue()` / `stream()` / `artifact()` instead of importing the compile worker directly.
- **Edit** `_KEY_RE` on `/firmware/{id}` — was hex-only (assumed a content-hash id), now a backend-agnostic safe-path-segment pattern. Path traversal still blocked (leading `.` rejected, `/` rejected, length capped, the route still returns 404 when the cache dir doesn't have that id).
- **New** `tests/test_build_backend.py` — protocol conformance, local-backend cache-hit replay, cache-miss `BuildUnavailable`, and a `_FakeRemoteBackend` driving the unchanged endpoints end-to-end (proves the drop-in).
- **CHANGELOG** + **START.md** entries.

## Test plan

- [x] `pytest tests/test_build_backend.py tests/test_lorawan_api.py tests/test_compile.py tests/test_targets.py tests/test_fleet.py` → 89 pass.
- [x] Full suite (excluding the kicad-pcb tier that needs external libs): 698 passed, 5 skipped.
- [x] `ruff check` clean.
- [x] Existing wire shapes preserved: `/lorawan/compile/status`, `/lorawan/compile` SSE frames (`{type:"log"}` / `{type:"done"}` / `event: error`), `/lorawan/firmware/{id}{,/factory}` responses — all unchanged. Existing `test_firmware_404_bad_key_format` still passes (the new regex still rejects `not-hex-..`).
- [ ] CI matches local (especially the `build` job — the lorawan firmware build path runs through the seam now).

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_