### PR TITLE
intent: multi-channel sensor triggers (phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Intent-to-device synthesis (phase 3 — multi-channel sensor triggers).**
+  An automation trigger gains an optional `channel:` selecting which sub-block
+  on a multi-output sensor it hangs off (e.g. `temperature` vs `humidity` on a
+  bme280). Capability `provides` entries gain a matching `channel:` so the
+  validator can check the trigger references a real (channel, event) pair, and
+  the lowering combines them into a `<channel>_<event>` params key so the
+  template's per-channel passthrough fires inside the right sub-block. Seven
+  environmental sensors gain channel-tagged capability blocks and the matching
+  `params.<channel>_on_value` passthroughs: `dht`, `bme280`, `bmp180`, `bmp280`,
+  `aht10`, `htu21d`, `sht3xd`. New worked example `temp-turns-on-fan.json`
+  exercises the path end-to-end (bme280 temperature -> switch). The validator's
+  unknown-event warning now lists provides as `<channel>.<event>` pairs so the
+  fix is obvious. `mpu6050` (7-channel IMU) replaces dht as the unannotated-
+  component test fixture; the remaining unannotated multi-output components
+  (power meters, the other IMU) carry too many channels to enumerate without
+  a further design call. `design.json` schema gains
+  `automations[].trigger.channel`.
+
 - **Intent-to-device synthesis (phase 2 — value→transform→action).** An
   automation action gains an optional `transform` (action-arg name → a C++
   expression in terms of `x`, the value the trigger emits) that the generator

--- a/docs/intent-to-device.md
+++ b/docs/intent-to-device.md
@@ -1,26 +1,27 @@
 # Intent-to-device synthesis (design direction)
 
-Status: **phases 1 + 1.5a + 1.5b + 2 shipped** (declarative event→action,
-broader library coverage, single-output sensor triggers, value→transform→action).
-On `main`: the `capability` library block, the `automations` schema in
-`design.json` (including `actions[].transform`), generator lowering with
-`!lambda` transforms, the permissive validator, and three worked examples
-(`button-toggles-light`, `motion-turns-on-light`, `encoder-drives-stepper`).
-Twenty-two components carry `capability` annotations: the two GPIO primitives,
-10 broader-library entries from 1.5a (PIR/microwave motion, RC522/RDM6300 RFID,
-rotary_encoder, ADC + HC-SR04, RF bridge, WS2812B, tuya_switch), 9 single-output
-sensors from 1.5b (ds18b20, bh1750, tsl2561, vl53l0x, hx711, max31855,
-pulse_counter, ads1115_channel, tuya_sensor) with `on_value` / `on_value_range`,
-and the uln2003 stepper from phase 2 (accepts `set_target`).
+Status: **phases 1 + 1.5a + 1.5b + 2 + 3 shipped** (declarative event→action,
+broader library coverage, single-output sensor triggers, value→transform→action,
+multi-channel sensor triggers). On `main`: the `capability` library block, the
+`automations` schema in `design.json` (including `trigger.channel` and
+`actions[].transform`), generator lowering with `!lambda` transforms and
+per-channel passthroughs, the permissive validator, and four worked examples
+(`button-toggles-light`, `motion-turns-on-light`, `encoder-drives-stepper`,
+`temp-turns-on-fan`). Twenty-nine components carry `capability` annotations:
+the two GPIO primitives, 10 broader-library entries from 1.5a, 9 single-output
+sensors from 1.5b, the uln2003 stepper from phase 2, and 7 multi-channel
+environmental sensors from phase 3 (dht, bme280, bmp180, bmp280, aht10,
+htu21d, sht3xd) with channel-tagged `on_value` provides.
 
-Phase 2 lowers an action's `transform` (arg → a C++ expression in `x`, the
-trigger's value) to an ESPHome `!lambda`; the encoder→stepper example drives
-`stepper.set_target` from the encoder's count. Multi-channel sensors (dht,
-bme280, IMUs, power meters) stay unannotated — which sub-channel a trigger
-hangs off is a separate design call. The `on_value_range` threshold case is
-declared but its range bounds await a richer trigger IR; multi-device topology
-and a live `esphome config` authoring loop arrive in later phases per
-*Suggested phasing* below.
+Phase 3 adds `trigger.channel` to the IR and per-channel passthroughs to each
+sub-block; the bme280 example drives a fan from the temperature channel,
+landing `on_value` inside `temperature:` (not at the platform level, not on the
+sibling humidity/pressure blocks). The remaining unannotated multi-output
+components (mpu6050/mpu6886 IMUs, cse7766/hlw8012/bl0906/sdm_meter power
+meters) carry too many channels to enumerate without a further design call.
+The `on_value_range` threshold case is declared but its range bounds await a
+richer trigger IR; multi-device topology and a live `esphome config` authoring
+loop arrive in later phases per *Suggested phasing* below.
 
 This document was the agreed plan; per-phase work updates this status line in
 place rather than appending a new file each time.

