### PR TITLE
intent: value→transform→action via !lambda (phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Intent-to-device synthesis (phase 2 — value→transform→action).** An
+  automation action gains an optional `transform` (action-arg name → a C++
+  expression in terms of `x`, the value the trigger emits) that the generator
+  lowers to an ESPHome `!lambda "return <expr>;"`. `rotary_encoder` gains
+  `on_value` (kind=value) and the `uln2003` stepper gains `set_target`
+  (→ `stepper.set_target`), wiring the canonical encoder→stepper case. New
+  worked example `encoder-drives-stepper.json`: a knob's cumulative count
+  drives the motor via `target: !lambda return (long) (x * 10);`, so each
+  detent commands ten steps. The lambda rides the existing `params.on_*`
+  `tojson` passthrough as a sentinel string and is restored to a tagged
+  `!lambda` scalar after parse; the tag-quoting fixup keeps the body quoted
+  when it isn't a plain-scalar-safe expression (a ternary, say). `design.json`
+  gains `automations[].actions[].transform` in model + schema.
+
 - **Intent-to-device synthesis (phase 1.5b — single-output sensor triggers).**
   Nine single-value sensors gain a `params.on_value` / `on_value_range`
   template passthrough plus a `role: sensor` `capability:` block, so a sensor

--- a/docs/intent-to-device.md
+++ b/docs/intent-to-device.md
@@ -1,22 +1,26 @@
 # Intent-to-device synthesis (design direction)
 
-Status: **phases 1 + 1.5a + 1.5b shipped** (declarative event→action, broader
-library coverage, single-output sensor triggers). On `main`: the `capability`
-library block, the `automations` schema in `design.json`, generator lowering,
-the permissive validator, and two worked examples (`button-toggles-light`,
-`motion-turns-on-light`). Twenty-one components carry `capability`
-annotations: the two GPIO primitives, 10 broader-library entries from 1.5a
-(PIR/microwave motion, RC522/RDM6300 RFID, rotary_encoder, ADC + HC-SR04, RF
-bridge, WS2812B, tuya_switch), and 9 single-output sensors from 1.5b (ds18b20,
-bh1750, tsl2561, vl53l0x, hx711, max31855, pulse_counter, ads1115_channel,
-tuya_sensor) with `on_value` / `on_value_range`.
+Status: **phases 1 + 1.5a + 1.5b + 2 shipped** (declarative event→action,
+broader library coverage, single-output sensor triggers, value→transform→action).
+On `main`: the `capability` library block, the `automations` schema in
+`design.json` (including `actions[].transform`), generator lowering with
+`!lambda` transforms, the permissive validator, and three worked examples
+(`button-toggles-light`, `motion-turns-on-light`, `encoder-drives-stepper`).
+Twenty-two components carry `capability` annotations: the two GPIO primitives,
+10 broader-library entries from 1.5a (PIR/microwave motion, RC522/RDM6300 RFID,
+rotary_encoder, ADC + HC-SR04, RF bridge, WS2812B, tuya_switch), 9 single-output
+sensors from 1.5b (ds18b20, bh1750, tsl2561, vl53l0x, hx711, max31855,
+pulse_counter, ads1115_channel, tuya_sensor) with `on_value` / `on_value_range`,
+and the uln2003 stepper from phase 2 (accepts `set_target`).
 
-Multi-channel sensors (dht, bme280, IMUs, power meters) stay unannotated —
-which sub-channel a trigger hangs off is a separate design call. The
-`on_value_range` threshold case is declared but awaits phase 2's richer
-trigger IR to carry the range bounds; value→transform→action (the
-encoder→stepper case), multi-device topology, and a live `esphome config`
-authoring loop arrive in later phases per *Suggested phasing* below.
+Phase 2 lowers an action's `transform` (arg → a C++ expression in `x`, the
+trigger's value) to an ESPHome `!lambda`; the encoder→stepper example drives
+`stepper.set_target` from the encoder's count. Multi-channel sensors (dht,
+bme280, IMUs, power meters) stay unannotated — which sub-channel a trigger
+hangs off is a separate design call. The `on_value_range` threshold case is
+declared but its range bounds await a richer trigger IR; multi-device topology
+and a live `esphome config` authoring loop arrive in later phases per
+*Suggested phasing* below.
 
 This document was the agreed plan; per-phase work updates this status line in
 place rather than appending a new file each time.

