### PR TITLE
intent: broaden capability coverage to 10 more components (phase 1.5a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Intent-to-device synthesis (phase 1.5a — wider library annotations).**
+  Ten more library components gain `capability:` blocks so they can
+  participate in `automations`: `hc-sr501` + `rcwl-0516` (motion sensors,
+  on_press/on_release), `rc522` + `rdm6300` (RFID readers, on_tag /
+  on_tag_removed), `rotary_encoder` (on_clockwise / on_anticlockwise; on_value
+  with a transform lands in phase 2), `adc` + `hc-sr04` (analog input + ultrasonic
+  distance, on_value / on_value_range), `rf_bridge` (on_code_received),
+  `ws2812b` (light, both events + the standard `light.turn_on`/`turn_off`/
+  `toggle` accepts), and `tuya_switch` (accepts side only — its template
+  doesn't pass through the on_turn_on/off events yet). The annotation is
+  evidence-grounded: each declared `provides.event` is gated by a test that
+  the component's existing ESPHome template actually has a matching
+  `params.<event>` passthrough (so an automation lowers into a key the
+  renderer emits), and each `accepts.esphome` verb is gated against the
+  known ESPHome platform prefixes (`switch.` / `light.` / `stepper.`).
+  Adds a second worked example, `motion-turns-on-light.json` (PIR -> WS2812B
+  via two automations on the on_press / on_release edges), proving the
+  lowering generalises across capability pairs. Components without an `on_*`
+  template passthrough (most of the bare-temperature/humidity sensors,
+  displays, buses, hubs, cameras, PMICs, generic radios) stay unannotated --
+  template-passthrough additions are phase 1.5b, scoped separately because
+  template surgery has a different risk profile than additive metadata.
+
+
+
 - **Intent-to-device synthesis (phase 1 — declarative event→action).** Adds a
   *functional* layer on top of the existing structural surface: library
   components gain an optional `capability:` block declaring their `role`

--- a/docs/intent-to-device.md
+++ b/docs/intent-to-device.md
@@ -1,12 +1,19 @@
 # Intent-to-device synthesis (design direction)
 
-Status: **phase 1 shipped** (declarative event→action, narrow). On `main`:
-the `capability` library block, the `automations` schema in `design.json`,
-generator lowering, the permissive validator, and the `button-toggles-light`
-worked example. `gpio_input` + `gpio_output` are annotated; the rest of the
-library picks up annotations in phase 1.5. Value→transform→action (the
-encoder→stepper case), multi-device topology, and a live `esphome config`
-authoring loop arrive in later phases per *Suggested phasing* below.
+Status: **phases 1 + 1.5a shipped** (declarative event→action, broader library
+coverage). On `main`: the `capability` library block, the `automations` schema
+in `design.json`, generator lowering, the permissive validator, and two
+worked examples (`button-toggles-light`, `motion-turns-on-light`). Twelve
+components carry `capability` annotations: the two GPIO primitives plus 10
+broader-library entries (PIR/microwave motion, RC522/RDM6300 RFID,
+rotary_encoder, ADC + HC-SR04, RF bridge, WS2812B, tuya_switch).
+
+Phase 1.5b — passing `params.on_*` through the remaining sensor / display /
+hub templates so they can be triggers or action targets — is scoped
+separately because template surgery has a different risk profile than
+additive capability metadata. Value→transform→action (the encoder→stepper
+case), multi-device topology, and a live `esphome config` authoring loop
+arrive in later phases per *Suggested phasing* below.
 
 This document was the agreed plan; per-phase work updates this status line in
 place rather than appending a new file each time.

--- a/tests/golden/motion-turns-on-light.txt
+++ b/tests/golden/motion-turns-on-light.txt
@@ -1,0 +1,24 @@
++---------------------------------------------------------------------+
+|  WeMos D1 Mini  ---  motion-turns-on-light                          |
++---------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                |
+|                                                                     |
+|  porch_pir  [HC-SR501 PIR motion sensor]  -- Porch Motion           |
+|    VCC   -> rail 5V                                                 |
+|    GND   -> rail GND                                                |
+|    OUT   -> D2                                                      |
+|                                                                     |
+|  porch_light  [WS2812B addressable LED (NeoPixel)]  -- Porch Light  |
+|    VCC   -> rail 5V                                                 |
+|    GND   -> rail GND                                                |
+|    DIN   -> D1                                                      |
+|                                                                     |
+|  BOM:                                                               |
+|    - WeMos D1 Mini                                                  |
+|    - HC-SR501 PIR motion sensor  (porch_pir)                        |
+|    - WS2812B addressable LED (NeoPixel)  (porch_light)              |
+|                                                                     |
+|  Power: ~70mA typical, ~125mA peak (budget 500mA)  OK               |
+|                                                                     |
+|  Warnings: none                                                     |
++---------------------------------------------------------------------+

--- a/tests/golden/motion-turns-on-light.yaml
+++ b/tests/golden/motion-turns-on-light.yaml
@@ -1,0 +1,31 @@
+esphome:
+  name: porch-motion-light
+esp8266:
+  board: d1_mini
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+binary_sensor:
+- platform: gpio
+  pin: D2
+  name: Porch Motion
+  device_class: motion
+  on_press:
+  - light.turn_on: porch_light
+  on_release:
+  - light.turn_off: porch_light
+light:
+- platform: neopixelbus
+  variant: 400KBPS
+  method: BIT_BANG
+  type: RGB
+  pin: D1
+  num_leds: 1
+  name: Porch Light
+  id: porch_light

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -69,8 +69,10 @@ def test_gpio_output_carries_actions_with_explicit_esphome_verbs(lib):
 
 def test_unannotated_components_keep_capability_none(lib):
     # The annotation rollout is incremental; an un-annotated component still
-    # loads, it just can't participate in `automations` yet.
-    assert lib.component("hc-sr501").capability is None
+    # loads, it just can't participate in `automations` yet. `ds18b20` is a
+    # 1-wire temperature sensor whose template carries no `on_*` passthrough,
+    # so it's a phase 1.5b candidate, not 1.5a -- still capability=None today.
+    assert lib.component("ds18b20").capability is None
 
 
 def test_automation_round_trips_through_the_model():
@@ -196,21 +198,121 @@ def test_validator_flags_unknown_action(lib):
 
 
 def test_validator_flags_component_without_capability(lib):
-    # hc-sr501 has no capability block, so it can't be used as a trigger
-    # source even though it's a real component in the library.
+    # ds18b20 (1-wire temperature sensor) has no capability block today, so it
+    # can't be used as a trigger source even though it's a real component.
+    # (1.5b will annotate sensors once their templates pass through on_value.)
     d = Design.model_validate({
         "schema_version": "0.1", "id": "t", "name": "T",
         "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
         "power": {"supply": "usb", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "buses": [{"id": "wire0", "type": "1wire", "pin": "D4"}],
         "components": [
-            {"id": "pir", "library_id": "hc-sr501", "label": "PIR"},
-            {"id": "lt",  "library_id": "gpio_output", "label": "Light"},
+            {"id": "temp", "library_id": "ds18b20", "label": "Temp",
+             "params": {"address": "0x1234567890abcdef"}},
+            {"id": "lt",   "library_id": "gpio_output", "label": "Light"},
+        ],
+        "connections": [
+            {"component_id": "temp", "pin_role": "DATA", "target": {"kind": "bus", "bus_id": "wire0"}},
+            {"component_id": "lt",   "pin_role": "OUT",  "target": {"kind": "gpio", "pin": "D6"}},
         ],
         "automations": [{
             "id": "a1",
-            "trigger": {"component_id": "pir", "event": "on_state"},
+            "trigger": {"component_id": "temp", "event": "on_value"},
             "actions": [{"component_id": "lt", "action": "turn_on"}],
         }],
     })
     codes = [w.code for w in validate_automations(d, lib)]
     assert "automation_component_no_capability" in codes
+
+
+# --- phase 1.5a: capability annotations on the broader library --------------
+#
+# 10 components gain capability blocks. The annotation must be congruent with
+# the existing ESPHome template -- a `provides` entry whose key the template
+# doesn't pass through is silently broken (the automation lowers into a
+# `params.<key>` the template ignores), so each provides is verified against
+# the actual template, and each accepts has an explicit ESPHome verb.
+
+# (component_id, role, provides, accepts) — sourced from each component's
+# template passthroughs + ESPHome's documented action verbs.
+_PHASE_1_5_ANNOTATIONS = [
+    ("hc-sr501",        "input",  ["on_press", "on_release"],                                []),
+    ("rcwl-0516",       "input",  ["on_press", "on_release"],                                []),
+    ("rc522",           "input",  ["on_tag", "on_tag_removed"],                              []),
+    ("rdm6300",         "input",  ["on_tag"],                                                []),
+    ("rotary_encoder",  "input",  ["on_clockwise", "on_anticlockwise"],                      []),
+    ("adc",             "sensor", ["on_value", "on_value_range"],                            []),
+    ("hc-sr04",         "sensor", ["on_value"],                                              []),
+    ("rf_bridge",       "input",  ["on_code_received"],                                      []),
+    ("ws2812b",         "output", ["on_turn_on", "on_turn_off"],                             ["turn_on", "turn_off", "toggle"]),
+    ("tuya_switch",     "output", [],                                                        ["turn_on", "turn_off", "toggle"]),
+]
+
+
+@pytest.mark.parametrize("lib_id, role, provides, accepts", _PHASE_1_5_ANNOTATIONS)
+def test_phase_1_5_capability_annotation_shape(lib, lib_id, role, provides, accepts):
+    cap = lib.component(lib_id).capability
+    assert cap is not None, f"{lib_id} should have a capability block"
+    assert cap.role == role
+    assert [p.event for p in cap.provides] == provides
+    assert [a.action for a in cap.accepts] == accepts
+
+
+def test_phase_1_5_provides_only_keys_the_template_passes_through(lib):
+    """Each annotated `provides.event` must match a `params.<event>`
+    passthrough in the component's own ESPHome template; otherwise the
+    automation lowers into a key the renderer drops on the floor."""
+    import re
+    for lib_id, _role, provides, _accepts in _PHASE_1_5_ANNOTATIONS:
+        tmpl = lib.component(lib_id).esphome.yaml_template or ""
+        passthroughs = set(re.findall(r"params\.(on_\w+)", tmpl))
+        for ev in provides:
+            assert ev in passthroughs, (
+                f"{lib_id}: capability declares provides.event={ev!r} but the "
+                f"template has no params.{ev} passthrough -- the automation "
+                f"would lower into a key the renderer drops. Template passes "
+                f"through: {sorted(passthroughs) or '(none)'}"
+            )
+
+
+def test_phase_1_5_accepts_have_known_esphome_verb_prefixes(lib):
+    """`accepts.esphome` must be a `<platform>.<verb>` action ESPHome
+    recognises. The platform prefix is asserted against the small set of
+    platforms phase 1.5 covers (switch / light / stepper). Catches typos."""
+    known_prefixes = {"switch", "light", "stepper"}
+    for lib_id, _role, _provides, accepts in _PHASE_1_5_ANNOTATIONS:
+        cap = lib.component(lib_id).capability
+        if not cap or not cap.accepts:
+            continue
+        for acc, declared in zip(accepts, cap.accepts):
+            assert declared.action == acc
+            prefix, _, _ = declared.esphome.partition(".")
+            assert prefix in known_prefixes, (
+                f"{lib_id} accepts.{acc} -> {declared.esphome!r}: "
+                f"unknown ESPHome platform prefix {prefix!r}"
+            )
+
+
+# --- second worked example: motion -> light --------------------------------
+
+MOTION_EXAMPLE = REPO_ROOT / "wirestudio" / "examples" / "motion-turns-on-light.json"
+
+
+def test_motion_to_light_example_matches_golden(lib):
+    d = Design.model_validate(json.loads(MOTION_EXAMPLE.read_text()))
+    expected = (REPO_ROOT / "tests" / "golden" / "motion-turns-on-light.yaml").read_text()
+    assert render_yaml(d, lib) == expected
+
+
+def test_motion_to_light_lowers_both_events_to_light_actions(lib):
+    """Both edges of motion fire a light action through the same lowering."""
+    d = Design.model_validate(json.loads(MOTION_EXAMPLE.read_text()))
+    yaml = render_yaml(d, lib)
+    assert "on_press:\n  - light.turn_on: porch_light" in yaml
+    assert "on_release:\n  - light.turn_off: porch_light" in yaml
+
+
+def test_motion_to_light_validator_quiet(lib):
+    d = Design.model_validate(json.loads(MOTION_EXAMPLE.read_text()))
+    assert validate_automations(d, lib) == []
+

--- a/wirestudio/examples/motion-turns-on-light.json
+++ b/wirestudio/examples/motion-turns-on-light.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "id": "motion-turns-on-light",
+  "name": "Motion turns on the porch light",
+  "description": "Second phase-1 worked example: a PIR motion sensor triggers a WS2812B LED to turn on. Exercises a different capability pair than button-toggles-light (sensor event -> light action vs. input event -> switch action), proving the lowering generalises across categories. The motion sensor's on_press event lowers to `light.turn_on: porch_light`; on_release lowers to `light.turn_off`.",
+  "created_at": "2026-06-19T00:00:00Z",
+  "updated_at": "2026-06-19T00:00:00Z",
+
+  "board": {
+    "library_id": "wemos-d1-mini",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-rt9013",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "turn on the porch light when motion is detected" }
+  ],
+
+  "components": [
+    {
+      "id": "porch_pir",
+      "library_id": "hc-sr501",
+      "label": "Porch Motion"
+    },
+    {
+      "id": "porch_light",
+      "library_id": "ws2812b",
+      "label": "Porch Light",
+      "params": {
+        "variant": "400KBPS",
+        "method": "BIT_BANG",
+        "type": "RGB",
+        "num_leds": 1
+      }
+    }
+  ],
+
+  "buses": [],
+
+  "connections": [
+    { "component_id": "porch_pir",   "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "porch_pir",   "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "porch_pir",   "pin_role": "OUT", "target": { "kind": "gpio", "pin": "D2" } },
+    { "component_id": "porch_light", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "porch_light", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "porch_light", "pin_role": "DIN", "target": { "kind": "gpio", "pin": "D1" } }
+  ],
+
+  "passives": [],
+
+  "automations": [
+    {
+      "id": "motion_turns_on_light",
+      "trigger": { "component_id": "porch_pir", "event": "on_press" },
+      "actions": [
+        { "component_id": "porch_light", "action": "turn_on" }
+      ]
+    },
+    {
+      "id": "no_motion_turns_off_light",
+      "trigger": { "component_id": "porch_pir", "event": "on_release" },
+      "actions": [
+        { "component_id": "porch_light", "action": "turn_off" }
+      ]
+    }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "porch-motion-light",
+    "tags": ["intent-to-device", "phase-1", "example"],
+    "secrets_ref": {
+      "wifi_ssid":     "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key":       "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/library/components/adc.yaml
+++ b/wirestudio/library/components/adc.yaml
@@ -45,6 +45,15 @@ esphome:
         on_value_range: {{ params.on_value_range | tojson }}
     {%- endif %}
 
+capability:
+  # Generic analog input. on_value (kind=value: yields the float x) and
+  # on_value_range (kind=event: fires entering/leaving a threshold) -- both
+  # already pass through the template.
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+    - {event: on_value_range, kind: event}
+
 params_schema:
   attenuation:
     type: string

--- a/wirestudio/library/components/hc-sr04.yaml
+++ b/wirestudio/library/components/hc-sr04.yaml
@@ -41,6 +41,12 @@ esphome:
         on_value: {{ params.on_value | tojson }}
     {%- endif %}
 
+capability:
+  # Ultrasonic distance sensor; emits a continuous distance value.
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+
 params_schema:
   update_interval: { type: string, default: "60s" }
   unit_of_measurement: { type: string, default: "m" }

--- a/wirestudio/library/components/hc-sr501.yaml
+++ b/wirestudio/library/components/hc-sr501.yaml
@@ -32,6 +32,15 @@ esphome:
         on_release: {{ params.on_release | tojson }}
     {%- endif %}
 
+capability:
+  # PIR (motion). ESPHome emits a press when motion starts and a release when
+  # it ends -- the template already passes these through, so an automation
+  # triggers off them cleanly.
+  role: input
+  provides:
+    - {event: on_press}
+    - {event: on_release}
+
 params_schema:
   retrigger:
     type: string

--- a/wirestudio/library/components/rc522.yaml
+++ b/wirestudio/library/components/rc522.yaml
@@ -38,6 +38,15 @@ esphome:
       on_tag_removed: {{ params.on_tag_removed | tojson }}
     {%- endif %}
 
+capability:
+  # 13.56MHz RFID reader. on_tag fires when a card is presented; on_tag_removed
+  # when the field clears. ESPHome supplies `tag` to actions; the simple
+  # event->action lowering yields a press+toggle / similar shape.
+  role: input
+  provides:
+    - {event: on_tag}
+    - {event: on_tag_removed}
+
 params_schema:
   update_interval: { type: string, default: "1s" }
 

--- a/wirestudio/library/components/rcwl-0516.yaml
+++ b/wirestudio/library/components/rcwl-0516.yaml
@@ -33,6 +33,14 @@ esphome:
         on_release: {{ params.on_release | tojson }}
     {%- endif %}
 
+capability:
+  # Microwave motion -- shape-identical to hc-sr501 (binary motion sensor),
+  # just doppler instead of pyroelectric. Same trigger shape.
+  role: input
+  provides:
+    - {event: on_press}
+    - {event: on_release}
+
 params_schema: {}
 
 notes: |

--- a/wirestudio/library/components/rdm6300.yaml
+++ b/wirestudio/library/components/rdm6300.yaml
@@ -29,6 +29,12 @@ esphome:
       on_tag: {{ params.on_tag | tojson }}
     {%- endif %}
 
+capability:
+  # 125kHz EM-style RFID reader. Only on_tag; no removal event in the platform.
+  role: input
+  provides:
+    - {event: on_tag}
+
 params_schema:
   on_tag:
     type: array

--- a/wirestudio/library/components/rf_bridge.yaml
+++ b/wirestudio/library/components/rf_bridge.yaml
@@ -27,6 +27,14 @@ esphome:
       on_code_received: {{ params.on_code_received | tojson }}
     {%- endif %}
 
+capability:
+  # Sonoff RF Bridge: on_code_received fires for each 433MHz code seen.
+  # Lowering surfaces the code via ESPHome's `data` substitution; the simple
+  # event -> action lowering wires it into a switch/light action by id.
+  role: input
+  provides:
+    - {event: on_code_received}
+
 params_schema:
   on_code_received:
     type: array

--- a/wirestudio/library/components/rotary_encoder.yaml
+++ b/wirestudio/library/components/rotary_encoder.yaml
@@ -53,6 +53,15 @@ esphome:
         on_anticlockwise: {{ params.on_anticlockwise | tojson }}
     {%- endif %}
 
+capability:
+  # Quadrature encoder. Phase 1.5 wires the discrete clockwise/anticlockwise
+  # events the template passes through. Phase 2 (value -> transform -> action,
+  # the encoder -> stepper case) adds on_value with a transform IR.
+  role: input
+  provides:
+    - {event: on_clockwise}
+    - {event: on_anticlockwise}
+
 params_schema:
   min_value:
     type: integer

--- a/wirestudio/library/components/tuya_switch.yaml
+++ b/wirestudio/library/components/tuya_switch.yaml
@@ -29,6 +29,17 @@ esphome:
         restore_mode: {{ params.restore_mode }}
     {%- endif %}
 
+capability:
+  # Tuya MCU-bridge switch (a switch entity behind the tuya: bridge component).
+  # The template doesn't pass through on_turn_on/off events today, so
+  # phase 1.5a only annotates the action side -- adding the trigger
+  # passthroughs is a follow-up in 1.5b.
+  role: output
+  accepts:
+    - {action: turn_on,  esphome: switch.turn_on}
+    - {action: turn_off, esphome: switch.turn_off}
+    - {action: toggle,   esphome: switch.toggle}
+
 params_schema:
   switch_datapoint:
     type: number

--- a/wirestudio/library/components/ws2812b.yaml
+++ b/wirestudio/library/components/ws2812b.yaml
@@ -35,6 +35,18 @@ esphome:
         on_turn_off: {{ params.on_turn_off | tojson }}
     {%- endif %}
 
+capability:
+  # Addressable LED strip / pixel under ESPHome's `light:` platform. Emits
+  # on_turn_on / on_turn_off and accepts the standard light action verbs.
+  role: output
+  provides:
+    - {event: on_turn_on}
+    - {event: on_turn_off}
+  accepts:
+    - {action: turn_on,  esphome: light.turn_on}
+    - {action: turn_off, esphome: light.turn_off}
+    - {action: toggle,   esphome: light.toggle}
+
 params_schema:
   variant: {type: string, default: "WS2812", enum: ["WS2811", "WS2812", "WS2812X", "400KBPS", "SK6812",
       "TM1814"]}


### PR DESCRIPTION
## Summary

Phase 1.5a of intent-to-device synthesis: extend `capability` annotations
from the two phase-1 GPIO primitives to ten broader-library components,
and add a second worked example that exercises a different
capability-pair than `button-toggles-light`.

### Components annotated

- Motion: `hc-sr501` (PIR), `rcwl-0516` (microwave)
- RFID: `rc522`, `rdm6300`
- Input: `rotary_encoder`
- Analog: `adc`, `hc-sr04`
- Switching: `rf_bridge`, `tuya_switch`
- Light: `ws2812b`

Selection is gated to components whose Jinja templates already pass
through the relevant `params.on_*` keys -- additive metadata only, no
template surgery. The remaining sensors/displays/hubs that need
`params.on_*` plumbed through (phase 1.5b) are scoped separately
because template surgery has a different risk profile.

### Worked example

`motion-turns-on-light` pairs an hc-sr501 PIR with a ws2812b LED on a
Wemos D1 Mini. Two automations: `on_press` -> `light.turn_on`,
`on_release` -> `light.turn_off`. Validates that the lowering
generalises across the sensor-event -> light-action pair (vs.
button-event -> switch-action in phase 1).

### Test gates added

- `test_phase_1_5_capability_annotation_shape` -- parameterised over the
  ten annotations, asserts role/provides/accepts as authored.
- `test_phase_1_5_provides_only_keys_the_template_passes_through` --
  regex-greps `params.on_*` in each template and asserts every declared
  `provides.event` is actually rendered. Prevents the silent-drop class
  of annotation bug.
- `test_phase_1_5_accepts_have_known_esphome_verb_prefixes` -- gates
  `accepts.esphome` against `{switch, light, stepper}` prefix
  allowlist.
- Golden + lowering + validator tests for the new example.

## Test plan

- [x] `pytest tests/test_intent.py` -- 30 passed
- [x] `pytest -q` full suite -- 732 passed, 11 skipped
- [x] `ruff check .` -- clean
- [x] Golden generated and checked in


---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_