--- a/tests/golden/temp-turns-on-fan.txt
+++ b/tests/golden/temp-turns-on-fan.txt
@@ -1,0 +1,23 @@
++-----------------------------------------------------+
+|  WeMos D1 Mini  ---  temp-turns-on-fan              |
++-----------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                |
+|                                                     |
+|  climate  [Bosch BME280 (T/H/P)]  -- Climate        |
+|    VCC   -> rail 3V3                                |
+|    GND   -> rail GND                                |
+|    SDA   -> i2c0 (D2)                               |
+|    SCL   -> i2c0 (D1)                               |
+|                                                     |
+|  fan  [Generic GPIO switch / relay output]  -- Fan  |
+|    OUT   -> D6                                      |
+|                                                     |
+|  BOM:                                               |
+|    - WeMos D1 Mini                                  |
+|    - Bosch BME280 (T/H/P)  (climate)                |
+|    - Generic GPIO switch / relay output  (fan)      |
+|                                                     |
+|  Power: ~0mA typical, ~4mA peak (budget 500mA)  OK  |
+|                                                     |
+|  Warnings: none                                     |
++-----------------------------------------------------+

--- a/tests/golden/temp-turns-on-fan.yaml
+++ b/tests/golden/temp-turns-on-fan.yaml
@@ -1,0 +1,35 @@
+esphome:
+  name: temp-fan
+esp8266:
+  board: d1_mini
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+i2c:
+- id: i2c0
+  sda: D2
+  scl: D1
+  frequency: 400kHz
+sensor:
+- platform: bme280_i2c
+  address: '0x76'
+  i2c_id: i2c0
+  temperature:
+    name: Climate Temperature
+    on_value:
+    - switch.turn_on: fan
+  humidity:
+    name: Climate Humidity
+  pressure:
+    name: Climate Pressure
+switch:
+- platform: gpio
+  pin: D6
+  name: Fan
+  id: fan

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -69,10 +69,11 @@ def test_gpio_output_carries_actions_with_explicit_esphome_verbs(lib):
 
 def test_unannotated_components_keep_capability_none(lib):
     # The annotation rollout is incremental; an un-annotated component still
-    # loads, it just can't participate in `automations` yet. `dht` is a
-    # multi-channel temp+humidity sensor -- which sub-channel an on_value
-    # trigger hangs off is unresolved, so it stays capability=None for now.
-    assert lib.component("dht").capability is None
+    # loads, it just can't participate in `automations` yet. `mpu6050` is a
+    # 7-channel IMU (accel x/y/z + gyro x/y/z + die temp) -- too rich to
+    # enumerate as triggers without a further design call, so it stays
+    # capability=None for now.
+    assert lib.component("mpu6050").capability is None
 
 
 def test_automation_round_trips_through_the_model():
@@ -198,26 +199,26 @@ def test_validator_flags_unknown_action(lib):
 
 
 def test_validator_flags_component_without_capability(lib):
