### PR TITLE
intent: on_value_range threshold bounds (phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Intent-to-device synthesis (phase 4 — on_value_range threshold bounds).**
+  An automation trigger gains optional `above` / `below` numeric bounds for the
+  `on_value_range` event; the lowering wraps the action list in a
+  `{above, below, then}` range entry, producing ESPHome's
+  `on_value_range: - above: 28.0\n  then: [...]` shape. Two new permissive
+  validator warnings (`automation_bounds_require_value_range`,
+  `automation_value_range_needs_bounds`) catch the two cooperative mistakes
+  -- bounds on the wrong event, or `on_value_range` with no bounds (which
+  would fire on every reading). All 7 phase-3 multi-channel sensors (dht,
+  bme280, bmp180, bmp280, aht10, htu21d, sht3xd) gain channel-tagged
+  `on_value_range` provides and matching `params.<channel>_on_value_range`
+  passthroughs in each sub-block, so a threshold trigger composes with the
+  multi-channel selector. New worked example
+  `temp-above-turns-on-fan.json` (bme280 temperature >= 28°C -> fan on).
+  `design.json` schema gains `automations[].trigger.above` / `.below`.
+
 - **Intent-to-device synthesis (phase 3 — multi-channel sensor triggers).**
   An automation trigger gains an optional `channel:` selecting which sub-block
   on a multi-output sensor it hangs off (e.g. `temperature` vs `humidity` on a

--- a/docs/intent-to-device.md
+++ b/docs/intent-to-device.md
@@ -1,27 +1,28 @@
 # Intent-to-device synthesis (design direction)
 
-Status: **phases 1 + 1.5a + 1.5b + 2 + 3 shipped** (declarative event→action,
-broader library coverage, single-output sensor triggers, value→transform→action,
-multi-channel sensor triggers). On `main`: the `capability` library block, the
-`automations` schema in `design.json` (including `trigger.channel` and
-`actions[].transform`), generator lowering with `!lambda` transforms and
-per-channel passthroughs, the permissive validator, and four worked examples
-(`button-toggles-light`, `motion-turns-on-light`, `encoder-drives-stepper`,
-`temp-turns-on-fan`). Twenty-nine components carry `capability` annotations:
-the two GPIO primitives, 10 broader-library entries from 1.5a, 9 single-output
-sensors from 1.5b, the uln2003 stepper from phase 2, and 7 multi-channel
-environmental sensors from phase 3 (dht, bme280, bmp180, bmp280, aht10,
-htu21d, sht3xd) with channel-tagged `on_value` provides.
+Status: **phases 1 + 1.5a + 1.5b + 2 + 3 + 4 shipped** (declarative
+event→action, broader library coverage, single-output sensor triggers,
+value→transform→action, multi-channel sensor triggers, on_value_range
+threshold bounds). On `main`: the `capability` library block, the
+`automations` schema in `design.json` (with `trigger.channel`,
+`trigger.above` / `.below`, `actions[].transform`), generator lowering with
+`!lambda` transforms, per-channel passthroughs and `{above, below, then}`
+range entries, the permissive validator (now catching bounds-on-wrong-event
+and range-without-bounds), and five worked examples (`button-toggles-light`,
+`motion-turns-on-light`, `encoder-drives-stepper`, `temp-turns-on-fan`,
+`temp-above-turns-on-fan`). Twenty-nine components carry `capability`
+annotations; the seven phase-3 multi-channel environmental sensors now also
+expose `on_value_range` per channel, so a threshold trigger composes with the
+channel selector cleanly.
 
-Phase 3 adds `trigger.channel` to the IR and per-channel passthroughs to each
-sub-block; the bme280 example drives a fan from the temperature channel,
-landing `on_value` inside `temperature:` (not at the platform level, not on the
-sibling humidity/pressure blocks). The remaining unannotated multi-output
-components (mpu6050/mpu6886 IMUs, cse7766/hlw8012/bl0906/sdm_meter power
-meters) carry too many channels to enumerate without a further design call.
-The `on_value_range` threshold case is declared but its range bounds await a
-richer trigger IR; multi-device topology and a live `esphome config` authoring
-loop arrive in later phases per *Suggested phasing* below.
+Phase 4 carries threshold bounds on the trigger; the bme280 example fires
+`switch.turn_on: fan` when temperature crosses 28°C and the lowering emits
+ESPHome's `on_value_range: - above: 28.0\n  then: [...]` shape inside the
+right sub-block. The remaining unannotated multi-output components
+(mpu6050/mpu6886 IMUs, cse7766/hlw8012/bl0906/sdm_meter power meters) carry
+too many channels to enumerate without a further design call. Condition
+gating, multi-device topology, and a live `esphome config` authoring loop
+arrive in later phases per *Suggested phasing* below.
 
 This document was the agreed plan; per-phase work updates this status line in
 place rather than appending a new file each time.

--- a/tests/golden/temp-above-turns-on-fan.txt
+++ b/tests/golden/temp-above-turns-on-fan.txt
@@ -1,0 +1,23 @@
++-----------------------------------------------------+
+|  WeMos D1 Mini  ---  temp-above-turns-on-fan        |
++-----------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                |
+|                                                     |
+|  climate  [Bosch BME280 (T/H/P)]  -- Climate        |
+|    VCC   -> rail 3V3                                |
+|    GND   -> rail GND                                |
+|    SDA   -> i2c0 (D2)                               |
+|    SCL   -> i2c0 (D1)                               |
+|                                                     |
+|  fan  [Generic GPIO switch / relay output]  -- Fan  |
+|    OUT   -> D6                                      |
+|                                                     |
+|  BOM:                                               |
+|    - WeMos D1 Mini                                  |
+|    - Bosch BME280 (T/H/P)  (climate)                |
+|    - Generic GPIO switch / relay output  (fan)      |
+|                                                     |
+|  Power: ~0mA typical, ~4mA peak (budget 500mA)  OK  |
+|                                                     |
+|  Warnings: none                                     |
++-----------------------------------------------------+

--- a/tests/golden/temp-above-turns-on-fan.yaml
+++ b/tests/golden/temp-above-turns-on-fan.yaml
@@ -1,0 +1,37 @@
+esphome:
+  name: temp-threshold-fan
+esp8266:
+  board: d1_mini
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+i2c:
+- id: i2c0
+  sda: D2
+  scl: D1
+  frequency: 400kHz
+sensor:
+- platform: bme280_i2c
+  address: '0x76'
+  i2c_id: i2c0
+  temperature:
+    name: Climate Temperature
+    on_value_range:
+    - above: 28.0
+      then:
+      - switch.turn_on: fan
+  humidity:
+    name: Climate Humidity
+  pressure:
+    name: Climate Pressure
+switch:
+- platform: gpio
+  pin: D6
+  name: Fan
+  id: fan

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -287,15 +287,25 @@ _PHASE_2_ANNOTATIONS = [
 # sub-block.
 #
 # (component_id, role, [(channel, event), ...])
+# Phase 4 doubles each channel: both on_value (kind=value) and on_value_range
+# (kind=event) so a multi-channel sensor can drive both direct-value and
+# threshold-bounded triggers.
 _PHASE_3_MULTICHANNEL = [
-    ("dht",     "sensor", [("temperature", "on_value"), ("humidity", "on_value")]),
-    ("bme280",  "sensor", [("temperature", "on_value"), ("humidity", "on_value"),
-                           ("pressure", "on_value")]),
-    ("bmp180",  "sensor", [("temperature", "on_value"), ("pressure", "on_value")]),
-    ("bmp280",  "sensor", [("temperature", "on_value"), ("pressure", "on_value")]),
-    ("aht10",   "sensor", [("temperature", "on_value"), ("humidity", "on_value")]),
-    ("htu21d",  "sensor", [("temperature", "on_value"), ("humidity", "on_value")]),
-    ("sht3xd",  "sensor", [("temperature", "on_value"), ("humidity", "on_value")]),
+    ("dht",     "sensor", [("temperature", "on_value"), ("temperature", "on_value_range"),
+                           ("humidity", "on_value"),    ("humidity", "on_value_range")]),
+    ("bme280",  "sensor", [("temperature", "on_value"), ("temperature", "on_value_range"),
+                           ("humidity", "on_value"),    ("humidity", "on_value_range"),
+                           ("pressure", "on_value"),    ("pressure", "on_value_range")]),
+    ("bmp180",  "sensor", [("temperature", "on_value"), ("temperature", "on_value_range"),
+                           ("pressure", "on_value"),    ("pressure", "on_value_range")]),
+    ("bmp280",  "sensor", [("temperature", "on_value"), ("temperature", "on_value_range"),
+                           ("pressure", "on_value"),    ("pressure", "on_value_range")]),
+    ("aht10",   "sensor", [("temperature", "on_value"), ("temperature", "on_value_range"),
+                           ("humidity", "on_value"),    ("humidity", "on_value_range")]),
+    ("htu21d",  "sensor", [("temperature", "on_value"), ("temperature", "on_value_range"),
+                           ("humidity", "on_value"),    ("humidity", "on_value_range")]),
+    ("sht3xd",  "sensor", [("temperature", "on_value"), ("temperature", "on_value_range"),
+                           ("humidity", "on_value"),    ("humidity", "on_value_range")]),
 ]
 
 _ALL_ANNOTATIONS = _PHASE_1_5_ANNOTATIONS + _PHASE_1_5B_ANNOTATIONS + _PHASE_2_ANNOTATIONS
@@ -406,8 +416,13 @@ def test_phase_3_multichannel_capability_shape(lib, lib_id, role, channels):
     assert cap is not None and cap.role == role
     actual = [(p.channel, p.event) for p in cap.provides]
     assert actual == channels
-    # Every entry is a value-kind provide
-    assert all(p.kind == "value" for p in cap.provides)
+    # on_value is kind=value (the cumulative reading); on_value_range is
+    # kind=event (a discrete threshold-crossing).
+    for p in cap.provides:
+        if p.event == "on_value":
+            assert p.kind == "value"
+        elif p.event == "on_value_range":
+            assert p.kind == "event"
 
 
 def test_phase_3_provides_match_template_per_channel_passthroughs(lib):
@@ -458,6 +473,118 @@ def test_temp_to_fan_lowers_into_the_temperature_sub_block(lib):
 def test_temp_to_fan_validator_quiet(lib):
     d = Design.model_validate(json.loads(TEMP_FAN_EXAMPLE.read_text()))
     assert validate_automations(d, lib) == []
+
+
+# --- phase 4: on_value_range threshold bounds -------------------------------
+
+TEMP_THRESHOLD_EXAMPLE = REPO_ROOT / "wirestudio" / "examples" / "temp-above-turns-on-fan.json"
+
+
+def test_temp_threshold_example_matches_golden(lib):
+    d = Design.model_validate(json.loads(TEMP_THRESHOLD_EXAMPLE.read_text()))
+    expected = (REPO_ROOT / "tests" / "golden" / "temp-above-turns-on-fan.yaml").read_text()
+    assert render_yaml(d, lib) == expected
+
+
+def test_temp_threshold_validator_quiet(lib):
+    d = Design.model_validate(json.loads(TEMP_THRESHOLD_EXAMPLE.read_text()))
+    assert validate_automations(d, lib) == []
+
+
+def test_threshold_above_lowers_into_range_entry_inside_sub_block(lib):
+    """A bme280 temperature range trigger lands a `{above, then}` entry
+    under `temperature.on_value_range`, with the action wrapped in `then:`."""
+    d = Design.model_validate(json.loads(TEMP_THRESHOLD_EXAMPLE.read_text()))
+    yaml = render_yaml(d, lib)
+    expected = (
+        "  temperature:\n"
+        "    name: Climate Temperature\n"
+        "    on_value_range:\n"
+        "    - above: 28.0\n"
+        "      then:\n"
+        "      - switch.turn_on: fan\n"
+    )
+    assert expected in yaml
+
+
+def test_threshold_above_and_below_emit_both_bounds(lib):
+    """Setting both above and below emits both keys in the range entry."""
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "buses": [{"id": "wire0", "type": "1wire", "pin": "D4"}],
+        "components": [
+            {"id": "temp", "library_id": "ds18b20", "label": "Temp",
+             "params": {"address": "0x1234567890abcdef"}},
+            {"id": "fan",  "library_id": "gpio_output", "label": "Fan"},
+        ],
+        "connections": [
+            {"component_id": "temp", "pin_role": "DATA", "target": {"kind": "bus", "bus_id": "wire0"}},
+            {"component_id": "fan",  "pin_role": "OUT",  "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+        "automations": [{
+            "id": "comfy",
+            "trigger": {"component_id": "temp", "event": "on_value_range",
+                        "above": -10.0, "below": 5.0},
+            "actions": [{"component_id": "fan", "action": "turn_on"}],
+        }],
+    })
+    assert validate_automations(d, lib) == []
+    yaml = render_yaml(d, lib)
+    assert "on_value_range:\n  - above: -10.0\n    below: 5.0\n    then:" in yaml
+
+
+def test_validator_flags_bounds_on_wrong_event(lib):
+    """above/below on a non-range event (e.g. on_press) must warn -- the
+    bounds would otherwise be silently dropped by the lowering."""
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [
+            {"id": "btn", "library_id": "gpio_input",  "label": "Button"},
+            {"id": "lt",  "library_id": "gpio_output", "label": "Light"},
+        ],
+        "connections": [
+            {"component_id": "btn", "pin_role": "IN",  "target": {"kind": "gpio", "pin": "D5"}},
+            {"component_id": "lt",  "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+        "automations": [{
+            "id": "a1",
+            "trigger": {"component_id": "btn", "event": "on_press", "above": 25.0},
+            "actions": [{"component_id": "lt", "action": "toggle"}],
+        }],
+    })
+    codes = [w.code for w in validate_automations(d, lib)]
+    assert "automation_bounds_require_value_range" in codes
+
+
+def test_validator_flags_on_value_range_without_bounds(lib):
+    """An on_value_range trigger with neither bound is meaningless -- the
+    range would fire on every reading."""
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "buses": [{"id": "wire0", "type": "1wire", "pin": "D4"}],
+        "components": [
+            {"id": "temp", "library_id": "ds18b20", "label": "Temp",
+             "params": {"address": "0x1234567890abcdef"}},
+            {"id": "fan",  "library_id": "gpio_output", "label": "Fan"},
+        ],
+        "connections": [
+            {"component_id": "temp", "pin_role": "DATA", "target": {"kind": "bus", "bus_id": "wire0"}},
+            {"component_id": "fan",  "pin_role": "OUT",  "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+        "automations": [{
+            "id": "a1",
+            "trigger": {"component_id": "temp", "event": "on_value_range"},
+            "actions": [{"component_id": "fan", "action": "turn_on"}],
+        }],
+    })
+    codes = [w.code for w in validate_automations(d, lib)]
+    assert "automation_value_range_needs_bounds" in codes
 
 
 def test_validator_flags_unknown_channel_on_multichannel_sensor(lib):