--- a/tests/golden/encoder-drives-stepper.txt
+++ b/tests/golden/encoder-drives-stepper.txt
@@ -1,0 +1,26 @@
++----------------------------------------------------------------------+
+|  ESP32-DevKitC-V4  ---  encoder-drives-stepper                       |
++----------------------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                                 |
+|                                                                      |
+|  knob  [Quadrature rotary encoder (KY-040 style)]  -- Position knob  |
+|    A     -> GPIO16                                                   |
+|    B     -> GPIO17                                                   |
+|                                                                      |
+|  motor  [ULN2003 stepper driver (28BYJ-48)]  -- Stepper              |
+|    A     -> GPIO25                                                   |
+|    B     -> GPIO26                                                   |
+|    C     -> GPIO27                                                   |
+|    D     -> GPIO14                                                   |
+|    VCC   -> rail 5V                                                  |
+|    GND   -> rail GND                                                 |
+|                                                                      |
+|  BOM:                                                                |
+|    - ESP32-DevKitC-V4                                                |
+|    - Quadrature rotary encoder (KY-040 style)  (knob)                |
+|    - ULN2003 stepper driver (28BYJ-48)  (motor)                      |
+|                                                                      |
+|  Power: ~100mA typical, ~240mA peak (budget 500mA)  OK               |
+|                                                                      |
+|  Warnings: none                                                      |
++----------------------------------------------------------------------+

--- a/tests/golden/encoder-drives-stepper.yaml
+++ b/tests/golden/encoder-drives-stepper.yaml
@@ -1,0 +1,37 @@
+esphome:
+  name: encoder-stepper
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+sensor:
+- platform: rotary_encoder
+  pin_a:
+    number: GPIO16
+    mode: INPUT
+  pin_b:
+    number: GPIO17
+    mode: INPUT
+  name: Position knob
+  id: knob
+  on_value:
+  - stepper.set_target:
+      id: motor
+      target: !lambda return (long) (x * 10);
+stepper:
+- platform: uln2003
+  id: motor
+  pin_a: GPIO25
+  pin_b: GPIO26
+  pin_c: GPIO27
+  pin_d: GPIO14
+  max_speed: 250 steps/s

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -240,7 +240,7 @@ _PHASE_1_5_ANNOTATIONS = [
     ("rcwl-0516",       "input",  ["on_press", "on_release"],                                []),
     ("rc522",           "input",  ["on_tag", "on_tag_removed"],                              []),
     ("rdm6300",         "input",  ["on_tag"],                                                []),
-    ("rotary_encoder",  "input",  ["on_clockwise", "on_anticlockwise"],                      []),
+    ("rotary_encoder",  "input",  ["on_clockwise", "on_anticlockwise", "on_value"],          []),
     ("adc",             "sensor", ["on_value", "on_value_range"],                            []),
     ("hc-sr04",         "sensor", ["on_value"],                                              []),
     ("rf_bridge",       "input",  ["on_code_received"],                                      []),
@@ -266,10 +266,20 @@ _PHASE_1_5B_ANNOTATIONS = [
     ("tuya_sensor",     "sensor", ["on_value", "on_value_range"], []),
 ]
 
-_ALL_1_5_ANNOTATIONS = _PHASE_1_5_ANNOTATIONS + _PHASE_1_5B_ANNOTATIONS
+# --- phase 2: value -> transform -> action -----------------------------------
+#
+# A sensor/encoder value drives an action through a transform the generator
+# lowers to a `!lambda`. The encoder gains on_value (above); the stepper is the
+# action target (accepts set_target -> stepper.set_target, no passthrough since
+# the action references the stepper by id).
+_PHASE_2_ANNOTATIONS = [
+    ("uln2003", "output", [], ["set_target"]),
+]
+
+_ALL_ANNOTATIONS = _PHASE_1_5_ANNOTATIONS + _PHASE_1_5B_ANNOTATIONS + _PHASE_2_ANNOTATIONS
 
 
-@pytest.mark.parametrize("lib_id, role, provides, accepts", _ALL_1_5_ANNOTATIONS)
+@pytest.mark.parametrize("lib_id, role, provides, accepts", _ALL_ANNOTATIONS)
 def test_phase_1_5_capability_annotation_shape(lib, lib_id, role, provides, accepts):
     cap = lib.component(lib_id).capability
     assert cap is not None, f"{lib_id} should have a capability block"
@@ -283,7 +293,7 @@ def test_phase_1_5_provides_only_keys_the_template_passes_through(lib):
     passthrough in the component's own ESPHome template; otherwise the
     automation lowers into a key the renderer drops on the floor."""
     import re
-    for lib_id, _role, provides, _accepts in _ALL_1_5_ANNOTATIONS:
+    for lib_id, _role, provides, _accepts in _ALL_ANNOTATIONS:
         tmpl = lib.component(lib_id).esphome.yaml_template or ""
         passthroughs = set(re.findall(r"params\.(on_\w+)", tmpl))
         for ev in provides:
@@ -300,7 +310,7 @@ def test_phase_1_5_accepts_have_known_esphome_verb_prefixes(lib):
     recognises. The platform prefix is asserted against the small set of
     platforms phase 1.5 covers (switch / light / stepper). Catches typos."""
     known_prefixes = {"switch", "light", "stepper"}
-    for lib_id, _role, _provides, accepts in _ALL_1_5_ANNOTATIONS:
+    for lib_id, _role, _provides, accepts in _ALL_ANNOTATIONS:
         cap = lib.component(lib_id).capability
         if not cap or not cap.accepts:
             continue
@@ -364,4 +374,61 @@ def test_sensor_on_value_lowers_into_the_sensor_template(lib):
     })
     assert validate_automations(d, lib) == []
     assert "on_value:\n  - switch.turn_on: fan" in render_yaml(d, lib)