-    # dht (temp+humidity) is multi-channel, so its on_value trigger placement is
-    # an open design question and it carries no capability block today -- it
-    # can't be a trigger source even though it's a real component. (Single-output
-    # sensors like ds18b20 gained capabilities in 1.5b; multi-channel ones did
-    # not.)
+    # mpu6050 is a 7-channel IMU (accel x/y/z + gyro x/y/z + die temp) -- too
+    # rich to enumerate as triggers without further design, so it carries no
+    # capability block today and can't be a trigger source.
     d = Design.model_validate({
         "schema_version": "0.1", "id": "t", "name": "T",
         "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
         "power": {"supply": "usb", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "buses": [{"id": "i2c0", "type": "i2c", "sda": "D2", "scl": "D1"}],
         "components": [
-            {"id": "temp", "library_id": "dht", "label": "Temp"},
-            {"id": "lt",   "library_id": "gpio_output", "label": "Light"},
+            {"id": "imu", "library_id": "mpu6050", "label": "IMU"},
+            {"id": "lt",  "library_id": "gpio_output", "label": "Light"},
         ],
         "connections": [
-            {"component_id": "temp", "pin_role": "DATA", "target": {"kind": "gpio", "pin": "D4"}},
-            {"component_id": "lt",   "pin_role": "OUT",  "target": {"kind": "gpio", "pin": "D6"}},
+            {"component_id": "imu", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "imu", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "lt",  "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D6"}},
         ],
         "automations": [{
             "id": "a1",
-            "trigger": {"component_id": "temp", "event": "on_value"},
+            "trigger": {"component_id": "imu", "event": "on_value"},
             "actions": [{"component_id": "lt", "action": "turn_on"}],
         }],
     })
@@ -274,6 +275,27 @@ _PHASE_1_5B_ANNOTATIONS = [
 # the action references the stepper by id).
 _PHASE_2_ANNOTATIONS = [
     ("uln2003", "output", [], ["set_target"]),
+]
+
+# --- phase 3: multi-channel sensor triggers ---------------------------------
+#
+# A trigger on a multi-channel sensor (e.g. bme280) carries a `channel:`
+# selector matching the sub-block the on_value belongs to. The capability
+# provides list one entry per channel. The lowering combines channel + event
+# into a `<channel>_<event>` params key, so the template's per-channel
+# `params.temperature_on_value` (etc.) passthrough fires inside the right
+# sub-block.
+#
+# (component_id, role, [(channel, event), ...])
+_PHASE_3_MULTICHANNEL = [
+    ("dht",     "sensor", [("temperature", "on_value"), ("humidity", "on_value")]),
+    ("bme280",  "sensor", [("temperature", "on_value"), ("humidity", "on_value"),
+                           ("pressure", "on_value")]),
+    ("bmp180",  "sensor", [("temperature", "on_value"), ("pressure", "on_value")]),
+    ("bmp280",  "sensor", [("temperature", "on_value"), ("pressure", "on_value")]),
+    ("aht10",   "sensor", [("temperature", "on_value"), ("humidity", "on_value")]),
+    ("htu21d",  "sensor", [("temperature", "on_value"), ("humidity", "on_value")]),
+    ("sht3xd",  "sensor", [("temperature", "on_value"), ("humidity", "on_value")]),
 ]
 
 _ALL_ANNOTATIONS = _PHASE_1_5_ANNOTATIONS + _PHASE_1_5B_ANNOTATIONS + _PHASE_2_ANNOTATIONS
@@ -374,6 +396,100 @@ def test_sensor_on_value_lowers_into_the_sensor_template(lib):
     })
     assert validate_automations(d, lib) == []
     assert "on_value:\n  - switch.turn_on: fan" in render_yaml(d, lib)