--- a/wirestudio/examples/temp-above-turns-on-fan.json
+++ b/wirestudio/examples/temp-above-turns-on-fan.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "0.1",
+  "id": "temp-above-turns-on-fan",
+  "name": "Fan turns on above a temperature threshold",
+  "description": "Phase-4 worked example for intent-to-device synthesis: a BME280's temperature channel fires `on_value_range` with `above: 28.0`, and the action turns a fan on. Demonstrates the threshold-bounds path -- the trigger carries `above` (and optionally `below`), the lowering wraps the action list in a `{above, below, then}` range entry, and the rendered `on_value_range:` lands inside the `temperature:` sub-block (proving the channel + range surfaces compose). The threshold-only case (no `below`) is open-ended on the upper bound -- fires whenever the reading is at or above 28°C.",
+  "created_at": "2026-06-19T00:00:00Z",
+  "updated_at": "2026-06-19T00:00:00Z",
+
+  "board": {
+    "library_id": "wemos-d1-mini",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-rt9013",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "turn on the fan when temperature rises above 28C" }
+  ],
+
+  "components": [
+    {
+      "id": "climate",
+      "library_id": "bme280",
+      "label": "Climate",
+      "params": { "address": "0x76" }
+    },
+    {
+      "id": "fan",
+      "library_id": "gpio_output",
+      "label": "Fan"
+    }
+  ],
+
+  "buses": [
+    { "id": "i2c0", "type": "i2c", "frequency_hz": 400000, "sda": "D2", "scl": "D1" }
+  ],
+
+  "connections": [
+    { "component_id": "climate", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "climate", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "climate", "pin_role": "SDA", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+    { "component_id": "climate", "pin_role": "SCL", "target": { "kind": "bus",  "bus_id": "i2c0" } },
+    { "component_id": "fan",     "pin_role": "OUT", "target": { "kind": "gpio", "pin": "D6" } }
+  ],
+
+  "passives": [],
+
+  "automations": [
+    {
+      "id": "hot_turns_on_fan",
+      "trigger": { "component_id": "climate", "channel": "temperature", "event": "on_value_range", "above": 28.0 },
+      "actions": [
+        { "component_id": "fan", "action": "turn_on" }
+      ]
+    }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "temp-threshold-fan",
+    "tags": ["intent-to-device", "phase-4", "example"],
+    "secrets_ref": {
+      "wifi_ssid":     "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key":       "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -209,7 +209,20 @@ def _lower_automations(design: Design, library: Library) -> dict[str, dict[str, 
 
         if not action_list:
             continue
-        out.setdefault(trig_comp.id, {}).setdefault(event_key, []).extend(action_list)
+        # on_value_range carries threshold bounds: ESPHome's syntax is a list
+        # of {above, below, then} entries (vs. a flat action list for the other
+        # triggers). Wrap the actions in a range entry when bounds are set so
+        # the rendered YAML is `on_value_range: - above: 25.0\n    then: [...]`.
+        if auto.trigger.above is not None or auto.trigger.below is not None:
+            range_entry: dict[str, Any] = {}
+            if auto.trigger.above is not None:
+                range_entry["above"] = auto.trigger.above
+            if auto.trigger.below is not None:
+                range_entry["below"] = auto.trigger.below
+            range_entry["then"] = action_list
+            out.setdefault(trig_comp.id, {}).setdefault(event_key, []).append(range_entry)
+        else:
+            out.setdefault(trig_comp.id, {}).setdefault(event_key, []).extend(action_list)
     return out
 
 

--- a/wirestudio/intent.py
+++ b/wirestudio/intent.py
@@ -1,11 +1,11 @@
-"""Intent-to-device synthesis (phase 1): validate the `automations` graph.
+"""Intent-to-device synthesis: validate the `automations` graph.
 
-Phase 1 covers declarative event -> action only (the `button_toggles_light`
-shape). Each automation's trigger references a component that must `provide`
-the named event in its library capability block; each action references a
-component that must `accept` the named action. The validator surfaces dangling
-references as permissive warnings (CLAUDE.md: warnings, don't block) so a
-half-authored automation doesn't refuse to render -- it just doesn't fire.
+Each automation's trigger references a component that must `provide` the
+named event in its library capability block; each action references a
+component that must `accept` the named action. The validator surfaces
+dangling references as permissive warnings (CLAUDE.md: warnings, don't
+block) so a half-authored automation doesn't refuse to render -- it just
+doesn't fire.
 
 The generator's lowering (``yaml_gen._lower_automations``) drops the same
 unresolved entries silently rather than emit invalid YAML, so the warnings here
@@ -29,11 +29,31 @@ def validate_automations(design: Design, library: Library) -> list[DesignWarning
       component's `capability.provides`.
     - ``automation_unknown_action``: the action name isn't in the action
       component's `capability.accepts`.
+    - ``automation_bounds_require_value_range``: the trigger sets
+      `above` / `below` on an event other than `on_value_range`.
+    - ``automation_value_range_needs_bounds``: the trigger event is
+      `on_value_range` but neither `above` nor `below` is set, so the
+      range would fire on every reading.
     """
     out: list[DesignWarning] = []
     by_id = {c.id: c for c in design.components}
     for auto in design.automations:
         trig = auto.trigger
+        has_bounds = trig.above is not None or trig.below is not None
+        if has_bounds and trig.event != "on_value_range":
+            out.append(DesignWarning(
+                level="warn", code="automation_bounds_require_value_range",
+                text=(f"automation {auto.id!r}: trigger sets above/below but "
+                      f"event is {trig.event!r}, not 'on_value_range' -- the "
+                      f"bounds would be silently dropped"),
+            ))
+        if trig.event == "on_value_range" and not has_bounds:
+            out.append(DesignWarning(
+                level="warn", code="automation_value_range_needs_bounds",
+                text=(f"automation {auto.id!r}: event is 'on_value_range' but "
+                      f"neither above nor below is set; the range would fire "
+                      f"on every reading"),
+            ))
         trig_comp = by_id.get(trig.component_id)
         if trig_comp is None:
             out.append(DesignWarning(

--- a/wirestudio/library/components/aht10.yaml
+++ b/wirestudio/library/components/aht10.yaml
@@ -34,17 +34,25 @@ esphome:
     {%- if params.temperature_on_value is defined %}
           on_value: {{ params.temperature_on_value | tojson }}
     {%- endif %}
+    {%- if params.temperature_on_value_range is defined %}
+          on_value_range: {{ params.temperature_on_value_range | tojson }}
+    {%- endif %}
         humidity:
           name: "{{ label }} Humidity"
     {%- if params.humidity_on_value is defined %}
           on_value: {{ params.humidity_on_value | tojson }}
+    {%- endif %}
+    {%- if params.humidity_on_value_range is defined %}
+          on_value_range: {{ params.humidity_on_value_range | tojson }}
     {%- endif %}
 
 capability:
   role: sensor
   provides:
     - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value_range, kind: event, channel: temperature}
     - {event: on_value, kind: value, channel: humidity}
+    - {event: on_value_range, kind: event, channel: humidity}
 
 params_schema:
   variant:

--- a/wirestudio/library/components/bme280.yaml
+++ b/wirestudio/library/components/bme280.yaml
@@ -33,23 +33,35 @@ esphome:
     {%- if params.temperature_on_value is defined %}
           on_value: {{ params.temperature_on_value | tojson }}
     {%- endif %}
+    {%- if params.temperature_on_value_range is defined %}
+          on_value_range: {{ params.temperature_on_value_range | tojson }}
+    {%- endif %}
         humidity:
           name: "{{ label }} Humidity"
     {%- if params.humidity_on_value is defined %}
           on_value: {{ params.humidity_on_value | tojson }}
+    {%- endif %}
+    {%- if params.humidity_on_value_range is defined %}
+          on_value_range: {{ params.humidity_on_value_range | tojson }}
     {%- endif %}
         pressure:
           name: "{{ label }} Pressure"
     {%- if params.pressure_on_value is defined %}
           on_value: {{ params.pressure_on_value | tojson }}
     {%- endif %}
+    {%- if params.pressure_on_value_range is defined %}
+          on_value_range: {{ params.pressure_on_value_range | tojson }}
+    {%- endif %}
 
 capability:
   role: sensor
   provides:
     - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value_range, kind: event, channel: temperature}
     - {event: on_value, kind: value, channel: humidity}
+    - {event: on_value_range, kind: event, channel: humidity}
     - {event: on_value, kind: value, channel: pressure}
+    - {event: on_value_range, kind: event, channel: pressure}
 
 params_schema:
   address:

--- a/wirestudio/library/components/bmp180.yaml
+++ b/wirestudio/library/components/bmp180.yaml
@@ -33,17 +33,25 @@ esphome:
     {%- if params.temperature_on_value is defined %}
           on_value: {{ params.temperature_on_value | tojson }}
     {%- endif %}
+    {%- if params.temperature_on_value_range is defined %}
+          on_value_range: {{ params.temperature_on_value_range | tojson }}
+    {%- endif %}
         pressure:
           name: "{{ label }} Pressure"
     {%- if params.pressure_on_value is defined %}
           on_value: {{ params.pressure_on_value | tojson }}
+    {%- endif %}
+    {%- if params.pressure_on_value_range is defined %}
+          on_value_range: {{ params.pressure_on_value_range | tojson }}
     {%- endif %}
 
 capability:
   role: sensor
   provides:
     - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value_range, kind: event, channel: temperature}
     - {event: on_value, kind: value, channel: pressure}
+    - {event: on_value_range, kind: event, channel: pressure}
 
 params_schema:
   update_interval:

--- a/wirestudio/library/components/bmp280.yaml
+++ b/wirestudio/library/components/bmp280.yaml
@@ -36,10 +36,16 @@ esphome:
     {%- if params.temperature_on_value is defined %}
           on_value: {{ params.temperature_on_value | tojson }}
     {%- endif %}
+    {%- if params.temperature_on_value_range is defined %}
+          on_value_range: {{ params.temperature_on_value_range | tojson }}
+    {%- endif %}
         pressure:
           name: "{{ label }} Pressure"
     {%- if params.pressure_on_value is defined %}
           on_value: {{ params.pressure_on_value | tojson }}
+    {%- endif %}
+    {%- if params.pressure_on_value_range is defined %}
+          on_value_range: {{ params.pressure_on_value_range | tojson }}
     {%- endif %}
     {%- if params.update_interval is defined %}
         update_interval: {{ params.update_interval }}
@@ -49,7 +55,9 @@ capability:
   role: sensor
   provides:
     - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value_range, kind: event, channel: temperature}
     - {event: on_value, kind: value, channel: pressure}
+    - {event: on_value_range, kind: event, channel: pressure}
 
 params_schema:
   address:

--- a/wirestudio/library/components/dht.yaml
+++ b/wirestudio/library/components/dht.yaml
@@ -70,10 +70,16 @@ esphome:
     {%- if params.temperature_on_value is defined %}
           on_value: {{ params.temperature_on_value | tojson }}
     {%- endif %}
+    {%- if params.temperature_on_value_range is defined %}
+          on_value_range: {{ params.temperature_on_value_range | tojson }}
+    {%- endif %}
         humidity:
           name: "{{ label }} Humidity"
     {%- if params.humidity_on_value is defined %}
           on_value: {{ params.humidity_on_value | tojson }}
+    {%- endif %}
+    {%- if params.humidity_on_value_range is defined %}
+          on_value_range: {{ params.humidity_on_value_range | tojson }}
     {%- endif %}
     {%- if params.update_interval is defined %}
         update_interval: {{ params.update_interval }}
@@ -83,7 +89,9 @@ capability:
   role: sensor
   provides:
     - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value_range, kind: event, channel: temperature}
     - {event: on_value, kind: value, channel: humidity}
+    - {event: on_value_range, kind: event, channel: humidity}
 
 params_schema:
   model:

--- a/wirestudio/library/components/htu21d.yaml
+++ b/wirestudio/library/components/htu21d.yaml
@@ -33,17 +33,25 @@ esphome:
     {%- if params.temperature_on_value is defined %}
           on_value: {{ params.temperature_on_value | tojson }}
     {%- endif %}
+    {%- if params.temperature_on_value_range is defined %}
+          on_value_range: {{ params.temperature_on_value_range | tojson }}
+    {%- endif %}
         humidity:
           name: "{{ label }} Humidity"
     {%- if params.humidity_on_value is defined %}
           on_value: {{ params.humidity_on_value | tojson }}
+    {%- endif %}
+    {%- if params.humidity_on_value_range is defined %}
+          on_value_range: {{ params.humidity_on_value_range | tojson }}
     {%- endif %}
 
 capability:
   role: sensor
   provides:
     - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value_range, kind: event, channel: temperature}
     - {event: on_value, kind: value, channel: humidity}
+    - {event: on_value_range, kind: event, channel: humidity}
 
 params_schema:
   update_interval:

--- a/wirestudio/library/components/sht3xd.yaml
+++ b/wirestudio/library/components/sht3xd.yaml
@@ -34,17 +34,25 @@ esphome:
     {%- if params.temperature_on_value is defined %}
           on_value: {{ params.temperature_on_value | tojson }}
     {%- endif %}
+    {%- if params.temperature_on_value_range is defined %}
+          on_value_range: {{ params.temperature_on_value_range | tojson }}
+    {%- endif %}
         humidity:
           name: "{{ label }} Humidity"
     {%- if params.humidity_on_value is defined %}
           on_value: {{ params.humidity_on_value | tojson }}
+    {%- endif %}
+    {%- if params.humidity_on_value_range is defined %}
+          on_value_range: {{ params.humidity_on_value_range | tojson }}
     {%- endif %}
 
 capability:
   role: sensor
   provides:
     - {event: on_value, kind: value, channel: temperature}
+    - {event: on_value_range, kind: event, channel: temperature}
     - {event: on_value, kind: value, channel: humidity}
+    - {event: on_value_range, kind: event, channel: humidity}
 
 params_schema:
   address:

--- a/wirestudio/model.py
+++ b/wirestudio/model.py
@@ -140,10 +140,18 @@ class AutomationTrigger(_Strict):
     component's library `capability.provides` declares. `component_id` is a
     design-level id (the validator checks it resolves). `channel` selects a
     sub-block on multi-channel components (e.g. `temperature` on a bme280) --
-    the provides entry must match both event AND channel."""
+    the provides entry must match both event AND channel.
+
+    `above` / `below` are threshold bounds for the `on_value_range` event:
+    the trigger fires when the value enters the [above, below] band (either
+    bound may be omitted for an open-ended range). At least one must be set
+    when the event is `on_value_range`, and they may NOT be set on any other
+    event -- the validator surfaces both as warnings."""
     component_id: str
     event: str
     channel: Optional[str] = None
+    above: Optional[float] = None
+    below: Optional[float] = None
 
 
 class AutomationAction(_Strict):

--- a/wirestudio/schema/design.schema.json
+++ b/wirestudio/schema/design.schema.json
@@ -202,6 +202,14 @@
               "channel": {
                 "type": "string",
                 "description": "Sub-block on multi-channel components (e.g. \"temperature\" on a bme280); omit for single-output."
+              },
+              "above": {
+                "type": "number",
+                "description": "Lower bound for an on_value_range trigger; value must rise above this to fire. Set only when event is on_value_range."
+              },
+              "below": {
+                "type": "number",
+                "description": "Upper bound for an on_value_range trigger; value must fall below this to fire. Set only when event is on_value_range."
               }
             }
           },


### PR DESCRIPTION
## Summary

Phase 4 of intent-to-device synthesis: **`on_value_range` threshold bounds**. An automation can now say "fire when temperature crosses 28°C" instead of "fire on every temperature reading" — the most common shape users actually want from a sensor.

### IR

- `AutomationTrigger` gains optional `above: float` and `below: float`. Either or both may be set (matches ESPHome's `on_value_range` semantics).
- Schema mirrors.
- Lowering: when bounds are set, the action list is wrapped in a `{above, below, then}` range entry inside `params.<event>` instead of being extended flat. The on_value_range passthrough renders it as ESPHome expects: `on_value_range: - above: 28.0\n  then: [...]`.

### Library

All 7 phase-3 multi-channel sensors (dht, bme280, bmp180, bmp280, aht10, htu21d, sht3xd) gain channel-tagged `on_value_range` provides (kind=event) plus matching `params.<channel>_on_value_range` passthroughs in each `temperature:` / `humidity:` / `pressure:` sub-block. The 9 single-output sensors from 1.5b already had `on_value_range` declared but no bounds carrier — they now work end-to-end.

### Validator

Two new cooperative-mistake warnings:

- `automation_bounds_require_value_range` — `above`/`below` set on a non-range event (would be silently dropped).
- `automation_value_range_needs_bounds` — `on_value_range` with neither bound (would fire on every reading).

### Worked example

`temp-above-turns-on-fan.json` — bme280 temperature → fan, fires at ≥ 28°C. The golden asserts the range entry lands inside `temperature:` with `above: 28.0`, `then:`, and the wrapped action; the validator is quiet.

### Tests

- Phase-3 capability shape now expects doubled provides per channel (`on_value` + `on_value_range`), with kind enforced per event.
- New phase-4 tests: golden match, sub-block placement of the range entry, both-bounds case (above + below in one entry), both validator warnings, validator quiet on the example.

## Test plan

- [x] `pytest tests/test_intent.py` — 63 passed
- [x] `pytest -q` full suite — 765 passed, 11 skipped
- [x] `ruff check .` — clean
- [x] No golden churn on existing examples (passthroughs are conditional)
- [ ] `esphome config` on the new example runs in CI (no esphome CLI locally; bme280 already passes, and `on_value_range:` is standard ESPHome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_