### PR TITLE
feat(intent): declarative event→action automations (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Intent-to-device synthesis (phase 1 — declarative event→action).** Adds a
+  *functional* layer on top of the existing structural surface: library
+  components gain an optional `capability:` block declaring their `role`
+  (input / sensor / output / controller), the events they `provides`, and the
+  actions they `accepts` with explicit ESPHome verbs. `design.json` gains an
+  `automations: [{trigger, actions}]` graph parallel to the physical
+  `connections` graph. The YAML generator lowers each automation onto the
+  trigger component's `params.<event_key>` (extending any user-authored list,
+  not replacing it), so the existing library templates render it as the right
+  ESPHome trigger block — for the worked example
+  (`button-toggles-light.json`), a press lowers to
+  `on_press: [{switch.toggle: porch_light}]`. The `/design/validate` endpoint
+  surfaces dangling refs as permissive warnings (`automation_unknown_component`,
+  `automation_component_no_capability`, `automation_unknown_event`,
+  `automation_unknown_action`) — half-authored automations don't block
+  rendering, they just don't fire. Annotated `gpio_input` + `gpio_output` (the
+  two components the worked example needs); the remaining ~58 library entries
+  pick up annotations in phase 1.5. Value→transform→action (the encoder /
+  stepper case) and a live `esphome config` authoring loop arrive in later
+  phases per `docs/intent-to-device.md`.
+
 - **Build-backend seam (framework axis, phase C — structural).** A
   `BuildBackend` protocol (`status` / `enqueue` / `stream` / `artifact`) now
   sits behind the LoRaWAN compile + firmware-download routes, with the in-pod