+
+
+# --- phase 3: multi-channel sensor capability + lowering ---------------------
+
+@pytest.mark.parametrize("lib_id, role, channels", _PHASE_3_MULTICHANNEL)
+def test_phase_3_multichannel_capability_shape(lib, lib_id, role, channels):
+    cap = lib.component(lib_id).capability
+    assert cap is not None and cap.role == role
+    actual = [(p.channel, p.event) for p in cap.provides]
+    assert actual == channels
+    # Every entry is a value-kind provide
+    assert all(p.kind == "value" for p in cap.provides)
+
+
+def test_phase_3_provides_match_template_per_channel_passthroughs(lib):
+    """Each (channel, event) pair must match a `params.<channel>_<event>`
+    passthrough in the component's template, INSIDE the matching sub-block."""
+    import re
+    for lib_id, _role, channels in _PHASE_3_MULTICHANNEL:
+        tmpl = lib.component(lib_id).esphome.yaml_template or ""
+        passthroughs = set(re.findall(r"params\.([a-z]+_on_\w+)", tmpl))
+        for channel, event in channels:
+            key = f"{channel}_{event}"
+            assert key in passthroughs, (
+                f"{lib_id}: capability declares ({channel!r}, {event!r}) but the "
+                f"template has no params.{key} passthrough. Template has: "
+                f"{sorted(passthroughs) or '(none)'}"
+            )
+
+
+TEMP_FAN_EXAMPLE = REPO_ROOT / "wirestudio" / "examples" / "temp-turns-on-fan.json"
+
+
+def test_temp_to_fan_example_matches_golden(lib):
+    d = Design.model_validate(json.loads(TEMP_FAN_EXAMPLE.read_text()))
+    expected = (REPO_ROOT / "tests" / "golden" / "temp-turns-on-fan.yaml").read_text()
+    assert render_yaml(d, lib) == expected
+
+
+def test_temp_to_fan_lowers_into_the_temperature_sub_block(lib):
+    """The bme280's temperature channel trigger lands on_value inside the
+    temperature sub-block -- not at the platform level, not under humidity."""
+    d = Design.model_validate(json.loads(TEMP_FAN_EXAMPLE.read_text()))
+    yaml = render_yaml(d, lib)
+    # Asserts both the sub-block placement and the absence of stray on_value
+    # on the sibling humidity/pressure channels.
+    expected = (
+        "  temperature:\n"
+        "    name: Climate Temperature\n"
+        "    on_value:\n"
+        "    - switch.turn_on: fan\n"
+        "  humidity:\n"
+        "    name: Climate Humidity\n"
+        "  pressure:\n"
+        "    name: Climate Pressure"
+    )
+    assert expected in yaml
+
+
+def test_temp_to_fan_validator_quiet(lib):
+    d = Design.model_validate(json.loads(TEMP_FAN_EXAMPLE.read_text()))
+    assert validate_automations(d, lib) == []
+
+
+def test_validator_flags_unknown_channel_on_multichannel_sensor(lib):
+    """A trigger naming a channel the component doesn't provide surfaces
+    automation_unknown_event, and the warning text lists what IS provided as
+    `<channel>.<event>` pairs so the fix is obvious."""
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "buses": [{"id": "i2c0", "type": "i2c", "sda": "D2", "scl": "D1"}],
+        "components": [
+            {"id": "bme", "library_id": "bme280", "label": "Climate"},
+            {"id": "fan", "library_id": "gpio_output", "label": "Fan"},
+        ],
+        "connections": [
+            {"component_id": "bme", "pin_role": "SDA", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "bme", "pin_role": "SCL", "target": {"kind": "bus", "bus_id": "i2c0"}},
+            {"component_id": "fan", "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+        "automations": [{
+            "id": "a1",
+            "trigger": {"component_id": "bme", "channel": "altitude", "event": "on_value"},
+            "actions": [{"component_id": "fan", "action": "turn_on"}],
+        }],
+    })
+    warns = validate_automations(d, lib)
+    codes = [w.code for w in warns]
+    assert "automation_unknown_event" in codes
+    text = next(w.text for w in warns if w.code == "automation_unknown_event")
+    assert "channel 'altitude'" in text
+    assert "temperature.on_value" in text  # the warning lists what IS provided
 
 
 # --- phase 2: value -> transform -> action (encoder -> stepper) -------------