+
+
+# --- phase 2: value -> transform -> action (encoder -> stepper) -------------
+
+ENCODER_EXAMPLE = REPO_ROOT / "wirestudio" / "examples" / "encoder-drives-stepper.json"
+
+
+def test_encoder_drives_stepper_example_matches_golden(lib):
+    d = Design.model_validate(json.loads(ENCODER_EXAMPLE.read_text()))
+    expected = (REPO_ROOT / "tests" / "golden" / "encoder-drives-stepper.yaml").read_text()
+    assert render_yaml(d, lib) == expected
+
+
+def test_encoder_drives_stepper_validator_quiet(lib):
+    d = Design.model_validate(json.loads(ENCODER_EXAMPLE.read_text()))
+    assert validate_automations(d, lib) == []
+
+
+def test_transform_lowers_to_a_lambda(lib):
+    """A transform on an action lowers to `<arg>: !lambda "return <expr>;"` --
+    the value→transform→action path. The expr rides through the tojson
+    passthrough as a sentinel and is restored to a tagged !lambda scalar."""
+    d = Design.model_validate(json.loads(ENCODER_EXAMPLE.read_text()))
+    yaml = render_yaml(d, lib)
+    assert "on_value:\n  - stepper.set_target:\n      id: motor\n      target: !lambda return (long) (x * 10);" in yaml
+
+
+def test_transform_keeps_quotes_when_expr_is_not_plain_scalar_safe(lib):
+    """An expression containing `: ` (e.g. a ternary) must stay quoted after the
+    !lambda tag, or the emitted YAML would parse as a mapping."""
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "esp32-devkitc-v4", "mcu": "esp32", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [
+            {"id": "knob",  "library_id": "rotary_encoder", "label": "Knob"},
+            {"id": "motor", "library_id": "uln2003", "label": "Motor"},
+        ],
+        "connections": [
+            {"component_id": "knob",  "pin_role": "A",   "target": {"kind": "gpio", "pin": "GPIO16"}},
+            {"component_id": "knob",  "pin_role": "B",   "target": {"kind": "gpio", "pin": "GPIO17"}},
+            {"component_id": "motor", "pin_role": "A",   "target": {"kind": "gpio", "pin": "GPIO25"}},
+            {"component_id": "motor", "pin_role": "B",   "target": {"kind": "gpio", "pin": "GPIO26"}},
+            {"component_id": "motor", "pin_role": "C",   "target": {"kind": "gpio", "pin": "GPIO27"}},
+            {"component_id": "motor", "pin_role": "D",   "target": {"kind": "gpio", "pin": "GPIO14"}},
+            {"component_id": "motor", "pin_role": "VCC", "target": {"kind": "rail", "rail": "5V"}},
+            {"component_id": "motor", "pin_role": "GND", "target": {"kind": "rail", "rail": "GND"}},
+        ],
+        "automations": [{
+            "id": "a1",
+            "trigger": {"component_id": "knob", "event": "on_value"},
+            "actions": [{"component_id": "motor", "action": "set_target",
+                         "transform": {"target": "x > 0 ? 100 : 0"}}],
+        }],
+    })
+    yaml = render_yaml(d, lib)
+    assert "target: !lambda 'return x > 0 ? 100 : 0;'" in yaml
 

