### PR TITLE
intent: single-output sensor on_value triggers (phase 1.5b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Intent-to-device synthesis (phase 1.5b — single-output sensor triggers).**
+  Nine single-value sensors gain a `params.on_value` / `on_value_range`
+  template passthrough plus a `role: sensor` `capability:` block, so a sensor
+  reading can drive an automation: `ds18b20` (1-wire temperature), `bh1750` +
+  `tsl2561` (lux), `vl53l0x` (ToF distance), `hx711` (load cell), `max31855`
+  (thermocouple), `pulse_counter` (rate), `ads1115_channel` (ADC channel), and
+  `tuya_sensor` (Tuya datapoint). `on_value` (kind=value) lowers a direct
+  action list through the existing phase-1 path; `on_value_range` (kind=event)
+  is declared for the threshold case that phase 2's richer trigger IR will
+  carry the bounds for. Multi-channel sensors (`dht`, `bme280`, IMUs, power
+  meters) stay unannotated: which sub-channel a trigger hangs off is a separate
+  design call. Same evidence gate as 1.5a — every declared `provides.event` is
+  tested against a real `params.<event>` passthrough — plus a lowering test
+  proving a `ds18b20` `on_value` automation renders `switch.turn_on` into the
+  sensor block.
+
 - **Intent-to-device synthesis (phase 1.5a — wider library annotations).**
   Ten more library components gain `capability:` blocks so they can
   participate in `automations`: `hc-sr501` + `rcwl-0516` (motion sensors,

--- a/docs/intent-to-device.md
+++ b/docs/intent-to-device.md
@@ -1,19 +1,22 @@
 # Intent-to-device synthesis (design direction)
 
-Status: **phases 1 + 1.5a shipped** (declarative event→action, broader library
-coverage). On `main`: the `capability` library block, the `automations` schema
-in `design.json`, generator lowering, the permissive validator, and two
-worked examples (`button-toggles-light`, `motion-turns-on-light`). Twelve
-components carry `capability` annotations: the two GPIO primitives plus 10
-broader-library entries (PIR/microwave motion, RC522/RDM6300 RFID,
-rotary_encoder, ADC + HC-SR04, RF bridge, WS2812B, tuya_switch).
+Status: **phases 1 + 1.5a + 1.5b shipped** (declarative event→action, broader
+library coverage, single-output sensor triggers). On `main`: the `capability`
+library block, the `automations` schema in `design.json`, generator lowering,
+the permissive validator, and two worked examples (`button-toggles-light`,
+`motion-turns-on-light`). Twenty-one components carry `capability`
+annotations: the two GPIO primitives, 10 broader-library entries from 1.5a
+(PIR/microwave motion, RC522/RDM6300 RFID, rotary_encoder, ADC + HC-SR04, RF
+bridge, WS2812B, tuya_switch), and 9 single-output sensors from 1.5b (ds18b20,
+bh1750, tsl2561, vl53l0x, hx711, max31855, pulse_counter, ads1115_channel,
+tuya_sensor) with `on_value` / `on_value_range`.
 
-Phase 1.5b — passing `params.on_*` through the remaining sensor / display /
-hub templates so they can be triggers or action targets — is scoped
-separately because template surgery has a different risk profile than
-additive capability metadata. Value→transform→action (the encoder→stepper
-case), multi-device topology, and a live `esphome config` authoring loop
-arrive in later phases per *Suggested phasing* below.
+Multi-channel sensors (dht, bme280, IMUs, power meters) stay unannotated —
+which sub-channel a trigger hangs off is a separate design call. The
+`on_value_range` threshold case is declared but awaits phase 2's richer
+trigger IR to carry the range bounds; value→transform→action (the
+encoder→stepper case), multi-device topology, and a live `esphome config`
+authoring loop arrive in later phases per *Suggested phasing* below.
 
 This document was the agreed plan; per-phase work updates this status line in
 place rather than appending a new file each time.

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -69,10 +69,10 @@ def test_gpio_output_carries_actions_with_explicit_esphome_verbs(lib):
 
 def test_unannotated_components_keep_capability_none(lib):
     # The annotation rollout is incremental; an un-annotated component still
-    # loads, it just can't participate in `automations` yet. `ds18b20` is a
-    # 1-wire temperature sensor whose template carries no `on_*` passthrough,
-    # so it's a phase 1.5b candidate, not 1.5a -- still capability=None today.
-    assert lib.component("ds18b20").capability is None
+    # loads, it just can't participate in `automations` yet. `dht` is a
+    # multi-channel temp+humidity sensor -- which sub-channel an on_value
+    # trigger hangs off is unresolved, so it stays capability=None for now.
+    assert lib.component("dht").capability is None
 
 
 def test_automation_round_trips_through_the_model():
@@ -198,21 +198,21 @@ def test_validator_flags_unknown_action(lib):
 
 
 def test_validator_flags_component_without_capability(lib):
-    # ds18b20 (1-wire temperature sensor) has no capability block today, so it
-    # can't be used as a trigger source even though it's a real component.
-    # (1.5b will annotate sensors once their templates pass through on_value.)
+    # dht (temp+humidity) is multi-channel, so its on_value trigger placement is
+    # an open design question and it carries no capability block today -- it
+    # can't be a trigger source even though it's a real component. (Single-output
+    # sensors like ds18b20 gained capabilities in 1.5b; multi-channel ones did
+    # not.)
     d = Design.model_validate({
         "schema_version": "0.1", "id": "t", "name": "T",
         "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
         "power": {"supply": "usb", "rail_voltage_v": 5.0, "budget_ma": 500},
-        "buses": [{"id": "wire0", "type": "1wire", "pin": "D4"}],
         "components": [
-            {"id": "temp", "library_id": "ds18b20", "label": "Temp",
-             "params": {"address": "0x1234567890abcdef"}},
+            {"id": "temp", "library_id": "dht", "label": "Temp"},
             {"id": "lt",   "library_id": "gpio_output", "label": "Light"},
         ],
         "connections": [
-            {"component_id": "temp", "pin_role": "DATA", "target": {"kind": "bus", "bus_id": "wire0"}},
+            {"component_id": "temp", "pin_role": "DATA", "target": {"kind": "gpio", "pin": "D4"}},
             {"component_id": "lt",   "pin_role": "OUT",  "target": {"kind": "gpio", "pin": "D6"}},
         ],
         "automations": [{
@@ -248,8 +248,28 @@ _PHASE_1_5_ANNOTATIONS = [
     ("tuya_switch",     "output", [],                                                        ["turn_on", "turn_off", "toggle"]),
 ]
 
+# --- phase 1.5b: single-output sensors gain on_value triggers ----------------
+#
+# The remaining single-value sensors get a params.on_value / on_value_range
+# passthrough plus a role=sensor capability, so a sensor reading can drive an
+# automation. Multi-channel sensors (dht, bme280, IMUs, power meters) are
+# deferred: which sub-channel a trigger hangs off is a separate design call.
+_PHASE_1_5B_ANNOTATIONS = [
+    ("ds18b20",         "sensor", ["on_value", "on_value_range"], []),
+    ("bh1750",          "sensor", ["on_value", "on_value_range"], []),
+    ("tsl2561",         "sensor", ["on_value", "on_value_range"], []),
+    ("vl53l0x",         "sensor", ["on_value", "on_value_range"], []),
+    ("hx711",           "sensor", ["on_value", "on_value_range"], []),
+    ("max31855",        "sensor", ["on_value", "on_value_range"], []),
+    ("pulse_counter",   "sensor", ["on_value", "on_value_range"], []),
+    ("ads1115_channel", "sensor", ["on_value", "on_value_range"], []),
+    ("tuya_sensor",     "sensor", ["on_value", "on_value_range"], []),
+]
 
-@pytest.mark.parametrize("lib_id, role, provides, accepts", _PHASE_1_5_ANNOTATIONS)
+_ALL_1_5_ANNOTATIONS = _PHASE_1_5_ANNOTATIONS + _PHASE_1_5B_ANNOTATIONS
+
+
+@pytest.mark.parametrize("lib_id, role, provides, accepts", _ALL_1_5_ANNOTATIONS)
 def test_phase_1_5_capability_annotation_shape(lib, lib_id, role, provides, accepts):
     cap = lib.component(lib_id).capability
     assert cap is not None, f"{lib_id} should have a capability block"
@@ -263,7 +283,7 @@ def test_phase_1_5_provides_only_keys_the_template_passes_through(lib):
     passthrough in the component's own ESPHome template; otherwise the
     automation lowers into a key the renderer drops on the floor."""
     import re
-    for lib_id, _role, provides, _accepts in _PHASE_1_5_ANNOTATIONS:
+    for lib_id, _role, provides, _accepts in _ALL_1_5_ANNOTATIONS:
         tmpl = lib.component(lib_id).esphome.yaml_template or ""
         passthroughs = set(re.findall(r"params\.(on_\w+)", tmpl))
         for ev in provides:
@@ -280,7 +300,7 @@ def test_phase_1_5_accepts_have_known_esphome_verb_prefixes(lib):
     recognises. The platform prefix is asserted against the small set of
     platforms phase 1.5 covers (switch / light / stepper). Catches typos."""
     known_prefixes = {"switch", "light", "stepper"}
-    for lib_id, _role, _provides, accepts in _PHASE_1_5_ANNOTATIONS:
+    for lib_id, _role, _provides, accepts in _ALL_1_5_ANNOTATIONS:
         cap = lib.component(lib_id).capability
         if not cap or not cap.accepts:
             continue
@@ -315,4 +335,33 @@ def test_motion_to_light_lowers_both_events_to_light_actions(lib):
 def test_motion_to_light_validator_quiet(lib):
     d = Design.model_validate(json.loads(MOTION_EXAMPLE.read_text()))
     assert validate_automations(d, lib) == []
+
+
+# --- phase 1.5b: a sensor value drives an action ---------------------------
+
+def test_sensor_on_value_lowers_into_the_sensor_template(lib):
+    """A single-output sensor's on_value trigger lowers a switch action into the
+    rendered sensor block -- the 1.5b path that lets a reading drive an automation."""
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "buses": [{"id": "wire0", "type": "1wire", "pin": "D4"}],
+        "components": [
+            {"id": "temp", "library_id": "ds18b20", "label": "Temp",
+             "params": {"address": "0x1234567890abcdef"}},
+            {"id": "fan",  "library_id": "gpio_output", "label": "Fan"},
+        ],
+        "connections": [
+            {"component_id": "temp", "pin_role": "DATA", "target": {"kind": "bus", "bus_id": "wire0"}},
+            {"component_id": "fan",  "pin_role": "OUT",  "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+        "automations": [{
+            "id": "a1",
+            "trigger": {"component_id": "temp", "event": "on_value"},
+            "actions": [{"component_id": "fan", "action": "turn_on"}],
+        }],
+    })
+    assert validate_automations(d, lib) == []
+    assert "on_value:\n  - switch.turn_on: fan" in render_yaml(d, lib)
 

--- a/wirestudio/library/components/ads1115_channel.yaml
+++ b/wirestudio/library/components/ads1115_channel.yaml
@@ -26,6 +26,18 @@ esphome:
         gain: {{ params.gain | default('6.144') }}
         name: "{{ label }}"
         update_interval: {{ params.update_interval | default('60s') }}
+    {%- if params.on_value is defined %}
+        on_value: {{ params.on_value | tojson }}
+    {%- endif %}
+    {%- if params.on_value_range is defined %}
+        on_value_range: {{ params.on_value_range | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+    - {event: on_value_range, kind: event}
 
 params_schema:
   multiplexer:

--- a/wirestudio/library/components/bh1750.yaml
+++ b/wirestudio/library/components/bh1750.yaml
@@ -31,6 +31,18 @@ esphome:
         address: "{{ params.address | default('0x23') }}"
         name: "{{ label }} Illuminance"
         update_interval: {{ params.update_interval | default('60s') }}
+    {%- if params.on_value is defined %}
+        on_value: {{ params.on_value | tojson }}
+    {%- endif %}
+    {%- if params.on_value_range is defined %}
+        on_value_range: {{ params.on_value_range | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+    - {event: on_value_range, kind: event}
 
 params_schema:
   address:

--- a/wirestudio/library/components/ds18b20.yaml
+++ b/wirestudio/library/components/ds18b20.yaml
@@ -30,6 +30,18 @@ esphome:
     {%- if params.resolution is defined %}
         resolution: {{ params.resolution }}
     {%- endif %}
+    {%- if params.on_value is defined %}
+        on_value: {{ params.on_value | tojson }}
+    {%- endif %}
+    {%- if params.on_value_range is defined %}
+        on_value_range: {{ params.on_value_range | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+    - {event: on_value_range, kind: event}
 
 params_schema:
   address:

--- a/wirestudio/library/components/hx711.yaml
+++ b/wirestudio/library/components/hx711.yaml
@@ -32,6 +32,18 @@ esphome:
     {%- if params.filters is defined %}
         filters: {{ params.filters | tojson }}
     {%- endif %}
+    {%- if params.on_value is defined %}
+        on_value: {{ params.on_value | tojson }}
+    {%- endif %}
+    {%- if params.on_value_range is defined %}
+        on_value_range: {{ params.on_value_range | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+    - {event: on_value_range, kind: event}
 
 params_schema:
   gain:

--- a/wirestudio/library/components/max31855.yaml
+++ b/wirestudio/library/components/max31855.yaml
@@ -32,6 +32,18 @@ esphome:
         reference_temperature:
           name: "{{ label }} Cold Junction"
     {%- endif %}
+    {%- if params.on_value is defined %}
+        on_value: {{ params.on_value | tojson }}
+    {%- endif %}
+    {%- if params.on_value_range is defined %}
+        on_value_range: {{ params.on_value_range | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+    - {event: on_value_range, kind: event}
 
 params_schema:
   update_interval:

--- a/wirestudio/library/components/pulse_counter.yaml
+++ b/wirestudio/library/components/pulse_counter.yaml
@@ -43,6 +43,18 @@ esphome:
     {%- if params.filters is defined %}
         filters: {{ params.filters | tojson }}
     {%- endif %}
+    {%- if params.on_value is defined %}
+        on_value: {{ params.on_value | tojson }}
+    {%- endif %}
+    {%- if params.on_value_range is defined %}
+        on_value_range: {{ params.on_value_range | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+    - {event: on_value_range, kind: event}
 
 params_schema:
   input_mode:

--- a/wirestudio/library/components/tsl2561.yaml
+++ b/wirestudio/library/components/tsl2561.yaml
@@ -36,6 +36,18 @@ esphome:
     {%- if params.integration_time is defined %}
         integration_time: {{ params.integration_time }}
     {%- endif %}
+    {%- if params.on_value is defined %}
+        on_value: {{ params.on_value | tojson }}
+    {%- endif %}
+    {%- if params.on_value_range is defined %}
+        on_value_range: {{ params.on_value_range | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+    - {event: on_value_range, kind: event}
 
 params_schema:
   address:

--- a/wirestudio/library/components/tuya_sensor.yaml
+++ b/wirestudio/library/components/tuya_sensor.yaml
@@ -31,6 +31,18 @@ esphome:
     {%- if params.filters is defined %}
         filters: {{ params.filters | tojson }}
     {%- endif %}
+    {%- if params.on_value is defined %}
+        on_value: {{ params.on_value | tojson }}
+    {%- endif %}
+    {%- if params.on_value_range is defined %}
+        on_value_range: {{ params.on_value_range | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+    - {event: on_value_range, kind: event}
 
 params_schema:
   sensor_datapoint:

--- a/wirestudio/library/components/vl53l0x.yaml
+++ b/wirestudio/library/components/vl53l0x.yaml
@@ -34,6 +34,18 @@ esphome:
         update_interval: {{ params.update_interval | default('60s') }}
         long_range: {{ params.long_range | default(false) | string | lower }}
         timeout: {{ params.timeout | default('200ms') }}
+    {%- if params.on_value is defined %}
+        on_value: {{ params.on_value | tojson }}
+    {%- endif %}
+    {%- if params.on_value_range is defined %}
+        on_value_range: {{ params.on_value_range | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+    - {event: on_value_range, kind: event}
 
 params_schema:
   address:


### PR DESCRIPTION
## Summary

Phase 1.5b of intent-to-device synthesis: extend the `automations` graph to **single-output sensors**, so a sensor reading can drive an automation. Nine sensors gain a `params.on_value` / `on_value_range` template passthrough plus a `role: sensor` `capability:` block, matching the pattern already proven by `adc`/`hc-sr04` in 1.5a.

### Sensors annotated

- Temperature: `ds18b20` (1-wire), `max31855` (thermocouple, SPI)
- Light: `bh1750`, `tsl2561` (lux, I2C)
- Distance: `vl53l0x` (ToF, I2C)
- Force: `hx711` (load cell)
- Rate: `pulse_counter`
- Analog: `ads1115_channel` (ADC channel)
- Tuya: `tuya_sensor` (datapoint)

`on_value` (kind=value) lowers a direct action list through the existing phase-1 path. `on_value_range` (kind=event) is declared for the threshold case, but the bounds (`above:`/`below:`) await phase 2's richer trigger IR — declaring it now documents the capability and lands the passthrough.

### Deferred (by design)

Multi-channel sensors — `dht`, `bme280`, IMUs (`mpu6050`/`mpu6886`), power meters (`cse7766`/`hlw8012`/`bl0906`/`sdm_meter`) — stay unannotated. `on_value` attaches per sub-sensor on those, so *which* channel a trigger hangs off is a separate design call, not a mechanical passthrough.

### Test gates

- `_PHASE_1_5B_ANNOTATIONS` table added; the existing shape + passthrough-congruence + verb-prefix gates now iterate the combined 1.5a+1.5b set, so every declared `provides.event` is verified against a real `params.<event>` passthrough in the component's own template.
- New positive lowering test: a `ds18b20` `on_value` → `gpio_output` automation renders `on_value:\n  - switch.turn_on: fan` into the dallas_temp block, and the validator is quiet.
- `dht` (multi-channel) replaces `ds18b20` as the unannotated-component fixture in two tests.

## Test plan

- [x] `pytest tests/test_intent.py` — 40 passed
- [x] `pytest -q` full suite — 742 passed, 11 skipped
- [x] `ruff check .` — clean
- [x] No golden churn: the new passthroughs are conditional (`{%- if params.on_value is defined %}`) and unused by existing examples, so rendered output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_