--- a/wirestudio/examples/temp-turns-on-fan.json
+++ b/wirestudio/examples/temp-turns-on-fan.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "0.1",
+  "id": "temp-turns-on-fan",
+  "name": "Temperature turns on the fan",
+  "description": "Phase-3 worked example for intent-to-device synthesis: a BME280's temperature channel triggers a switch action when its on_value fires. Exercises the multi-channel sensor trigger path -- the trigger carries a `channel: temperature` selector that the lowering combines with the event to land `on_value:` inside the `temperature:` sub-block (vs. the bme280's humidity / pressure siblings, which stay clear). Complements the single-channel sensor examples by proving the lowering picks the right sub-block on a multi-output sensor.",
+  "created_at": "2026-06-19T00:00:00Z",
+  "updated_at": "2026-06-19T00:00:00Z",
+
+  "board": {
+    "library_id": "wemos-d1-mini",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-rt9013",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "turn on the fan when temperature rises" }
+  ],
+
+  "components": [
+    {
+      "id": "climate",
+      "library_id": "bme280",
+      "label": "Climate",
+      "params": { "address": "0x76" }
+    },
+    {
+      "id": "fan",
+      "library_id": "gpio_output",
+      "label": "Fan"
+    }
+  ],
+
+  "buses": [
+    { "id": "i2c0", "type": "i2c", "frequency_hz": 400000, "sda": "D2", "scl": "D1" }
+  ],
+
+  "connections": [
+    { "component_id": "climate", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "climate", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "climate", "pin_role": "SDA", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+    { "component_id": "climate", "pin_role": "SCL", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+    { "component_id": "fan",     "pin_role": "OUT", "target": { "kind": "gpio", "pin": "D6" } }
+  ],
+
+  "passives": [],
+
+  "automations": [
+    {
+      "id": "temp_turns_on_fan",
+      "trigger": { "component_id": "climate", "channel": "temperature", "event": "on_value" },
+      "actions": [
+        { "component_id": "fan", "action": "turn_on" }
+      ]
+    }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "temp-fan",
+    "tags": ["intent-to-device", "phase-3", "example"],
+    "secrets_ref": {
+      "wifi_ssid":     "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key":       "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -161,10 +161,24 @@ def _lower_automations(design: Design, library: Library) -> dict[str, dict[str, 
         cap = trig_lib.capability
         if cap is None:
             continue
-        provide = next((p for p in cap.provides if p.event == auto.trigger.event), None)
+        trig_channel = auto.trigger.channel
+        provide = next(
+            (p for p in cap.provides
+             if p.event == auto.trigger.event and (p.channel or None) == (trig_channel or None)),
+            None,
+        )
         if provide is None:
             continue
-        event_key = provide.esphome or provide.event
+        # When `esphome` is set, it's a full explicit override on the params key.
+        # Otherwise build it from the channel + event so a multi-channel
+        # template's per-channel passthrough (e.g. params.temperature_on_value)
+        # fires inside the right sub-block.
+        if provide.esphome:
+            event_key = provide.esphome
+        elif provide.channel:
+            event_key = f"{provide.channel}_{provide.event}"
+        else:
+            event_key = provide.event
 
         action_list: list = []
         for act in auto.actions:

--- a/wirestudio/intent.py
+++ b/wirestudio/intent.py
@@ -57,14 +57,28 @@ def validate_automations(design: Design, library: Library) -> list[DesignWarning
                               f"{trig_comp.library_id!r}) has no capability "
                               f"block and can't trigger automations"),
                     ))
-                elif not any(p.event == trig.event for p in cap.provides):
-                    provided = ", ".join(p.event for p in cap.provides) or "(none)"
-                    out.append(DesignWarning(
-                        level="warn", code="automation_unknown_event",
-                        text=(f"automation {auto.id!r}: component "
-                              f"{trig.component_id!r} does not provide event "
-                              f"{trig.event!r}; provides: {provided}"),
-                    ))
+                else:
+                    trig_channel = trig.channel
+                    match = next(
+                        (p for p in cap.provides
+                         if p.event == trig.event and (p.channel or None) == (trig_channel or None)),
+                        None,
+                    )
+                    if match is None:
+                        provided = ", ".join(
+                            f"{p.channel}.{p.event}" if p.channel else p.event
+                            for p in cap.provides
+                        ) or "(none)"
+                        suffix = (
+                            f"event {trig.event!r} on channel {trig_channel!r}"
+                            if trig_channel else f"event {trig.event!r}"
+                        )
+                        out.append(DesignWarning(
+                            level="warn", code="automation_unknown_event",
+                            text=(f"automation {auto.id!r}: component "
+                                  f"{trig.component_id!r} does not provide "
+                                  f"{suffix}; provides: {provided}"),
+                        ))
 
         for act in auto.actions:
             act_comp = by_id.get(act.component_id)

--- a/wirestudio/library/__init__.py
+++ b/wirestudio/library/__init__.py
@@ -95,10 +95,15 @@ class CapabilityProvides(_Strict):
     template `params.<event>` passthrough uses, e.g. `on_press`). `esphome`
     overrides the rendered ESPHome trigger key when it differs from `event`;
     defaults to `event` so the common case is a single line per provide.
+    `channel` names the sub-block this provide lives under for multi-channel
+    components (e.g. a bme280's `temperature` block); single-output components
+    omit it. When set, the rendered params key is `<channel>_<event>` so the
+    template's per-channel passthrough fires the right `on_value`.
     """
     event: str
     kind: Literal["event", "value"] = "event"
     esphome: Optional[str] = None
+    channel: Optional[str] = None
 
 
 class CapabilityAccepts(_Strict):

--- a/wirestudio/library/components/aht10.yaml
+++ b/wirestudio/library/components/aht10.yaml
@@ -31,8 +31,20 @@ esphome:
         update_interval: {{ params.update_interval | default('60s') }}
         temperature:
           name: "{{ label }} Temperature"
+    {%- if params.temperature_on_value is defined %}
+          on_value: {{ params.temperature_on_value | tojson }}
+    {%- endif %}
         humidity:
           name: "{{ label }} Humidity"
+    {%- if params.humidity_on_value is defined %}
+          on_value: {{ params.humidity_on_value | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value, kind: value, channel: humidity}
 
 params_schema:
   variant:

--- a/wirestudio/library/components/bme280.yaml
+++ b/wirestudio/library/components/bme280.yaml
@@ -30,10 +30,26 @@ esphome:
         i2c_id: {{ bus.id }}
         temperature:
           name: "{{ label }} Temperature"
+    {%- if params.temperature_on_value is defined %}
+          on_value: {{ params.temperature_on_value | tojson }}
+    {%- endif %}
         humidity:
           name: "{{ label }} Humidity"
+    {%- if params.humidity_on_value is defined %}
+          on_value: {{ params.humidity_on_value | tojson }}
+    {%- endif %}
         pressure:
           name: "{{ label }} Pressure"
+    {%- if params.pressure_on_value is defined %}
+          on_value: {{ params.pressure_on_value | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value, kind: value, channel: humidity}
+    - {event: on_value, kind: value, channel: pressure}
 
 params_schema:
   address:

--- a/wirestudio/library/components/bmp180.yaml
+++ b/wirestudio/library/components/bmp180.yaml
@@ -30,8 +30,20 @@ esphome:
         update_interval: {{ params.update_interval | default('60s') }}
         temperature:
           name: "{{ label }} Temperature"
+    {%- if params.temperature_on_value is defined %}
+          on_value: {{ params.temperature_on_value | tojson }}
+    {%- endif %}
         pressure:
           name: "{{ label }} Pressure"
+    {%- if params.pressure_on_value is defined %}
+          on_value: {{ params.pressure_on_value | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value, kind: value, channel: pressure}
 
 params_schema:
   update_interval:

--- a/wirestudio/library/components/bmp280.yaml
+++ b/wirestudio/library/components/bmp280.yaml
@@ -33,11 +33,23 @@ esphome:
     {%- if params.oversampling is defined %}
           oversampling: {{ params.oversampling }}
     {%- endif %}
+    {%- if params.temperature_on_value is defined %}
+          on_value: {{ params.temperature_on_value | tojson }}
+    {%- endif %}
         pressure:
           name: "{{ label }} Pressure"
+    {%- if params.pressure_on_value is defined %}
+          on_value: {{ params.pressure_on_value | tojson }}
+    {%- endif %}
     {%- if params.update_interval is defined %}
         update_interval: {{ params.update_interval }}
     {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value, kind: value, channel: pressure}
 
 params_schema:
   address:

--- a/wirestudio/library/components/dht.yaml
+++ b/wirestudio/library/components/dht.yaml
@@ -67,11 +67,23 @@ esphome:
         pin: {{ pins.DATA | tojson }}
         temperature:
           name: "{{ label }} Temperature"
+    {%- if params.temperature_on_value is defined %}
+          on_value: {{ params.temperature_on_value | tojson }}
+    {%- endif %}
         humidity:
           name: "{{ label }} Humidity"
+    {%- if params.humidity_on_value is defined %}
+          on_value: {{ params.humidity_on_value | tojson }}
+    {%- endif %}
     {%- if params.update_interval is defined %}
         update_interval: {{ params.update_interval }}
     {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value, kind: value, channel: humidity}
 
 params_schema:
   model:

--- a/wirestudio/library/components/htu21d.yaml
+++ b/wirestudio/library/components/htu21d.yaml
@@ -30,8 +30,20 @@ esphome:
         update_interval: {{ params.update_interval | default('60s') }}
         temperature:
           name: "{{ label }} Temperature"
+    {%- if params.temperature_on_value is defined %}
+          on_value: {{ params.temperature_on_value | tojson }}
+    {%- endif %}
         humidity:
           name: "{{ label }} Humidity"
+    {%- if params.humidity_on_value is defined %}
+          on_value: {{ params.humidity_on_value | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value, kind: value, channel: humidity}
 
 params_schema:
   update_interval:

--- a/wirestudio/library/components/sht3xd.yaml
+++ b/wirestudio/library/components/sht3xd.yaml
@@ -31,8 +31,20 @@ esphome:
         update_interval: {{ params.update_interval | default('60s') }}
         temperature:
           name: "{{ label }} Temperature"
+    {%- if params.temperature_on_value is defined %}
+          on_value: {{ params.temperature_on_value | tojson }}
+    {%- endif %}
         humidity:
           name: "{{ label }} Humidity"
+    {%- if params.humidity_on_value is defined %}
+          on_value: {{ params.humidity_on_value | tojson }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value, kind: value, channel: humidity}
 
 params_schema:
   address:

--- a/wirestudio/model.py
+++ b/wirestudio/model.py
@@ -138,9 +138,12 @@ class DesignWarning(_Strict):
 class AutomationTrigger(_Strict):
     """The event side of one automation: a component emits an event the
     component's library `capability.provides` declares. `component_id` is a
-    design-level id (the validator checks it resolves)."""
+    design-level id (the validator checks it resolves). `channel` selects a
+    sub-block on multi-channel components (e.g. `temperature` on a bme280) --
+    the provides entry must match both event AND channel."""
     component_id: str
     event: str
+    channel: Optional[str] = None
 
 
 class AutomationAction(_Strict):

--- a/wirestudio/schema/design.schema.json
+++ b/wirestudio/schema/design.schema.json
@@ -198,7 +198,11 @@
             "additionalProperties": false,
             "properties": {
               "component_id": { "type": "string" },
-              "event": { "type": "string" }
+              "event": { "type": "string" },
+              "channel": {
+                "type": "string",
+                "description": "Sub-block on multi-channel components (e.g. \"temperature\" on a bme280); omit for single-output."
+              }
             }
           },
           "actions": {


### PR DESCRIPTION
## Summary

Phase 3 of intent-to-device synthesis: **multi-channel sensor triggers**. The seven most-used environmental sensors can now drive automations from a specific sub-channel — pick `temperature` or `humidity` or `pressure`, and the trigger lands inside the matching ESPHome sub-block.

### IR

- `AutomationTrigger` gains optional `channel: Optional[str]` — selects the sub-block on a multi-output component.
- `CapabilityProvides` gains the same field — capability annotations declare per-channel triggers.
- Validator matches on both `(channel, event)`; warning text lists provides as `<channel>.<event>` so the fix is obvious.
- Lowering combines them into a `<channel>_<event>` params key (or just `<event>` for single-output); per-channel templates branch on that.

### Sensors annotated

`dht`, `bme280`, `bmp180`, `bmp280`, `aht10`, `htu21d`, `sht3xd` — every one a temp/humidity/pressure combo with a clean sub-block structure. Each gets a `params.<channel>_on_value` passthrough inside the corresponding `temperature:` / `humidity:` / `pressure:` block, plus a capability listing channel-tagged provides.

### Worked example

`temp-turns-on-fan.json` — bme280 temperature → `switch.turn_on: fan` on a Wemos D1 Mini. The golden test asserts on_value lands inside `temperature:` and **not** on the sibling humidity/pressure blocks; the validator is quiet. Plus a unit test exercising the unknown-channel warning text.

### Deferred (by design)

- `mpu6050`, `mpu6886`, `cse7766`, `hlw8012`, `bl0906`, `sdm_meter` — too many sub-channels to enumerate without a further design call.
- `on_value_range` for multi-channel — same shape as single-output 1.5b, declared but bounds await a richer trigger IR.

### Stats

29 components carry capability annotations (up from 22). `mpu6050` replaces `dht` as the unannotated-component test fixture.

## Test plan

- [x] `pytest tests/test_intent.py` — 57 passed (annotation shape, per-channel passthrough match, golden, sub-block placement, unknown-channel warning text, validator quiet on the example)
- [x] `pytest -q` full suite — 759 passed, 11 skipped
- [x] `ruff check .` — clean
- [x] No golden churn on existing examples (passthroughs are conditional; existing renders byte-identical)
- [ ] `esphome config` on the new example runs in CI (no esphome CLI locally; bme280 already passes the gate, and `on_value` inside a sub-block is standard ESPHome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_