### PR TITLE
intent: condition gating via is_on/is_off (phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Intent-to-device synthesis (phase 5 — condition gating).** An automation
+  gains an optional `conditions: [...]` list; the trigger must fire AND every
+  condition must hold for the actions to run. The generator wraps the action
+  list in ESPHome's `if: { condition: ..., then: [...] }` form -- a single
+  condition emits as an inline mapping, multiple conditions emit as a list
+  (ESPHome's implicit AND). `CapabilityChecks` adds a `predicate -> esphome`
+  mapping; 5 components gain `is_on` / `is_off` predicates that lower to
+  `binary_sensor.is_on`, `switch.is_on`, or `light.is_on`: `gpio_input`,
+  `gpio_output`, `ws2812b`, `hc-sr501`, `rcwl-0516`. The two motion sensors
+  also gain an `id:` line in their binary_sensor template so condition
+  predicates can reference them. New validator warnings:
+  `automation_unknown_predicate` (predicate not in the component's checks),
+  plus the existing `automation_unknown_component` /
+  `automation_component_no_capability` codes now cover condition references.
+  Worked example `guarded-button-light.json`: a button press toggles a light
+  only when an enable switch is on. `design.json` schema gains
+  `automations[].conditions`. The `sensor.in_range` predicate (single-output
+  and multi-channel) is scoped separately because the multi-channel
+  sub-sensor needs per-channel `id:` template surgery.
+
 - **Intent-to-device synthesis (phase 4 — on_value_range threshold bounds).**
   An automation trigger gains optional `above` / `below` numeric bounds for the
   `on_value_range` event; the lowering wraps the action list in a

--- a/docs/intent-to-device.md
+++ b/docs/intent-to-device.md
@@ -1,9 +1,9 @@
 # Intent-to-device synthesis (design direction)
 
-Status: **phases 1 + 1.5a + 1.5b + 2 + 3 + 4 shipped** (declarative
+Status: **phases 1 + 1.5a + 1.5b + 2 + 3 + 4 + 5 shipped** (declarative
 event→action, broader library coverage, single-output sensor triggers,
 value→transform→action, multi-channel sensor triggers, on_value_range
-threshold bounds). On `main`: the `capability` library block, the
+threshold bounds, condition gating). On `main`: the `capability` library block, the
 `automations` schema in `design.json` (with `trigger.channel`,
 `trigger.above` / `.below`, `actions[].transform`), generator lowering with
 `!lambda` transforms, per-channel passthroughs and `{above, below, then}`

--- a/tests/golden/bluemotion.yaml
+++ b/tests/golden/bluemotion.yaml
@@ -20,6 +20,7 @@ binary_sensor:
 - platform: gpio
   pin: GPIO4
   name: Blue Motion
+  id: pir1
   device_class: motion
   filters:
   - delayed_on: 40ms

--- a/tests/golden/garage-motion.yaml
+++ b/tests/golden/garage-motion.yaml
@@ -24,6 +24,7 @@ binary_sensor:
 - platform: gpio
   pin: GPIO13
   name: Driveway PIR
+  id: pir1
   device_class: motion
 sensor:
 - platform: bme280_i2c

--- a/tests/golden/guarded-button-light.txt
+++ b/tests/golden/guarded-button-light.txt
@@ -1,0 +1,24 @@
++-----------------------------------------------------------+
+|  WeMos D1 Mini  ---  guarded-button-light                 |
++-----------------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                      |
+|                                                           |
+|  btn  [Generic GPIO binary sensor]  -- Button             |
+|    IN    -> D5                                            |
+|                                                           |
+|  enable  [Generic GPIO switch / relay output]  -- Enable  |
+|    OUT   -> D7                                            |
+|                                                           |
+|  light  [Generic GPIO switch / relay output]  -- Light    |
+|    OUT   -> D6                                            |
+|                                                           |
+|  BOM:                                                     |
+|    - WeMos D1 Mini                                        |
+|    - Generic GPIO binary sensor  (btn)                    |
+|    - Generic GPIO switch / relay output  (enable)         |
+|    - Generic GPIO switch / relay output  (light)          |
+|                                                           |
+|  Power: ~0mA typical, ~0mA peak (budget 500mA)  OK        |
+|                                                           |
+|  Warnings: none                                           |
++-----------------------------------------------------------+

--- a/tests/golden/guarded-button-light.yaml
+++ b/tests/golden/guarded-button-light.yaml
@@ -1,0 +1,33 @@
+esphome:
+  name: guarded-button-light
+esp8266:
+  board: d1_mini
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+binary_sensor:
+- platform: gpio
+  pin: D5
+  name: Button
+  id: btn
+  on_press:
+  - if:
+      condition:
+        switch.is_on: enable
+      then:
+      - switch.toggle: light
+switch:
+- platform: gpio
+  pin: D7
+  name: Enable
+  id: enable
+- platform: gpio
+  pin: D6
+  name: Light
+  id: light

--- a/tests/golden/motion-turns-on-light.yaml
+++ b/tests/golden/motion-turns-on-light.yaml
@@ -15,6 +15,7 @@ binary_sensor:
 - platform: gpio
   pin: D2
   name: Porch Motion
+  id: porch_pir
   device_class: motion
   on_press:
   - light.turn_on: porch_light

--- a/tests/golden/multi-temp.yaml
+++ b/tests/golden/multi-temp.yaml
@@ -32,4 +32,5 @@ binary_sensor:
 - platform: gpio
   pin: D5
   name: Boiler room presence
+  id: radar1
   device_class: motion

--- a/tests/golden/wasserpir.yaml
+++ b/tests/golden/wasserpir.yaml
@@ -15,6 +15,7 @@ binary_sensor:
 - platform: gpio
   pin: D2
   name: Wasserstein Motion
+  id: pir1
   device_class: motion
   filters:
   - delayed_on: 100ms

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -10,7 +10,13 @@ import pytest
 from wirestudio.generate.yaml_gen import _lower_automations, render_yaml
 from wirestudio.intent import validate_automations
 from wirestudio.library import default_library
-from wirestudio.model import Automation, AutomationAction, AutomationTrigger, Design
+from wirestudio.model import (
+    Automation,
+    AutomationAction,
+    AutomationCondition,
+    AutomationTrigger,
+    Design,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -617,6 +623,194 @@ def test_validator_flags_unknown_channel_on_multichannel_sensor(lib):
     text = next(w.text for w in warns if w.code == "automation_unknown_event")
     assert "channel 'altitude'" in text
     assert "temperature.on_value" in text  # the warning lists what IS provided
+
+
+# --- phase 5: condition gating ----------------------------------------------
+
+GUARDED_EXAMPLE = REPO_ROOT / "wirestudio" / "examples" / "guarded-button-light.json"
+
+
+def test_guarded_example_matches_golden(lib):
+    d = Design.model_validate(json.loads(GUARDED_EXAMPLE.read_text()))
+    expected = (REPO_ROOT / "tests" / "golden" / "guarded-button-light.yaml").read_text()
+    assert render_yaml(d, lib) == expected
+
+
+def test_guarded_validator_quiet(lib):
+    d = Design.model_validate(json.loads(GUARDED_EXAMPLE.read_text()))
+    assert validate_automations(d, lib) == []
+
+
+def test_single_condition_emits_inline_dict(lib):
+    """A single condition emits as a mapping directly under `condition:` --
+    not wrapped in a list -- matching ESPHome's inline form."""
+    d = Design.model_validate(json.loads(GUARDED_EXAMPLE.read_text()))
+    yaml = render_yaml(d, lib)
+    expected = (
+        "  on_press:\n"
+        "  - if:\n"
+        "      condition:\n"
+        "        switch.is_on: enable\n"
+        "      then:\n"
+        "      - switch.toggle: light\n"
+    )
+    assert expected in yaml
+
+
+def test_multiple_conditions_emit_as_list_for_implicit_and(lib):
+    """Two or more conditions emit as a YAML list under `condition:` --
+    ESPHome treats the list form as implicit AND."""
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [
+            {"id": "btn",    "library_id": "gpio_input",  "label": "Button"},
+            {"id": "enable", "library_id": "gpio_output", "label": "Enable"},
+            {"id": "safe",   "library_id": "gpio_input",  "label": "Safety"},
+            {"id": "light",  "library_id": "gpio_output", "label": "Light"},
+        ],
+        "connections": [
+            {"component_id": "btn",    "pin_role": "IN",  "target": {"kind": "gpio", "pin": "D5"}},
+            {"component_id": "enable", "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D7"}},
+            {"component_id": "safe",   "pin_role": "IN",  "target": {"kind": "gpio", "pin": "D3"}},
+            {"component_id": "light",  "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+        "automations": [{
+            "id": "a", "trigger": {"component_id": "btn", "event": "on_press"},
+            "conditions": [
+                {"component_id": "enable", "predicate": "is_on"},
+                {"component_id": "safe",   "predicate": "is_on"},
+            ],
+            "actions": [{"component_id": "light", "action": "toggle"}],
+        }],
+    })
+    assert validate_automations(d, lib) == []
+    yaml = render_yaml(d, lib)
+    expected = (
+        "      condition:\n"
+        "      - switch.is_on: enable\n"
+        "      - binary_sensor.is_on: safe\n"
+        "      then:\n"
+        "      - switch.toggle: light\n"
+    )
+    assert expected in yaml
+
+
+def test_validator_flags_unknown_predicate(lib):
+    """A predicate not in the component's `checks` surfaces a warning that
+    lists what IS supported."""
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [
+            {"id": "btn",    "library_id": "gpio_input",  "label": "Button"},
+            {"id": "enable", "library_id": "gpio_output", "label": "Enable"},
+            {"id": "light",  "library_id": "gpio_output", "label": "Light"},
+        ],
+        "connections": [
+            {"component_id": "btn",    "pin_role": "IN",  "target": {"kind": "gpio", "pin": "D5"}},
+            {"component_id": "enable", "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D7"}},
+            {"component_id": "light",  "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+        "automations": [{
+            "id": "a", "trigger": {"component_id": "btn", "event": "on_press"},
+            "conditions": [{"component_id": "enable", "predicate": "is_pulsing"}],
+            "actions": [{"component_id": "light", "action": "toggle"}],
+        }],
+    })
+    warns = validate_automations(d, lib)
+    codes = [w.code for w in warns]
+    assert "automation_unknown_predicate" in codes
+    text = next(w.text for w in warns if w.code == "automation_unknown_predicate")
+    assert "is_on" in text  # warning lists supported predicates
+
+
+def test_validator_flags_condition_on_capability_less_component(lib):
+    """A condition on a component without a capability block warns
+    (same code as the existing trigger/action checks)."""
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "buses": [{"id": "i2c0", "type": "i2c", "sda": "D2", "scl": "D1"}],
+        "components": [
+            {"id": "btn",   "library_id": "gpio_input",  "label": "Button"},
+            {"id": "imu",   "library_id": "mpu6050",     "label": "IMU"},
+            {"id": "light", "library_id": "gpio_output", "label": "Light"},
+        ],
+        "connections": [
+            {"component_id": "btn",   "pin_role": "IN",  "target": {"kind": "gpio", "pin": "D5"}},
+            {"component_id": "imu",   "pin_role": "SDA", "target": {"kind": "bus",  "bus_id": "i2c0"}},
+            {"component_id": "imu",   "pin_role": "SCL", "target": {"kind": "bus",  "bus_id": "i2c0"}},
+            {"component_id": "light", "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+        "automations": [{
+            "id": "a", "trigger": {"component_id": "btn", "event": "on_press"},
+            "conditions": [{"component_id": "imu", "predicate": "is_on"}],
+            "actions": [{"component_id": "light", "action": "toggle"}],
+        }],
+    })
+    codes = [w.code for w in validate_automations(d, lib)]
+    assert "automation_component_no_capability" in codes
+
+
+def test_unresolved_conditions_drop_silently_from_yaml(lib):
+    """Mirroring the existing trigger/action behavior: an unresolved condition
+    is dropped by the lowering (the validator surfaces it). The action list
+    still emits, unwrapped, when no conditions resolve."""
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [
+            {"id": "btn",   "library_id": "gpio_input",  "label": "Button"},
+            {"id": "light", "library_id": "gpio_output", "label": "Light"},
+        ],
+        "connections": [
+            {"component_id": "btn",   "pin_role": "IN",  "target": {"kind": "gpio", "pin": "D5"}},
+            {"component_id": "light", "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+        "automations": [{
+            "id": "a", "trigger": {"component_id": "btn", "event": "on_press"},
+            "conditions": [{"component_id": "missing", "predicate": "is_on"}],
+            "actions": [{"component_id": "light", "action": "toggle"}],
+        }],
+    })
+    yaml = render_yaml(d, lib)
+    # No `if:` wrap, no dangling ref; the action still fires
+    assert "missing" not in yaml
+    assert "if:" not in yaml
+    assert "switch.toggle: light" in yaml
+
+
+def test_condition_round_trips_through_the_model():
+    """The IR model carries conditions as AutomationCondition instances."""
+    d = Design.model_validate({
+        "schema_version": "0.1", "id": "t", "name": "T",
+        "board": {"library_id": "wemos-d1-mini", "mcu": "esp8266", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+        "components": [
+            {"id": "btn", "library_id": "gpio_input", "label": "B"},
+            {"id": "en",  "library_id": "gpio_output", "label": "E"},
+            {"id": "lt",  "library_id": "gpio_output", "label": "L"},
+        ],
+        "connections": [
+            {"component_id": "btn", "pin_role": "IN",  "target": {"kind": "gpio", "pin": "D5"}},
+            {"component_id": "en",  "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D7"}},
+            {"component_id": "lt",  "pin_role": "OUT", "target": {"kind": "gpio", "pin": "D6"}},
+        ],
+        "automations": [{
+            "id": "a", "trigger": {"component_id": "btn", "event": "on_press"},
+            "conditions": [{"component_id": "en", "predicate": "is_on"}],
+            "actions": [{"component_id": "lt", "action": "toggle"}],
+        }],
+    })
+    auto = d.automations[0]
+    assert len(auto.conditions) == 1
+    assert isinstance(auto.conditions[0], AutomationCondition)
+    assert auto.conditions[0].predicate == "is_on"
 
 
 # --- phase 2: value -> transform -> action (encoder -> stepper) -------------