--- a/docs/intent-to-device.md
+++ b/docs/intent-to-device.md
@@ -1,0 +1,245 @@
+# Intent-to-device synthesis (design direction)
+
+Status: **phase 1 shipped** (declarative event→action, narrow). On `main`:
+the `capability` library block, the `automations` schema in `design.json`,
+generator lowering, the permissive validator, and the `button-toggles-light`
+worked example. `gpio_input` + `gpio_output` are annotated; the rest of the
+library picks up annotations in phase 1.5. Value→transform→action (the
+encoder→stepper case), multi-device topology, and a live `esphome config`
+authoring loop arrive in later phases per *Suggested phasing* below.
+
+This document was the agreed plan; per-phase work updates this status line in
+place rather than appending a new file each time.
+
+## Problem
+
+Today the MCP/agent surface is *structural*: pick a board, add components, wire
+pins, solve pins, render YAML. That gets the user correct hardware. It does not
+get them a device that *does the thing they asked for* -- "push a button and a
+light turns on", "detect motion", "turn this knob and the motor follows". The
+behavior -- ESPHome's automations, triggers, actions, lambdas, and the
+cross-entity wiring between them -- is the missing layer.
+
+The goal: the model interpreting a request must know enough about *how ESPHome
+functions* to (a) decide which components are needed, (b) wire them together --
+physically and behaviorally -- to produce the requested outcome, and (c)
+recognize when a single device cannot satisfy the intent and walk the user
+through building the multiple devices it does require.
+
+## Two kinds of knowledge
+
+The catalog/recommender work buys *syntactic* knowledge -- what configuration is
+valid (platforms, fields, types, which `on_*` keys exist). That is importable
+from ESPHome's schema and is the easy half.
+
+The hard half is *functional* knowledge -- what each piece **does** and how
+pieces **compose** into a behavior. Raw schema does not carry this: it says
+`binary_sensor.gpio` has an `on_press` key taking an action list; it does not
+say "a button is an input that emits press events you hang actions on." That
+functional layer is what lets the model select and connect, and it is the core
+of this work.
+
+## The functional/capability layer
+
+Annotate every library component (and, by derivation, every ESPHome platform)
+with four things:
+
+1. **Role** -- input event source / sensor value source / output actuator /
+   controller. ("Motion detector" -> binary_sensor input, device_class motion;
+   "dimmable light" -> PWM output under a `light` platform.)
+2. **`provides`** -- events and values the entity emits. Button: press / release
+   / click. Encoder: rotation events + a cumulative value. Temp sensor: a float.
+3. **`accepts`** -- actions and state the entity takes. Light/switch: turn_on /
+   off / toggle. Stepper: set_target. Number: set-value.
+4. **Composition grammar** -- the small, finite set of ways ESPHome links
+   behavior. Most intent reduces to combinations of five:
+   - event -> action
+   - value -> transform -> action (the lambda case)
+   - state-condition gating (`if` / `condition`)
+   - periodic (`interval`)
+   - stateful glue (`global` to remember, `script` to reuse)
+
+Provenance: trigger/action *names* and argument shapes come from ESPHome's
+schema (import-for-vocabulary, honoring "schema-derived data only, no vendoring
+upstream source"). Role and provides/accepts *semantics* need a thin curated
+annotation pass on the library, with derivation where the schema makes it
+inferable. This annotation + the grammar is the actual deliverable.
+
+Proposed library shape (per component YAML), additive and optional:
+
+```yaml
+capability:
+  role: input            # input | sensor | output | controller
+  provides:
+    - {event: on_press,   kind: event}
+    - {event: on_release, kind: event}
+  accepts: []            # an input typically accepts nothing
+```
+
+```yaml
+capability:
+  role: output
+  provides: []
+  accepts:
+    - {action: turn_on,  esphome: switch.turn_on}
+    - {action: turn_off, esphome: switch.turn_off}
+    - {action: toggle,   esphome: switch.toggle}
+```
+
+## The behavioral graph in design.json
+
+`design.json` stays the single source of truth. Add a first-class, optional
+`automations` list -- the behavioral graph, parallel to the existing physical
+graph (connections + buses):
+
+```jsonc
+"automations": [
+  {
+    "id": "btn_toggles_light",
+    "trigger": {"component_id": "porch_button", "event": "on_press"},
+    "conditions": [],
+    "actions": [
+      {"component_id": "porch_light", "action": "toggle"}
+    ]
+  }
+]
+```
+
+For the computed cases the action carries a `transform` (a typed expression the
+generator lowers to a `!lambda`), so the value-mapping recipe is reviewed code,
+not free-handed YAML. Lowering is a pure function of `design.json` + the
+capability annotations -- same contract as every other generator. The agent's
+job is intent -> automation structure; the generator owns the YAML.
+
+Two worked examples to validate the schema (built first):
+`button_toggles_light` (event -> action) and `encoder_drives_stepper`
+(value -> transform -> action).
+
+## Connecting them: two graphs over the same parts
+
+- **Physical graph** -- pins, buses, power. Already built (`set_connection`,
+  `add_bus`, `solve_pins`).
+- **Behavioral graph** -- connect one component's `provides` to another's
+  `accepts`, optionally through a transform. New.
+
+The model's job reads cleanly: **intent -> required roles -> components that
+fill those roles -> wire both graphs.** This generalizes past enumerated
+templates because it reasons over roles/provides/accepts, not string matches.
+
+## When one device is not enough (topology)
+
+Some intent is inherently distributed: "push a button in this room, have a thing
+happen in another room." The input and the output live on different physical
+nodes, so it cannot be one `design.json`. The model must:
+
+1. **Detect** -- the requested input role and output role cannot share a board
+   (different locations, or a count/placement the user states). This is a
+   topology check, distinct from "this board lacks a free pin."
+2. **Explain** -- tell the user plainly: this needs N devices, here is what each
+   does, and the link between them rides the network, not a wire. Surface the
+   transport tradeoff (below) rather than silently picking one.
+3. **Walk through** -- create each device design in turn (reusing single-device
+   synthesis), then wire the cross-device link, then summarize what lives where.
+
+### The ESPHome boundary
+
+Cross-device behavior is **not** an ESPHome automation -- ESPHome automations
+are intra-device. Across devices the connective tissue is one of:
+
+- **Home Assistant (default).** Device A exposes the button as an entity over
+  the `api:` (already emitted in the base config); an HA automation turns on
+  device B. The link lives in HA, not in either ESPHome YAML -- so the
+  deliverable is two device YAMLs **plus** an HA automation we surface (and can
+  optionally emit as a YAML snippet the user pastes into HA).
+- **Device-to-device native.** ESPHome's `homeassistant` sensor platform (B
+  subscribes to an HA entity), `api` services, or MQTT -- still HA/broker-
+  mediated but expressible largely in ESPHome YAML.
+- **ESP-NOW.** Direct node-to-node, no HA/broker. Lowest latency, no
+  infrastructure, but its own setup and no HA visibility.
+
+The agent must understand that "make X in room A do Y in room B" usually implies
+Home Assistant (or a broker) as a required component of the *system*, and say so
+-- this is exactly the "a single device may not accomplish the intent" case the
+user must be told about up front.
+
+### System/topology model
+
+Proposed: a lightweight `system` concept that groups device designs and declares
+the links between them. Two options to decide between:
+
+- **A -- explicit system object.** A new `system.json` referencing member design
+  ids and a `links: [{from: {design, component, event}, to: {design, component,
+  action}, transport: ha|mqtt|espnow}]` list. Clean, inspectable, but a new
+  top-level artifact beyond `design.json`.
+- **B -- links as design metadata.** Keep designs independent; each carries a
+  `peer_links` block referencing the peer design id + transport. No new artifact,
+  but the system view is reconstructed by scanning designs.
+
+Recommendation: **A**, because the cross-device link is a relationship that
+belongs to neither device alone, and a system object gives the agent a place to
+reason about and the UI a place to show the whole topology. Flagging as a
+decision to lock -- B is viable if we want to avoid a second artifact type.
+
+## How the agent acquires and uses the knowledge
+
+- **Schema import** -- ESPHome's generated schema as both an MCP *resource* the
+  agent can query ("what triggers does this platform expose? what args does
+  `stepper.set_target` take?") and the structural validator.
+- **Capability annotations** -- the role/provides/accepts function layer on the
+  library (above).
+- **Composition grammar + topology rules** -- distilled authoring guidance in
+  the tool/system prompt: how to wire provides->accepts, when a transform is
+  needed, and the single-vs-multi-device decision with its transport tradeoffs.
+- **Correctness backstop -- a validation loop, not a constrained vocabulary.**
+  Two stages: cheap structural validation against the imported schema (trigger
+  exists on platform? action args valid? referenced `component_id` resolves?),
+  then the authoritative `esphome config` check already run by
+  `scripts/check_examples.py` + the esphome-config workflow. The leverage is
+  putting that compile step *inside the agent's authoring loop* so it
+  self-corrects before output reaches the user. Open authoring is made safe by
+  *checking* the result, not by limiting what the agent can say.
+
+## MCP / agent surface additions
+
+- `query_capability(component_id | platform)` -- read-only; returns role /
+  provides / accepts. Lets the agent reason instead of guess.
+- `add_automation` / `remove_automation` -- author the behavioral graph
+  (validated against capability annotations).
+- `suggest_topology(intent)` / `link_devices(...)` -- detect the multi-device
+  case and create the system + links.
+- Session changes: the active-design model extends to a *system* context so a
+  single walkthrough can create and switch between multiple device designs.
+
+## Architecture fit and constraints
+
+- `design.json` stays the single source of truth; generators stay pure
+  functions of `design.json` (+ system.json) + library + schema-derived data.
+- Schema-derived data only; no vendored upstream ESPHome source.
+- Secrets never enter `design.json` / `system.json` -- HA/MQTT credentials stay
+  referenced via fleet-for-esphome's `secrets.yaml`.
+- Permissive mode: an unsatisfiable or partially-wired automation surfaces in
+  `warnings[]`, it does not block generation.
+- No premature abstraction: build `button_toggles_light` and
+  `encoder_drives_stepper` against the real schema first; generalize the grammar
+  only as a third and fourth case demand it.
+
+## Decisions to lock before scoping
+
+1. System topology model: **A (system object)** vs **B (link metadata)**.
+2. Cross-device default transport surfaced first: Home Assistant (recommended)
+   vs MQTT vs ESP-NOW -- and whether we *emit* the HA automation snippet or only
+   describe it.
+3. Does the agent get a live `esphome config` check *in its authoring loop*
+   (required for safe open-ended intent), or does generation stay deterministic
+   with the IR as the ceiling on expressible behavior?
+4. Capability annotation: hand-authored on the library now, or blocked on the
+   ESPHome schema importer landing first.
+
+## Suggested phasing
+
+1. Capability annotations + `automations` schema + deterministic lowering +
+   the two worked examples, gated by `esphome config`. (Single-device behavior.)
+2. ESPHome schema import as MCP resource + structural validator; the agent
+   authoring loop.
+3. System/topology model + cross-device links + the detect/explain/walkthrough
+   flow.

--- a/tests/golden/button-toggles-light.txt
+++ b/tests/golden/button-toggles-light.txt
@@ -1,0 +1,20 @@
++---------------------------------------------------------------------+
+|  WeMos D1 Mini  ---  button-toggles-light                           |
++---------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                |
+|                                                                     |
+|  porch_button  [Generic GPIO binary sensor]  -- Porch Button        |
+|    IN    -> D5                                                      |
+|                                                                     |
+|  porch_light  [Generic GPIO switch / relay output]  -- Porch Light  |
+|    OUT   -> D6                                                      |
+|                                                                     |
+|  BOM:                                                               |
+|    - WeMos D1 Mini                                                  |
+|    - Generic GPIO binary sensor  (porch_button)                     |
+|    - Generic GPIO switch / relay output  (porch_light)              |
+|                                                                     |
+|  Power: ~0mA typical, ~0mA peak (budget 500mA)  OK                  |
+|                                                                     |
+|  Warnings: none                                                     |
++---------------------------------------------------------------------+

--- a/tests/golden/button-toggles-light.yaml
+++ b/tests/golden/button-toggles-light.yaml
@@ -1,0 +1,25 @@
+esphome:
+  name: porch-button-light
+esp8266:
+  board: d1_mini
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+binary_sensor:
+- platform: gpio
+  pin: D5
+  name: Porch Button
+  id: porch_button
+  on_press:
+  - switch.toggle: porch_light
+switch:
+- platform: gpio
+  pin: D6
+  name: Porch Light
+  id: porch_light

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -1,0 +1,216 @@
+"""Intent-to-device synthesis (phase 1): library capability annotations,
+automation schema in design.json, generator lowering, validator warnings."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wirestudio.generate.yaml_gen import _lower_automations, render_yaml
+from wirestudio.intent import validate_automations
+from wirestudio.library import default_library
+from wirestudio.model import Automation, AutomationAction, AutomationTrigger, Design
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE = REPO_ROOT / "wirestudio" / "examples" / "button-toggles-light.json"
+
+
+@pytest.fixture
+def lib():
+    return default_library()
+
+
+@pytest.fixture
+def example(lib) -> Design:
+    return Design.model_validate(json.loads(EXAMPLE.read_text()))
+
+
+def _design(automations: list[dict]) -> Design:
+    return Design.model_validate({
+        "schema_version": "0.1",
+        "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [
+            {"id": "btn", "library_id": "gpio_input",  "label": "Button"},
+            {"id": "lt",  "library_id": "gpio_output", "label": "Light"},
+        ],
+        "connections": [
+            {"component_id": "btn", "pin_role": "IN",  "target": {"kind": "gpio", "pin": "D5"}},
+            {"component_id": "lt",  "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+        "automations": automations,
+    })
+
+
+# --- schema --------------------------------------------------------------
+
+def test_gpio_input_carries_a_capability_block(lib):
+    cap = lib.component("gpio_input").capability
+    assert cap is not None
+    assert cap.role == "input"
+    assert {p.event for p in cap.provides} == {"on_press", "on_release", "on_click", "on_state"}
+    assert cap.accepts == []  # an input has no actions
+
+
+def test_gpio_output_carries_actions_with_explicit_esphome_verbs(lib):
+    cap = lib.component("gpio_output").capability
+    assert cap is not None
+    assert cap.role == "output"
+    by_action = {a.action: a.esphome for a in cap.accepts}
+    assert by_action == {
+        "turn_on":  "switch.turn_on",
+        "turn_off": "switch.turn_off",
+        "toggle":   "switch.toggle",
+    }
+
+
+def test_unannotated_components_keep_capability_none(lib):
+    # The annotation rollout is incremental; an un-annotated component still
+    # loads, it just can't participate in `automations` yet.
+    assert lib.component("hc-sr501").capability is None
+
+
+def test_automation_round_trips_through_the_model():
+    d = _design([{
+        "id": "a1",
+        "trigger": {"component_id": "btn", "event": "on_press"},
+        "actions": [{"component_id": "lt", "action": "toggle"}],
+    }])
+    assert len(d.automations) == 1
+    a = d.automations[0]
+    assert isinstance(a, Automation)
+    assert isinstance(a.trigger, AutomationTrigger)
+    assert isinstance(a.actions[0], AutomationAction)
+    assert a.trigger.event == "on_press"
+
+
+# --- lowering ------------------------------------------------------------
+
+def test_lowering_emits_short_form_when_no_args(lib):
+    d = _design([{
+        "id": "a1",
+        "trigger": {"component_id": "btn", "event": "on_press"},
+        "actions": [{"component_id": "lt", "action": "toggle"}],
+    }])
+    out = _lower_automations(d, lib)
+    assert out == {"btn": {"on_press": [{"switch.toggle": "lt"}]}}
+
+
+def test_lowering_emits_long_form_when_args_present(lib):
+    # gpio_output's accept verbs don't take args today, but the lowering
+    # shape must handle the general case (light.turn_on with brightness etc.)
+    # so the path is exercised here against the gpio_output adapter.
+    d = _design([{
+        "id": "a1",
+        "trigger": {"component_id": "btn", "event": "on_press"},
+        "actions": [{"component_id": "lt", "action": "turn_on", "args": {"transition_length": "1s"}}],
+    }])
+    out = _lower_automations(d, lib)
+    assert out == {"btn": {"on_press": [
+        {"switch.turn_on": {"id": "lt", "transition_length": "1s"}},
+    ]}}
+
+
+def test_lowering_extends_a_user_authored_param_list(lib):
+    # If a user already set params.on_press to a raw action list (the
+    # escape hatch), the automation-graph entries extend that list rather
+    # than silently replacing it -- nothing the user wrote is lost.
+    d = _design([{
+        "id": "a1",
+        "trigger": {"component_id": "btn", "event": "on_press"},
+        "actions": [{"component_id": "lt", "action": "toggle"}],
+    }])
+    btn = next(c for c in d.components if c.id == "btn")
+    btn.params["on_press"] = [{"logger.log": "manual"}]
+    yaml = render_yaml(d, lib)
+    assert 'on_press' in yaml
+    # Both the user-authored logger.log AND the lowered switch.toggle land.
+    assert "logger.log: manual" in yaml
+    assert "switch.toggle: porch_light" not in yaml  # different ids in this fixture
+    assert "switch.toggle: lt" in yaml
+
+
+def test_lowering_silently_drops_dangling_refs_in_yaml(lib):
+    # The validator surfaces the warning; the renderer must not emit invalid
+    # YAML referencing the missing id.
+    d = _design([{
+        "id": "a1",
+        "trigger": {"component_id": "btn", "event": "on_press"},
+        "actions": [{"component_id": "nope", "action": "toggle"}],
+    }])
+    yaml = render_yaml(d, lib)
+    assert "nope" not in yaml          # no dangling ref in the output
+    assert "on_press" not in yaml      # the trigger has no actions, so the key drops too
+
+
+# --- generator end-to-end + golden ---------------------------------------
+
+def test_button_toggles_light_example_matches_golden(example, lib):
+    expected = (REPO_ROOT / "tests" / "golden" / "button-toggles-light.yaml").read_text()
+    assert render_yaml(example, lib) == expected
+
+
+def test_button_toggles_light_yaml_contains_the_lowered_automation(example, lib):
+    yaml = render_yaml(example, lib)
+    assert "on_press:\n  - switch.toggle: porch_light" in yaml
+
+
+# --- validator -----------------------------------------------------------
+
+def test_validator_quiet_on_a_well_formed_automation(example, lib):
+    assert validate_automations(example, lib) == []
+
+
+def test_validator_flags_unknown_trigger_component(lib):
+    d = _design([{
+        "id": "a1",
+        "trigger": {"component_id": "missing", "event": "on_press"},
+        "actions": [{"component_id": "lt", "action": "toggle"}],
+    }])
+    codes = [w.code for w in validate_automations(d, lib)]
+    assert "automation_unknown_component" in codes
+
+
+def test_validator_flags_unknown_event(lib):
+    d = _design([{
+        "id": "a1",
+        "trigger": {"component_id": "btn", "event": "on_double_press"},  # not provided
+        "actions": [{"component_id": "lt", "action": "toggle"}],
+    }])
+    warns = validate_automations(d, lib)
+    assert any(w.code == "automation_unknown_event" for w in warns)
+    assert any("on_press" in w.text for w in warns)  # lists what IS provided
+
+
+def test_validator_flags_unknown_action(lib):
+    d = _design([{
+        "id": "a1",
+        "trigger": {"component_id": "btn", "event": "on_press"},
+        "actions": [{"component_id": "lt", "action": "set_brightness"}],  # not accepted
+    }])
+    codes = [w.code for w in validate_automations(d, lib)]
+    assert "automation_unknown_action" in codes
+
+
+def test_validator_flags_component_without_capability(lib):
+    # hc-sr501 has no capability block, so it can't be used as a trigger
+    # source even though it's a real component in the library.
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [
+            {"id": "pir", "library_id": "hc-sr501", "label": "PIR"},
+            {"id": "lt",  "library_id": "gpio_output", "label": "Light"},
+        ],
+        "automations": [{
+            "id": "a1",
+            "trigger": {"component_id": "pir", "event": "on_state"},
+            "actions": [{"component_id": "lt", "action": "turn_on"}],
+        }],
+    })
+    codes = [w.code for w in validate_automations(d, lib)]
+    assert "automation_component_no_capability" in codes

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -75,6 +75,7 @@ from wirestudio.designs.events import DesignEventBus, EventEmittingDesignStore
 from wirestudio.fleet.client import FleetClient, FleetUnavailable
 from wirestudio.csp.compatibility import check_pin_compatibility
 from wirestudio.csp.pin_solver import solve_pins as run_solve_pins
+from wirestudio.intent import validate_automations
 from wirestudio.enclosure import (
     EnclosureUnavailable,
     default_sources,
@@ -394,8 +395,11 @@ def create_app(
         d = _validate_design(design)
         # Append the active target's permissive checks. esphome adds none,
         # so existing designs see no change; lorawan flags a non-radio board
-        # or a missing config block.
+        # or a missing config block. The intent-to-device automation
+        # validator surfaces dangling trigger/action refs the same way
+        # (warnings, not blocks) so a half-authored automation can render.
         target_warnings = get_target(d.target).validate(d, lib)
+        automation_warnings = validate_automations(d, lib)
         return ValidateResponse(
             ok=True,
             design_id=d.id,
@@ -403,7 +407,10 @@ def create_app(
             component_count=len(d.components),
             bus_count=len(d.buses),
             connection_count=len(d.connections),
-            warnings=[w.model_dump() for w in list(d.warnings) + target_warnings],
+            warnings=[
+                w.model_dump()
+                for w in list(d.warnings) + target_warnings + automation_warnings
+            ],
             compatibility_warnings=_wire_compat(check_pin_compatibility(design, lib)),
         )
 

--- a/wirestudio/examples/button-toggles-light.json
+++ b/wirestudio/examples/button-toggles-light.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "0.1",
+  "id": "button-toggles-light",
+  "name": "Porch button toggles porch light",
+  "description": "Phase 1 worked example for intent-to-device synthesis: one GPIO button toggles one GPIO switch (relay/LED/mosfet). The trigger -> action wiring lives in `automations` (not as a raw `params.on_press` blob), so the generator lowers it from the library's `capability` blocks into ESPHome's `on_press: [{switch.toggle: porch_light}]`.",
+  "created_at": "2026-06-15T08:00:00Z",
+  "updated_at": "2026-06-15T08:00:00Z",
+
+  "board": {
+    "library_id": "wemos-d1-mini",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-rt9013",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "press button to toggle the porch light" }
+  ],
+
+  "components": [
+    {
+      "id": "porch_button",
+      "library_id": "gpio_input",
+      "label": "Porch Button"
+    },
+    {
+      "id": "porch_light",
+      "library_id": "gpio_output",
+      "label": "Porch Light"
+    }
+  ],
+
+  "buses": [],
+
+  "connections": [
+    { "component_id": "porch_button", "pin_role": "IN",  "target": { "kind": "gpio", "pin": "D5" } },
+    { "component_id": "porch_light",  "pin_role": "OUT", "target": { "kind": "gpio", "pin": "D6" } }
+  ],
+
+  "passives": [],
+
+  "automations": [
+    {
+      "id": "porch_button_toggles_light",
+      "trigger": { "component_id": "porch_button", "event": "on_press" },
+      "actions": [
+        { "component_id": "porch_light", "action": "toggle" }
+      ]
+    }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "porch-button-light",
+    "tags": ["intent-to-device", "phase-1", "example"],
+    "secrets_ref": {
+      "wifi_ssid":     "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key":       "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -110,7 +110,63 @@ def _deep_merge(dst: dict, src: dict) -> dict:
     return dst
 
 
-def _render_component(comp: Component, design: Design, library: Library) -> dict[str, Any]:
+def _lower_automations(design: Design, library: Library) -> dict[str, dict[str, list]]:
+    """Lower `design.automations` into a `{component_id: {event_key: [actions]}}`
+    map the renderer merges into the trigger component's `params`. Returns an
+    empty map when a referenced component / event / action can't be resolved --
+    the validator surfaces those as warnings; the renderer just drops the
+    automation rather than emit invalid YAML.
+    """
+    by_id = {c.id: c for c in design.components}
+    out: dict[str, dict[str, list]] = {}
+    for auto in design.automations:
+        trig_comp = by_id.get(auto.trigger.component_id)
+        if trig_comp is None:
+            continue
+        try:
+            trig_lib = library.component(trig_comp.library_id)
+        except FileNotFoundError:
+            continue
+        cap = trig_lib.capability
+        if cap is None:
+            continue
+        provide = next((p for p in cap.provides if p.event == auto.trigger.event), None)
+        if provide is None:
+            continue
+        event_key = provide.esphome or provide.event
+
+        action_list: list = []
+        for act in auto.actions:
+            act_comp = by_id.get(act.component_id)
+            if act_comp is None:
+                continue
+            try:
+                act_lib = library.component(act_comp.library_id)
+            except FileNotFoundError:
+                continue
+            act_cap = act_lib.capability
+            if act_cap is None:
+                continue
+            accept = next((a for a in act_cap.accepts if a.action == act.action), None)
+            if accept is None:
+                continue
+            # Short form when there are no extra args: `{switch.toggle: porch_light}`.
+            # Long form with args:                     `{light.turn_on: {id: porch_light, brightness: "50%"}}`.
+            if act.args:
+                action_list.append({accept.esphome: {"id": act.component_id, **act.args}})
+            else:
+                action_list.append({accept.esphome: act.component_id})
+
+        if not action_list:
+            continue
+        out.setdefault(trig_comp.id, {}).setdefault(event_key, []).extend(action_list)
+    return out
+
+
+def _render_component(
+    comp: Component, design: Design, library: Library,
+    auto_params: dict[str, dict[str, list]] | None = None,
+) -> dict[str, Any]:
     lib_comp = library.component(comp.library_id)
     template_str = lib_comp.esphome.yaml_template
     if not template_str.strip():
@@ -132,10 +188,25 @@ def _render_component(comp: Component, design: Design, library: Library) -> dict
         }
     except FileNotFoundError:
         board_ctx = None
+    # Merge lowered automations into params: each `params.on_*` list extends
+    # any user-authored list rather than replacing it, so the existing escape
+    # hatch (raw action YAML in `params.on_press`) still composes with new
+    # automation-graph entries instead of silently losing either side.
+    params = dict(comp.params)
+    if auto_params:
+        for key, actions in auto_params.get(comp.id, {}).items():
+            existing = params.get(key)
+            if isinstance(existing, list):
+                params[key] = existing + actions
+            elif existing is None:
+                params[key] = actions
+            else:
+                # Existing param wasn't a list (single action dict); coerce.
+                params[key] = [existing, *actions]
     ctx = {
         "id": comp.id,
         "label": comp.label,
-        "params": dict(comp.params),
+        "params": params,
         "pins": _pins_for(comp.id, design, library),
         "bus": bus.model_dump() if bus else None,
         "parent": parent,
@@ -265,8 +336,9 @@ def build_yaml_dict(design: Design, library: Library) -> dict[str, Any]:
             }
             out.setdefault("one_wire", []).append(wire_entry)
 
+    auto_params = _lower_automations(design, library)
     for comp in design.components:
-        _deep_merge(out, _render_component(comp, design, library))
+        _deep_merge(out, _render_component(comp, design, library, auto_params))
 
     if extras:
         _deep_merge(out, extras)

--- a/wirestudio/intent.py
+++ b/wirestudio/intent.py
@@ -1,0 +1,100 @@
+"""Intent-to-device synthesis (phase 1): validate the `automations` graph.
+
+Phase 1 covers declarative event -> action only (the `button_toggles_light`
+shape). Each automation's trigger references a component that must `provide`
+the named event in its library capability block; each action references a
+component that must `accept` the named action. The validator surfaces dangling
+references as permissive warnings (CLAUDE.md: warnings, don't block) so a
+half-authored automation doesn't refuse to render -- it just doesn't fire.
+
+The generator's lowering (``yaml_gen._lower_automations``) drops the same
+unresolved entries silently rather than emit invalid YAML, so the warnings here
+are what tells the user *why* nothing happened.
+"""
+from __future__ import annotations
+
+from wirestudio.library import Library
+from wirestudio.model import Design, DesignWarning
+
+
+def validate_automations(design: Design, library: Library) -> list[DesignWarning]:
+    """Permissive checks over `design.automations`. Returns DesignWarnings;
+    never raises. Each warning's `code` is one of:
+
+    - ``automation_unknown_component``: trigger or action references an id
+      that isn't in `design.components`.
+    - ``automation_component_no_capability``: the referenced component's
+      library entry has no `capability` block (so it can't trigger or act).
+    - ``automation_unknown_event``: the event name isn't in the trigger
+      component's `capability.provides`.
+    - ``automation_unknown_action``: the action name isn't in the action
+      component's `capability.accepts`.
+    """
+    out: list[DesignWarning] = []
+    by_id = {c.id: c for c in design.components}
+    for auto in design.automations:
+        trig = auto.trigger
+        trig_comp = by_id.get(trig.component_id)
+        if trig_comp is None:
+            out.append(DesignWarning(
+                level="warn", code="automation_unknown_component",
+                text=(f"automation {auto.id!r}: trigger component "
+                      f"{trig.component_id!r} is not in the design"),
+            ))
+        else:
+            try:
+                lib_comp = library.component(trig_comp.library_id)
+            except FileNotFoundError:
+                # Unknown library_id surfaces from the core validators.
+                lib_comp = None
+            if lib_comp is not None:
+                cap = lib_comp.capability
+                if cap is None:
+                    out.append(DesignWarning(
+                        level="warn", code="automation_component_no_capability",
+                        text=(f"automation {auto.id!r}: trigger component "
+                              f"{trig.component_id!r} (library_id="
+                              f"{trig_comp.library_id!r}) has no capability "
+                              f"block and can't trigger automations"),
+                    ))
+                elif not any(p.event == trig.event for p in cap.provides):
+                    provided = ", ".join(p.event for p in cap.provides) or "(none)"
+                    out.append(DesignWarning(
+                        level="warn", code="automation_unknown_event",
+                        text=(f"automation {auto.id!r}: component "
+                              f"{trig.component_id!r} does not provide event "
+                              f"{trig.event!r}; provides: {provided}"),
+                    ))
+
+        for act in auto.actions:
+            act_comp = by_id.get(act.component_id)
+            if act_comp is None:
+                out.append(DesignWarning(
+                    level="warn", code="automation_unknown_component",
+                    text=(f"automation {auto.id!r}: action component "
+                          f"{act.component_id!r} is not in the design"),
+                ))
+                continue
+            try:
+                act_lib = library.component(act_comp.library_id)
+            except FileNotFoundError:
+                continue
+            cap = act_lib.capability
+            if cap is None:
+                out.append(DesignWarning(
+                    level="warn", code="automation_component_no_capability",
+                    text=(f"automation {auto.id!r}: action component "
+                          f"{act.component_id!r} (library_id="
+                          f"{act_comp.library_id!r}) has no capability block "
+                          f"and can't be an automation target"),
+                ))
+                continue
+            if not any(a.action == act.action for a in cap.accepts):
+                accepted = ", ".join(a.action for a in cap.accepts) or "(none)"
+                out.append(DesignWarning(
+                    level="warn", code="automation_unknown_action",
+                    text=(f"automation {auto.id!r}: component "
+                          f"{act.component_id!r} does not accept action "
+                          f"{act.action!r}; accepts: {accepted}"),
+                ))
+    return out

--- a/wirestudio/library/__init__.py
+++ b/wirestudio/library/__init__.py
@@ -88,6 +88,41 @@ class EsphomeSpec(_Strict):
     expander_pin_key: Optional[str] = None
 
 
+class CapabilityProvides(_Strict):
+    """One event/value a component emits, used as an `automations` trigger.
+
+    `event` is the name a design references (the same name the existing ESPHome
+    template `params.<event>` passthrough uses, e.g. `on_press`). `esphome`
+    overrides the rendered ESPHome trigger key when it differs from `event`;
+    defaults to `event` so the common case is a single line per provide.
+    """
+    event: str
+    kind: Literal["event", "value"] = "event"
+    esphome: Optional[str] = None
+
+
+class CapabilityAccepts(_Strict):
+    """One action a component takes, used as an `automations` action target.
+
+    `action` is the studio-side name (e.g. `turn_on`); `esphome` is the
+    explicit ESPHome action verb the generator lowers to (e.g.
+    `switch.turn_on`). Explicit rather than category-inferred so the mapping
+    is reviewed code, not a runtime guess.
+    """
+    action: str
+    esphome: str
+
+
+class Capability(_Strict):
+    """Functional layer (intent-to-device synthesis): what role this component
+    plays, what events/values it `provides` to triggers, and what actions it
+    `accepts` from automations. Optional per component; an unannotated
+    component simply cannot be a trigger or action target."""
+    role: Literal["input", "sensor", "output", "controller"]
+    provides: list[CapabilityProvides] = Field(default_factory=list)
+    accepts: list[CapabilityAccepts] = Field(default_factory=list)
+
+
 class LibraryComponent(_Strict):
     id: str
     name: str
@@ -97,6 +132,7 @@ class LibraryComponent(_Strict):
     electrical: Electrical = Field(default_factory=Electrical)
     esphome: EsphomeSpec = Field(default_factory=EsphomeSpec)
     lorawan: Optional[LorawanSpec] = None
+    capability: Optional[Capability] = None
     params_schema: dict = Field(default_factory=dict)
     notes: Optional[str] = None
     kicad: Optional[KicadSymbolRef] = None

--- a/wirestudio/library/components/gpio_input.yaml
+++ b/wirestudio/library/components/gpio_input.yaml
@@ -43,6 +43,18 @@ esphome:
         on_state: {{ params.on_state | tojson }}
     {%- endif %}
 
+capability:
+  # Functional layer (intent-to-device): a button/contact is an input that
+  # emits press / release / click events plus a boolean state value. The
+  # generator lowers `automations` triggers into the matching params.on_*
+  # keys the ESPHome template above already passes through.
+  role: input
+  provides:
+    - {event: on_press}
+    - {event: on_release}
+    - {event: on_click}
+    - {event: on_state, kind: value}
+
 params_schema:
   device_class:
     type: string

--- a/wirestudio/library/components/gpio_output.yaml
+++ b/wirestudio/library/components/gpio_output.yaml
@@ -34,6 +34,19 @@ esphome:
         on_turn_off: {{ params.on_turn_off | tojson }}
     {%- endif %}
 
+capability:
+  # Functional layer (intent-to-device): a relay / mosfet / indicator is a
+  # switchable output. Triggers in automations targeting this component lower
+  # to ESPHome's `switch.turn_on` / `turn_off` / `toggle` action verbs.
+  role: output
+  provides:
+    - {event: on_turn_on}
+    - {event: on_turn_off}
+  accepts:
+    - {action: turn_on,  esphome: switch.turn_on}
+    - {action: turn_off, esphome: switch.turn_off}
+    - {action: toggle,   esphome: switch.toggle}
+
 params_schema:
   icon:
     type: string

--- a/wirestudio/model.py
+++ b/wirestudio/model.py
@@ -135,6 +135,39 @@ class DesignWarning(_Strict):
     text: str
 
 
+class AutomationTrigger(_Strict):
+    """The event side of one automation: a component emits an event the
+    component's library `capability.provides` declares. `component_id` is a
+    design-level id (the validator checks it resolves)."""
+    component_id: str
+    event: str
+
+
+class AutomationAction(_Strict):
+    """The action side: a component takes an action its library
+    `capability.accepts` declares. `args` are extra ESPHome action args
+    (e.g. `{brightness: "50%"}`) that ride alongside the action target id."""
+    component_id: str
+    action: str
+    args: dict = Field(default_factory=dict)
+
+
+class Automation(_Strict):
+    """One trigger→actions wiring (intent-to-device synthesis, phase 1).
+
+    Declarative event→action only -- value/transform, condition gating, and
+    the periodic / stateful composition patterns from the design doc arrive
+    in later phases. The generator lowers each automation onto the trigger
+    component's params, where the existing ESPHome `params.on_*` passthrough
+    in the library YAML emits it. An automation referencing an unknown
+    component / event / action surfaces as a permissive warning, not a hard
+    failure (CLAUDE.md: warnings, don't block).
+    """
+    id: str
+    trigger: AutomationTrigger
+    actions: list[AutomationAction]
+
+
 class Fleet(_Strict):
     device_name: Optional[str] = None
     tags: list[str] = Field(default_factory=list)
@@ -201,6 +234,10 @@ class Design(_Strict):
     buses: list[Bus] = Field(default_factory=list)
     connections: list[Connection] = Field(default_factory=list)
     passives: list[Passive] = Field(default_factory=list)
+    # Behavioral graph: trigger -> actions wiring lowered into ESPHome
+    # automations by the generator. Parallel to the physical `connections`
+    # graph; optional, default empty so existing designs are unaffected.
+    automations: list[Automation] = Field(default_factory=list)
     warnings: list[DesignWarning] = Field(default_factory=list)
     esphome_extras: dict = Field(default_factory=dict)
     fleet: Optional[Fleet] = None

--- a/wirestudio/schema/design.schema.json
+++ b/wirestudio/schema/design.schema.json
@@ -184,6 +184,40 @@
       }
     },
 
+    "automations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "trigger", "actions"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string" },
+          "trigger": {
+            "type": "object",
+            "required": ["component_id", "event"],
+            "additionalProperties": false,
+            "properties": {
+              "component_id": { "type": "string" },
+              "event": { "type": "string" }
+            }
+          },
+          "actions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["component_id", "action"],
+              "additionalProperties": false,
+              "properties": {
+                "component_id": { "type": "string" },
+                "action": { "type": "string" },
+                "args": { "type": "object" }
+              }
+            }
+          }
+        }
+      }
+    },
+
     "warnings": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## Summary

First piece of intent-to-device synthesis (per `docs/intent-to-device.md`): a *functional* layer on top of the existing structural surface, so a design can carry behavior (a button press toggling a light) rather than just hardware.

**Scope narrowed deliberately to declarative event→action.** Value→transform→action (the encoder→stepper case), multi-device topology, and a live `esphome config` authoring loop arrive in later phases. The point of phase 1 is to prove the seam end-to-end with `button_toggles_light` as the worked example, on minimal new surface.

## What's new

- **Library schema (`capability:`)** — components can declare `role` (input / sensor / output / controller), the events they `provides` (with an optional ESPHome trigger-key override; defaults to the event name), and the actions they `accepts` with **explicit** ESPHome verbs (e.g. `switch.turn_on`). Annotated `gpio_input` + `gpio_output`; the remaining ~58 components pick up annotations in phase 1.5. Unannotated components keep `capability=None` and simply can't participate in automations yet.
- **Design model (`automations: [...]`)** — first-class graph in `design.json` parallel to the physical `connections` graph: `{id, trigger: {component_id, event}, actions: [{component_id, action, args?}]}`. Optional/default-empty so existing designs are unaffected. JSON schema updated to match.
- **Generator lowering** — `_lower_automations` walks the graph, looks up each action's ESPHome verb from the action component's `capability.accepts`, and merges into the trigger component's `params.<event_key>` before render. **Extends** any user-authored param list rather than replacing it, so the existing `params.on_press` escape hatch composes with new automation-graph entries instead of silently losing one side. Short form (`{switch.toggle: porch_light}`) when no args; long form (`{light.turn_on: {id: ..., brightness: ...}}`) when args present.
- **Validator (`wirestudio/intent.validate_automations`)** — permissive: surfaces dangling refs as `DesignWarning`s (`automation_unknown_component`, `automation_component_no_capability`, `automation_unknown_event`, `automation_unknown_action`) wired into `/design/validate`. Renderer silently drops unresolved entries rather than emit invalid YAML; the warning tells the user why nothing fires.
- **Worked example** (`wirestudio/examples/button-toggles-light.json`) — D1 Mini + button on D5 + relay on D6 + one automation. Lowers to `on_press: [{switch.toggle: porch_light}]`. Will be exercised by the existing `esphome-config` CI gate (runs against every `examples/*.json` via `check_examples.py`) — that's the correctness oracle, since `esphome` itself can't install in the sandbox here.
- **Restored `docs/intent-to-device.md`** — the design plan was deleted by PR #89's mass-deletion and never noticed. Restored from its original commit and updated the status line to record phase 1's scope.

## Test plan

- [x] `tests/test_intent.py` (15 tests) — schema annotations parse, unannotated components stay `capability=None`, lowering short/long forms, extends user-authored lists, drops dangling refs in YAML, golden match for the worked example, all four validator codes fire.
- [x] Full suite: **713 passed, 5 skipped** (one pre-existing test caught my schema additions and was fixed in lockstep). Ruff clean. Coverage `--strict` OK.
- [ ] CI matches local — especially the `esphome-config` gate validating the new example.

## Out of scope (phase 2+, per the design doc)

- Value→transform→action (encoder→stepper): needs the typed-expression layer to lower to `!lambda`.
- Multi-device topology + cross-device link via HA / MQTT / ESP-NOW.
- `esphome config` in the agent's authoring loop (the open-ended-intent correctness backstop).
- Bulk annotating the rest of the library.

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_