--- a/wirestudio/examples/encoder-drives-stepper.json
+++ b/wirestudio/examples/encoder-drives-stepper.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "0.1",
+  "id": "encoder-drives-stepper",
+  "name": "Knob drives a stepper (value -> transform -> action)",
+  "description": "Phase-2 worked example for intent-to-device synthesis: a rotary encoder's cumulative value drives a ULN2003/28BYJ-48 stepper. The encoder's on_value (kind=value) trigger fires stepper.set_target through a transform lowered to an ESPHome !lambda -- target = (long)(x * 10), so each encoder detent commands ten motor steps. This is the value->transform->action case that complements the declarative event->action examples (button-toggles-light, motion-turns-on-light).",
+  "created_at": "2026-06-19T00:00:00Z",
+  "updated_at": "2026-06-19T00:00:00Z",
+
+  "board": {
+    "library_id": "esp32-devkitc-v4",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "turn the knob and the motor follows" }
+  ],
+
+  "components": [
+    {
+      "id": "knob",
+      "library_id": "rotary_encoder",
+      "label": "Position knob"
+    },
+    {
+      "id": "motor",
+      "library_id": "uln2003",
+      "label": "Stepper",
+      "params": { "max_speed": "250 steps/s" }
+    }
+  ],
+
+  "buses": [],
+
+  "connections": [
+    { "component_id": "knob",  "pin_role": "A",   "target": { "kind": "gpio", "pin": "GPIO16" } },
+    { "component_id": "knob",  "pin_role": "B",   "target": { "kind": "gpio", "pin": "GPIO17" } },
+    { "component_id": "motor", "pin_role": "A",   "target": { "kind": "gpio", "pin": "GPIO25" } },
+    { "component_id": "motor", "pin_role": "B",   "target": { "kind": "gpio", "pin": "GPIO26" } },
+    { "component_id": "motor", "pin_role": "C",   "target": { "kind": "gpio", "pin": "GPIO27" } },
+    { "component_id": "motor", "pin_role": "D",   "target": { "kind": "gpio", "pin": "GPIO14" } },
+    { "component_id": "motor", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "motor", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } }
+  ],
+
+  "passives": [],
+
+  "automations": [
+    {
+      "id": "knob_drives_motor",
+      "trigger": { "component_id": "knob", "event": "on_value" },
+      "actions": [
+        {
+          "component_id": "motor",
+          "action": "set_target",
+          "transform": { "target": "(long) (x * 10)" }
+        }
+      ]
+    }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "encoder-stepper",
+    "tags": ["intent-to-device", "phase-2", "example"],
+    "secrets_ref": {
+      "wifi_ssid":     "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key":       "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -22,6 +22,37 @@ yaml.add_representer(Secret, _secret_representer)
 yaml.SafeDumper.add_representer(Secret, _secret_representer)
 
 
+class Lambda(str):
+    """String wrapper that dumps as a YAML `!lambda <body>` tag -- an ESPHome
+    inline lambda (e.g. `target: !lambda 'return (long) (x * 10);'`)."""
+
+
+def _lambda_representer(dumper: yaml.Dumper, data: Lambda) -> yaml.ScalarNode:
+    return dumper.represent_scalar("!lambda", str(data), style="'")
+
+
+yaml.add_representer(Lambda, _lambda_representer)
+yaml.SafeDumper.add_representer(Lambda, _lambda_representer)
+
+
+# Lowered automation actions reach the renderer through the trigger template's
+# `{{ params.on_* | tojson }}` passthrough, and JSON can't carry a YAML tag --
+# a Lambda would flatten to a plain string. So carry it as a sentinel-prefixed
+# string across the tojson -> safe_load round-trip, then restore it to a Lambda
+# (which the final dump tags as `!lambda`) once the YAML is parsed back.
+_LAMBDA_SENTINEL = "__wirestudio_lambda__:"
+
+
+def _restore_lambdas(obj: Any) -> Any:
+    if isinstance(obj, str):
+        return Lambda(obj[len(_LAMBDA_SENTINEL):]) if obj.startswith(_LAMBDA_SENTINEL) else obj
+    if isinstance(obj, list):
+        return [_restore_lambdas(v) for v in obj]
+    if isinstance(obj, dict):
+        return {k: _restore_lambdas(v) for k, v in obj.items()}
+    return obj
+
+
 def _str_representer(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
     if "\n" in data:
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
@@ -152,8 +183,13 @@ def _lower_automations(design: Design, library: Library) -> dict[str, dict[str, 
                 continue
             # Short form when there are no extra args: `{switch.toggle: porch_light}`.
             # Long form with args:                     `{light.turn_on: {id: porch_light, brightness: "50%"}}`.
-            if act.args:
-                action_list.append({accept.esphome: {"id": act.component_id, **act.args}})
+            # Transform args lower to `!lambda "return <expr>;"` (phase 2,
+            # value→transform→action): `{stepper.set_target: {id: motor, target: !lambda ...}}`.
+            if act.args or act.transform:
+                inner = {"id": act.component_id, **act.args}
+                for arg_name, expr in act.transform.items():
+                    inner[arg_name] = f"{_LAMBDA_SENTINEL}return {expr};"
+                action_list.append({accept.esphome: inner})
             else:
                 action_list.append({accept.esphome: act.component_id})
 
@@ -237,7 +273,7 @@ def _render_component(
             ) from e
         raise
     parsed = yaml.safe_load(rendered)
-    return parsed or {}
+    return _restore_lambdas(parsed) if parsed else {}
 
 
 def _hz_to_freq(hz: int) -> str:

--- a/wirestudio/library/components/rotary_encoder.yaml
+++ b/wirestudio/library/components/rotary_encoder.yaml
@@ -52,15 +52,19 @@ esphome:
     {%- if params.on_anticlockwise is defined %}
         on_anticlockwise: {{ params.on_anticlockwise | tojson }}
     {%- endif %}
+    {%- if params.on_value is defined %}
+        on_value: {{ params.on_value | tojson }}
+    {%- endif %}
 
 capability:
-  # Quadrature encoder. Phase 1.5 wires the discrete clockwise/anticlockwise
-  # events the template passes through. Phase 2 (value -> transform -> action,
-  # the encoder -> stepper case) adds on_value with a transform IR.
+  # Quadrature encoder. The discrete clockwise/anticlockwise events (phase 1.5)
+  # and the cumulative count via on_value (kind=value) -- the phase-2
+  # value→transform→action source for the encoder→stepper case.
   role: input
   provides:
     - {event: on_clockwise}
     - {event: on_anticlockwise}
+    - {event: on_value, kind: value}
 
 params_schema:
   min_value:
@@ -74,6 +78,8 @@ params_schema:
   on_clockwise:
     type: array
   on_anticlockwise:
+    type: array
+  on_value:
     type: array
 
 notes: "Both pins must support edge interrupts -- on the ESP8266 D0/GPIO16 does not. KY-040 modules ship

--- a/wirestudio/library/components/uln2003.yaml
+++ b/wirestudio/library/components/uln2003.yaml
@@ -45,6 +45,14 @@ esphome:
         deceleration: {{ params.deceleration }}
     {%- endif %}
 
+capability:
+  # Stepper. Action target only -- `stepper.set_target` references the stepper
+  # by id (already emitted), so no template passthrough is needed. The target
+  # is the phase-2 value→transform→action sink for the encoder→stepper case.
+  role: output
+  accepts:
+    - {action: set_target, esphome: stepper.set_target}
+
 params_schema:
   max_speed:
     type: string

--- a/wirestudio/model.py
+++ b/wirestudio/model.py
@@ -146,22 +146,32 @@ class AutomationTrigger(_Strict):
 class AutomationAction(_Strict):
     """The action side: a component takes an action its library
     `capability.accepts` declares. `args` are extra ESPHome action args
-    (e.g. `{brightness: "50%"}`) that ride alongside the action target id."""
+    (e.g. `{brightness: "50%"}`) that ride alongside the action target id.
+
+    `transform` maps an action arg name to a C++ expression in terms of `x`
+    (the value the trigger emits) -- the value→transform→action case. The
+    generator lowers each entry to `<arg>: !lambda "return <expr>;"`. The
+    expression is a reviewed recipe carried in design.json, not free-handed
+    YAML: e.g. an encoder's count driving a stepper is
+    `{"target": "(long) (x * 10)"}`.
+    """
     component_id: str
     action: str
     args: dict = Field(default_factory=dict)
+    transform: dict[str, str] = Field(default_factory=dict)
 
 
 class Automation(_Strict):
-    """One trigger→actions wiring (intent-to-device synthesis, phase 1).
+    """One trigger→actions wiring (intent-to-device synthesis).
 
-    Declarative event→action only -- value/transform, condition gating, and
-    the periodic / stateful composition patterns from the design doc arrive
-    in later phases. The generator lowers each automation onto the trigger
-    component's params, where the existing ESPHome `params.on_*` passthrough
-    in the library YAML emits it. An automation referencing an unknown
-    component / event / action surfaces as a permissive warning, not a hard
-    failure (CLAUDE.md: warnings, don't block).
+    Phase 1 is declarative event→action; phase 2 adds value→transform→action
+    via `AutomationAction.transform` (lowered to a `!lambda`). Condition
+    gating and the periodic / stateful composition patterns from the design
+    doc arrive in later phases. The generator lowers each automation onto the
+    trigger component's params, where the existing ESPHome `params.on_*`
+    passthrough in the library YAML emits it. An automation referencing an
+    unknown component / event / action surfaces as a permissive warning, not a
+    hard failure (CLAUDE.md: warnings, don't block).
     """
     id: str
     trigger: AutomationTrigger

--- a/wirestudio/schema/design.schema.json
+++ b/wirestudio/schema/design.schema.json
@@ -210,7 +210,12 @@
               "properties": {
                 "component_id": { "type": "string" },
                 "action": { "type": "string" },
-                "args": { "type": "object" }
+                "args": { "type": "object" },
+                "transform": {
+                  "type": "object",
+                  "additionalProperties": { "type": "string" },
+                  "description": "Action arg name -> C++ expression in terms of x (the trigger's value); lowered to !lambda \"return <expr>;\"."
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary

Phase 2 of intent-to-device synthesis: **value→transform→action**, the second worked example the original plan always intended. An automation reading drives an action through a transform the generator lowers to an ESPHome `!lambda`.

> **Stacked on #105 (phase 1.5b).** Base is `claude/intent-phase-1-5b-sensor-triggers`, so this diff shows phase-2 only. Once #105 merges to `main`, retarget/rebase this onto `main`.

### What's new

- **IR:** `AutomationAction` gains an optional `transform` — a map of action-arg name → a C++ expression in terms of `x` (the value the trigger emits). The generator lowers each to `<arg>: !lambda "return <expr>;"`. Model + `design.json` schema both updated.
- **Library:** `rotary_encoder` gains `on_value` (kind=value) — its cumulative count — and the `uln2003` stepper gains `set_target` → `stepper.set_target` (accept-only; the action references the stepper by id, so no template passthrough).
- **Worked example** `encoder-drives-stepper.json`: a knob drives the motor via `target: !lambda return (long) (x * 10);` — each detent commands ten steps. Complements the event→action examples (button-toggles-light, motion-turns-on-light).

### The one non-obvious bit

Lowered actions reach the renderer through the trigger template's `{{ params.on_* | tojson }}` passthrough, and **JSON can't carry a YAML tag** — a `Lambda` would flatten to a plain string. So the lambda rides the round-trip as a sentinel-prefixed string and is restored to a tagged `!lambda` scalar right after `safe_load`. The codebase's existing tag-quoting fixup (`_TAGGED_THEN_QUOTED`, which already listed `lambda`) keeps the body quoted when it isn't a plain-scalar-safe expression — verified with a ternary test (`x > 0 ? 100 : 0` stays quoted).

## Test plan

- [x] `pytest tests/test_intent.py` — 45 passed (golden match, validator quiet, transform→lambda, ternary-quote retention, uln2003 capability shape)
- [x] `pytest -q` full suite — 747 passed, 11 skipped
- [x] `ruff check .` — clean
- [x] No golden churn on existing examples (the new passthroughs are conditional; blind-stepper/oled-knob render identically)
- [ ] `esphome config` on the new example runs in CI (couldn't run locally — no esphome CLI; uln2003 and rotary_encoder already pass it via blind-stepper/oled-knob, and `on_value` + `stepper.set_target: !lambda` are standard ESPHome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_