--- a/wirestudio/examples/guarded-button-light.json
+++ b/wirestudio/examples/guarded-button-light.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "0.1",
+  "id": "guarded-button-light",
+  "name": "Button toggles a light only when the enable switch is on",
+  "description": "Phase-5 worked example for intent-to-device synthesis: a button press toggles a light, BUT only when an enable switch is on (a manual override / safety interlock). Exercises condition gating -- the trigger fires AND every condition in the list must hold. The generator wraps the action list in `if: { condition: { switch.is_on: enable }, then: [switch.toggle: light] }`. Pairing the button-toggles-light shape with a single is_on condition is the simplest demonstration that composition between the trigger graph and the condition graph works without touching either side.",
+  "created_at": "2026-06-19T00:00:00Z",
+  "updated_at": "2026-06-19T00:00:00Z",
+
+  "board": {
+    "library_id": "wemos-d1-mini",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-rt9013",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "toggle the light when the button is pressed AND the enable switch is on" }
+  ],
+
+  "components": [
+    {
+      "id": "btn",
+      "library_id": "gpio_input",
+      "label": "Button"
+    },
+    {
+      "id": "enable",
+      "library_id": "gpio_output",
+      "label": "Enable"
+    },
+    {
+      "id": "light",
+      "library_id": "gpio_output",
+      "label": "Light"
+    }
+  ],
+
+  "buses": [],
+
+  "connections": [
+    { "component_id": "btn",    "pin_role": "IN",  "target": { "kind": "gpio", "pin": "D5" } },
+    { "component_id": "enable", "pin_role": "OUT", "target": { "kind": "gpio", "pin": "D7" } },
+    { "component_id": "light",  "pin_role": "OUT", "target": { "kind": "gpio", "pin": "D6" } }
+  ],
+
+  "passives": [],
+
+  "automations": [
+    {
+      "id": "guarded_toggle",
+      "trigger": { "component_id": "btn", "event": "on_press" },
+      "conditions": [
+        { "component_id": "enable", "predicate": "is_on" }
+      ],
+      "actions": [
+        { "component_id": "light", "action": "toggle" }
+      ]
+    }
+  ],
+
+  "warnings": [],
+
+  "esphome_extras": {
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "guarded-button-light",
+    "tags": ["intent-to-device", "phase-5", "example"],
+    "secrets_ref": {
+      "wifi_ssid":     "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key":       "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -209,6 +209,33 @@ def _lower_automations(design: Design, library: Library) -> dict[str, dict[str, 
 
         if not action_list:
             continue
+        # Condition gating: wrap the action list in `if: { condition, then }`
+        # when one or more conditions resolve. A single condition emits as a
+        # mapping under `condition:`; multiple emit as a list (ESPHome treats
+        # the list form as implicit AND). Conditions that don't resolve
+        # (unknown component / capability / predicate) are dropped silently;
+        # the validator surfaces those as warnings.
+        condition_items: list = []
+        for cond in auto.conditions:
+            cond_comp = by_id.get(cond.component_id)
+            if cond_comp is None:
+                continue
+            try:
+                cond_lib = library.component(cond_comp.library_id)
+            except FileNotFoundError:
+                continue
+            cond_cap = cond_lib.capability
+            if cond_cap is None:
+                continue
+            check = next((c for c in cond_cap.checks if c.predicate == cond.predicate), None)
+            if check is None:
+                continue
+            condition_items.append({check.esphome: cond.component_id})
+        if condition_items:
+            condition_value: Any = (condition_items[0] if len(condition_items) == 1
+                                    else condition_items)
+            action_list = [{"if": {"condition": condition_value, "then": action_list}}]
+
         # on_value_range carries threshold bounds: ESPHome's syntax is a list
         # of {above, below, then} entries (vs. a flat action list for the other
         # triggers). Wrap the actions in a range entry when bounds are set so

--- a/wirestudio/intent.py
+++ b/wirestudio/intent.py
@@ -34,6 +34,8 @@ def validate_automations(design: Design, library: Library) -> list[DesignWarning
     - ``automation_value_range_needs_bounds``: the trigger event is
       `on_value_range` but neither `above` nor `below` is set, so the
       range would fire on every reading.
+    - ``automation_unknown_predicate``: a condition names a predicate not
+      in the referenced component's `capability.checks`.
     """
     out: list[DesignWarning] = []
     by_id = {c.id: c for c in design.components}
@@ -99,6 +101,38 @@ def validate_automations(design: Design, library: Library) -> list[DesignWarning
                                   f"{trig.component_id!r} does not provide "
                                   f"{suffix}; provides: {provided}"),
                         ))
+
+        for cond in auto.conditions:
+            cond_comp = by_id.get(cond.component_id)
+            if cond_comp is None:
+                out.append(DesignWarning(
+                    level="warn", code="automation_unknown_component",
+                    text=(f"automation {auto.id!r}: condition component "
+                          f"{cond.component_id!r} is not in the design"),
+                ))
+                continue
+            try:
+                cond_lib = library.component(cond_comp.library_id)
+            except FileNotFoundError:
+                continue
+            cap = cond_lib.capability
+            if cap is None:
+                out.append(DesignWarning(
+                    level="warn", code="automation_component_no_capability",
+                    text=(f"automation {auto.id!r}: condition component "
+                          f"{cond.component_id!r} (library_id="
+                          f"{cond_comp.library_id!r}) has no capability block "
+                          f"and can't be a condition source"),
+                ))
+                continue
+            if not any(c.predicate == cond.predicate for c in cap.checks):
+                supported = ", ".join(c.predicate for c in cap.checks) or "(none)"
+                out.append(DesignWarning(
+                    level="warn", code="automation_unknown_predicate",
+                    text=(f"automation {auto.id!r}: component "
+                          f"{cond.component_id!r} does not support predicate "
+                          f"{cond.predicate!r}; supports: {supported}"),
+                ))
 
         for act in auto.actions:
             act_comp = by_id.get(act.component_id)

--- a/wirestudio/library/__init__.py
+++ b/wirestudio/library/__init__.py
@@ -118,14 +118,29 @@ class CapabilityAccepts(_Strict):
     esphome: str
 
 
+class CapabilityChecks(_Strict):
+    """One predicate a component supports as an automation `condition`.
+
+    `predicate` is the studio-side name (e.g. `is_on`); `esphome` is the
+    explicit ESPHome condition verb (e.g. `switch.is_on`). Mirrors the
+    accepts/esphome split so the mapping stays reviewed code. `is_on` / `is_off`
+    cover binary_sensor / switch / light state; `in_range` carries above/below
+    bounds at the trigger site.
+    """
+    predicate: str
+    esphome: str
+
+
 class Capability(_Strict):
     """Functional layer (intent-to-device synthesis): what role this component
-    plays, what events/values it `provides` to triggers, and what actions it
-    `accepts` from automations. Optional per component; an unannotated
-    component simply cannot be a trigger or action target."""
+    plays, what events/values it `provides` to triggers, what actions it
+    `accepts` from automations, and what predicates it supports as condition
+    `checks`. Optional per component; an unannotated component simply cannot
+    be a trigger, action target, or condition source."""
     role: Literal["input", "sensor", "output", "controller"]
     provides: list[CapabilityProvides] = Field(default_factory=list)
     accepts: list[CapabilityAccepts] = Field(default_factory=list)
+    checks: list[CapabilityChecks] = Field(default_factory=list)
 
 
 class LibraryComponent(_Strict):

--- a/wirestudio/library/components/gpio_input.yaml
+++ b/wirestudio/library/components/gpio_input.yaml
@@ -54,6 +54,9 @@ capability:
     - {event: on_release}
     - {event: on_click}
     - {event: on_state, kind: value}
+  checks:
+    - {predicate: is_on,  esphome: binary_sensor.is_on}
+    - {predicate: is_off, esphome: binary_sensor.is_off}
 
 params_schema:
   device_class:

--- a/wirestudio/library/components/gpio_output.yaml
+++ b/wirestudio/library/components/gpio_output.yaml
@@ -46,6 +46,9 @@ capability:
     - {action: turn_on,  esphome: switch.turn_on}
     - {action: turn_off, esphome: switch.turn_off}
     - {action: toggle,   esphome: switch.toggle}
+  checks:
+    - {predicate: is_on,  esphome: switch.is_on}
+    - {predicate: is_off, esphome: switch.is_off}
 
 params_schema:
   icon:

--- a/wirestudio/library/components/hc-sr501.yaml
+++ b/wirestudio/library/components/hc-sr501.yaml
@@ -21,6 +21,7 @@ esphome:
       - platform: gpio
         pin: {{ pins.OUT | tojson }}
         name: "{{ label }}"
+        id: {{ id }}
         device_class: motion
     {%- if params.filters is defined %}
         filters: {{ params.filters | tojson }}
@@ -33,13 +34,13 @@ esphome:
     {%- endif %}
 
 capability:
-  # PIR (motion). ESPHome emits a press when motion starts and a release when
-  # it ends -- the template already passes these through, so an automation
-  # triggers off them cleanly.
   role: input
   provides:
     - {event: on_press}
     - {event: on_release}
+  checks:
+    - {predicate: is_on,  esphome: binary_sensor.is_on}
+    - {predicate: is_off, esphome: binary_sensor.is_off}
 
 params_schema:
   retrigger:

--- a/wirestudio/library/components/rcwl-0516.yaml
+++ b/wirestudio/library/components/rcwl-0516.yaml
@@ -22,6 +22,7 @@ esphome:
       - platform: gpio
         pin: {{ pins.OUT | tojson }}
         name: "{{ label }}"
+        id: {{ id }}
         device_class: motion
     {%- if params.filters is defined %}
         filters: {{ params.filters | tojson }}
@@ -40,6 +41,9 @@ capability:
   provides:
     - {event: on_press}
     - {event: on_release}
+  checks:
+    - {predicate: is_on,  esphome: binary_sensor.is_on}
+    - {predicate: is_off, esphome: binary_sensor.is_off}
 
 params_schema: {}
 

--- a/wirestudio/library/components/ws2812b.yaml
+++ b/wirestudio/library/components/ws2812b.yaml
@@ -46,6 +46,9 @@ capability:
     - {action: turn_on,  esphome: light.turn_on}
     - {action: turn_off, esphome: light.turn_off}
     - {action: toggle,   esphome: light.toggle}
+  checks:
+    - {predicate: is_on,  esphome: light.is_on}
+    - {predicate: is_off, esphome: light.is_off}
 
 params_schema:
   variant: {type: string, default: "WS2812", enum: ["WS2811", "WS2812", "WS2812X", "400KBPS", "SK6812",

--- a/wirestudio/model.py
+++ b/wirestudio/model.py
@@ -154,6 +154,16 @@ class AutomationTrigger(_Strict):
     below: Optional[float] = None
 
 
+class AutomationCondition(_Strict):
+    """One predicate that gates an automation: the actions only fire when the
+    condition holds. `component_id` is a design-level id; `predicate` is the
+    studio-side name (e.g. `is_on`) that must appear in the component's
+    `capability.checks`. Multiple conditions on one automation are combined
+    as ESPHome AND (the list form of `condition:`)."""
+    component_id: str
+    predicate: str
+
+
 class AutomationAction(_Strict):
     """The action side: a component takes an action its library
     `capability.accepts` declares. `args` are extra ESPHome action args
@@ -175,17 +185,18 @@ class AutomationAction(_Strict):
 class Automation(_Strict):
     """One trigger→actions wiring (intent-to-device synthesis).
 
-    Phase 1 is declarative event→action; phase 2 adds value→transform→action
-    via `AutomationAction.transform` (lowered to a `!lambda`). Condition
-    gating and the periodic / stateful composition patterns from the design
-    doc arrive in later phases. The generator lowers each automation onto the
-    trigger component's params, where the existing ESPHome `params.on_*`
-    passthrough in the library YAML emits it. An automation referencing an
-    unknown component / event / action surfaces as a permissive warning, not a
-    hard failure (CLAUDE.md: warnings, don't block).
+    The action list fires when the trigger event lands AND every entry in
+    `conditions` holds. Conditions reference predicates the component declares
+    via its `capability.checks`; the lowering wraps the actions in
+    `if: { condition: ..., then: [...] }`. A transform on an action
+    (phase 2) lowers to a `!lambda`. The periodic / stateful composition
+    patterns from the design doc arrive in later phases. An automation
+    referencing an unknown component / event / action / predicate surfaces as
+    a permissive warning, not a hard failure (CLAUDE.md: warnings, don't block).
     """
     id: str
     trigger: AutomationTrigger
+    conditions: list[AutomationCondition] = Field(default_factory=list)
     actions: list[AutomationAction]
 
 

--- a/wirestudio/schema/design.schema.json
+++ b/wirestudio/schema/design.schema.json
@@ -213,6 +213,19 @@
               }
             }
           },
+          "conditions": {
+            "type": "array",
+            "description": "Predicates that gate the actions; the trigger must fire AND every condition must hold. Lowered to ESPHome's `if: { condition: ..., then: [...] }`.",
+            "items": {
+              "type": "object",
+              "required": ["component_id", "predicate"],
+              "additionalProperties": false,
+              "properties": {
+                "component_id": { "type": "string" },
+                "predicate": { "type": "string" }
+              }
+            }
+          },
           "actions": {
             "type": "array",
             "items": {


### PR DESCRIPTION
## Summary

Phase 5 of intent-to-device synthesis: **condition gating**. An automation can now say "fire **only when** the enable switch is on" or "**and** the safety sensor is closed". The third of the five composition primitives from the design doc.

> **Stacked on #108 (phase 4).** Base is `claude/intent-on-value-range` so this diff shows phase-5 only. Once #108 merges to `main`, retarget/rebase this onto `main`.

### IR

- `AutomationCondition { component_id, predicate }` and `Automation.conditions: list[...]` (default empty).
- Schema mirrors.
- Lowering: when conditions resolve, the action list is wrapped in `if: { condition: ..., then: [...] }`. Single condition emits as an inline dict; multiple emit as a YAML list (ESPHome treats the list form as implicit AND). Conditions that don't resolve are dropped by the renderer; the validator surfaces them as warnings.

### Library

`CapabilityChecks { predicate, esphome }` mirrors the accepts/esphome pattern. Five components gain `is_on` / `is_off`:

- `gpio_input` → `binary_sensor.is_on` / `is_off`
- `gpio_output` → `switch.is_on` / `is_off`
- `hc-sr501`, `rcwl-0516` (PIR / microwave motion) → `binary_sensor.is_on` / `is_off`
- `ws2812b` → `light.is_on` / `is_off`

The two motion sensors gain `id: {{ id }}` in their binary_sensor template so conditions can reference them (was missing; necessary even without conditions for any cross-component reference).

### Validator

`automation_unknown_predicate` — predicate not in the component's `checks`; the warning text lists what IS supported. The existing `automation_unknown_component` and `automation_component_no_capability` codes now cover condition references too.

### Worked example

`guarded-button-light.json` — a button press toggles a light, but only when an enable switch is on. The golden asserts the `if: { condition: { switch.is_on: enable }, then: [switch.toggle: light] }` shape; the validator is quiet.

### Refreshed goldens

Five motion-sensor goldens (bluemotion, garage-motion, motion-turns-on-light, multi-temp, wasserpir) gain a single additive `id:` line each from the hc-sr501/rcwl-0516 template surgery. Verified additive-only via diff.

### Deferred (by design)

- `sensor.in_range` predicate — single-output sensors need an `id:` line; multi-channel sensors need per-channel `id:` template surgery. Separate phase.
- OR combinator — keeping AND-only for now (the common case); a `combine: and|or` field can be added if a use case demands it.

## Test plan

- [x] `pytest tests/test_intent.py` — 71 passed (golden, single inline condition, multi-condition list form, unknown-predicate warning, no-capability warning on condition, drop-silently behavior on unresolved condition, IR round-trip)
- [x] `pytest -q` full suite — 773 passed, 11 skipped
- [x] `ruff check .` — clean
- [x] Golden churn audited — only additive `id:` lines on the 5 motion sensor goldens
- [ ] `esphome config` on the new example runs in CI (no esphome CLI locally; `binary_sensor`, `switch`, `if: condition: switch.is_on:` are all standard ESPHome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_