### PR TITLE
lorawan: Design.lorawan IR for the external-component path (W1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **LoRaWAN workflow integration (W2 — generator emits the external-component
+  block).** When `design.lorawan.payload` is non-empty, the YAML generator now
+  emits an `external_components: - source: github://moellere/lorawan-for-esphome
+  ref: <pinned>` block, the `lorawan:` config (region / sub_band / keys via
+  `!secret` / radio config sourced from the board library's existing
+  metadata), and one `sensor: - platform: lorawan, sensor: <id>` binding per
+  payload field. Keys never enter `design.json` -- `dev_eui` / `join_eui` /
+  `app_key` route through `Design.fleet.secrets_ref`. The radio block adapts
+  to the chip family: SX127x boards emit dio0; SX126x boards emit dio1, busy,
+  optional `tcxo_voltage`, and `dio2_as_rf_switch`. Worked example
+  `lorawan-battery-uplink.json` (TTGO LoRa32 v1 + ADC battery, US915 sub-band
+  2) -- the smallest design that exercises the full new path and can be
+  hand-flashed against the live ChirpStack for the hardware-join test ahead
+  of W3's orchestration UI. The standalone Arduino path is unaffected:
+  emission is gated on `payload` non-empty, so existing non-LoRaWAN designs
+  render byte-identical.
+
 - **LoRaWAN workflow integration (W1 — `Design.lorawan` IR extension).** Adds
   the IR shape the external-component path needs: a `PayloadField` class
   (`{sensor: <component_id>}`) and an ordered `LoRaWAN.payload: list[...]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **LoRaWAN workflow integration (W1 — `Design.lorawan` IR extension).** Adds
+  the IR shape the external-component path needs: a `PayloadField` class
+  (`{sensor: <component_id>}`) and an ordered `LoRaWAN.payload: list[...]`
+  list -- the codec contract shared between the device's wire bytes and the
+  ChirpStack `decodeUplink` decoder. Broadens `LoRaWAN.region` to accept
+  US915 / EU868 / AU915 / AS923 (default still US915). The existing
+  standalone-Arduino fields (`gps` / `dht22` / `oled` / `provisioning`) are
+  untouched -- both paths share the block during the transition documented in
+  `docs/lorawan/workflow-integration.md`. Schema mirrors. Pure IR addition,
+  no generator branch yet (W2 wires that up).
+
 - **Intent-to-device synthesis (phase 4 — on_value_range threshold bounds).**
   An automation trigger gains optional `above` / `below` numeric bounds for the
   `on_value_range` event; the lowering wraps the action list in a

--- a/scripts/check_examples.py
+++ b/scripts/check_examples.py
@@ -49,6 +49,13 @@ def _stub_value(name: str) -> str:
         return "stub-password-1234"
     if name == "ota_password":
         return "stub-ota-password"
+    # LoRaWAN keys carried in secrets.yaml for the external-component path
+    # (lorawan-for-esphome). The component's schema validates them as hex,
+    # so a plain `stub-<name>` would fail `esphome config`.
+    if name in ("dev_eui", "join_eui"):
+        return "0123456789abcdef"  # 16 hex chars (EUI-64)
+    if name == "app_key":
+        return "00112233445566778899aabbccddeeff"  # 32 hex chars (128-bit AES key)
     return f"stub-{name}"
 
 

--- a/tests/golden/lorawan-battery-uplink.txt
+++ b/tests/golden/lorawan-battery-uplink.txt
@@ -1,0 +1,16 @@
++-----------------------------------------------------+
+|  TTGO LoRa32 V1 (T3)  ---  lorawan-battery-uplink   |
++-----------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                |
+|                                                     |
+|  battery  [Generic analog input]  -- Battery        |
+|    IN    -> GPIO36                                  |
+|                                                     |
+|  BOM:                                               |
+|    - TTGO LoRa32 V1 (T3)                            |
+|    - Generic analog input  (battery)                |
+|                                                     |
+|  Power: ~0mA typical, ~0mA peak (budget 250mA)  OK  |
+|                                                     |
+|  Warnings: none                                     |
++-----------------------------------------------------+

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -25,8 +25,7 @@ sensor:
   lorawan_id: lw
   sensor: battery
 external_components:
-- source: github://moellere/lorawan-for-esphome
-  ref: main
+- source: github://moellere/lorawan-for-esphome@main
   components:
   - lorawan
 lorawan:

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -1,0 +1,43 @@
+esphome:
+  name: lorawan-battery-uplink
+esp32:
+  board: ttgo-lora32-v1
+  framework:
+    type: arduino
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+sensor:
+- platform: adc
+  pin: GPIO36
+  name: Battery
+  id: battery
+  attenuation: 11db
+  update_interval: 30s
+  unit_of_measurement: V
+- platform: lorawan
+  lorawan_id: lw
+  sensor: battery
+external_components:
+- source: github://moellere/lorawan-for-esphome
+  ref: main
+  components:
+  - lorawan
+lorawan:
+  id: lw
+  region: US915
+  sub_band: 2
+  dev_eui: !secret dev_eui
+  join_eui: !secret join_eui
+  app_key: !secret app_key
+  radio:
+    chip: sx1276
+    cs_pin: GPIO18
+    rst_pin: GPIO23
+    dio0_pin: GPIO26

--- a/tests/test_lorawan.py
+++ b/tests/test_lorawan.py
@@ -122,6 +122,129 @@ def test_lorawan_payload_field_rejects_unknown_keys_at_schema_level():
         jsonschema.validate(raw, SCHEMA)
 
 
+# --- W2: generator emits external_components: + lorawan: + payload bindings -
+
+from wirestudio.generate.yaml_gen import render_yaml  # noqa: E402
+
+LORAWAN_EXAMPLE = REPO_ROOT / "wirestudio" / "examples" / "lorawan-battery-uplink.json"
+
+
+def test_lorawan_payload_design_matches_golden():
+    """Round-trip: the W2 worked example renders byte-identical to its
+    pinned golden. Catches drift in any of the four moving pieces --
+    external_components ref, radio config emission, !secret routing, payload
+    sensor binding -- in one assertion."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    lib = default_library()
+    expected = (REPO_ROOT / "tests" / "golden" / "lorawan-battery-uplink.yaml").read_text()
+    assert render_yaml(d, lib) == expected
+
+
+def test_lorawan_emission_skipped_when_payload_empty():
+    """Without `payload`, the generator MUST NOT emit external_components or
+    a lorawan: block -- existing non-LoRaWAN designs render byte-identical."""
+    d = Design(
+        schema_version="0.1", id="x", name="X",
+        board={"library_id": "ttgo-lora32-v1", "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        target="esphome",
+        # No lorawan block at all
+    )
+    yaml = render_yaml(d, default_library())
+    assert "external_components" not in yaml
+    assert "lorawan:" not in yaml
+
+
+def test_lorawan_emission_skipped_when_lorawan_block_has_empty_payload():
+    """A lorawan block with an empty payload list is treated the same as no
+    block -- the W2 emission is gated on payload being non-empty, since an
+    uplink with zero fields is meaningless."""
+    d = Design(
+        schema_version="0.1", id="x", name="X",
+        board={"library_id": "ttgo-lora32-v1", "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        target="esphome",
+        lorawan={"payload": []},
+    )
+    yaml = render_yaml(d, default_library())
+    assert "external_components" not in yaml
+    assert "lorawan:" not in yaml
+
+
+def test_lorawan_emission_pins_the_external_component_ref():
+    """The generator pins lorawan-for-esphome at a known ref (commit SHA per
+    the locked decision); the rendered YAML must carry both `source:` and
+    `ref:` so a future bump is a one-line reviewed change."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    yaml = render_yaml(d, default_library())
+    assert "source: github://moellere/lorawan-for-esphome" in yaml
+    assert "ref: " in yaml
+
+
+def test_lorawan_emission_uses_secret_references_for_keys():
+    """Keys (dev_eui / join_eui / app_key) must render as !secret references,
+    not literals -- the CLAUDE.md secrets-never-in-design.json rule applies
+    to the rendered YAML too."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    yaml = render_yaml(d, default_library())
+    for key in ("dev_eui", "join_eui", "app_key"):
+        assert f"{key}: !secret {key}" in yaml
+
+
+def test_lorawan_emission_reads_radio_config_from_board_library():
+    """The radio block (chip, pins, optional tcxo/dio2-rf-switch) comes from
+    the board library's `radio:` metadata -- not duplicated in design.json.
+    Validates by comparing SX1276 (TTGO LoRa32 v1) and SX1262 (Heltec V3)
+    boards: chip differs, pin set differs, and SX1262 carries tcxo +
+    dio2_as_rf_switch."""
+    sx1276 = Design(
+        schema_version="0.1", id="x", name="X",
+        board={"library_id": "ttgo-lora32-v1", "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        target="esphome",
+        lorawan={"payload": [{"sensor": "x"}]},
+    )
+    sx1262 = Design(
+        schema_version="0.1", id="x", name="X",
+        board={"library_id": "heltec-wifi-lora32-v3", "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        target="esphome",
+        lorawan={"payload": [{"sensor": "x"}]},
+    )
+    y1276 = render_yaml(sx1276, default_library())
+    y1262 = render_yaml(sx1262, default_library())
+
+    assert "chip: sx1276" in y1276
+    assert "dio0_pin:" in y1276
+    assert "tcxo_voltage" not in y1276
+
+    assert "chip: sx1262" in y1262
+    assert "dio1_pin:" in y1262
+    assert "busy_pin:" in y1262
+    assert "tcxo_voltage: 1.8" in y1262
+    assert "dio2_as_rf_switch: true" in y1262
+
+
+def test_lorawan_payload_emits_one_sensor_binding_per_field_in_order():
+    """Each payload entry emits one `sensor: - platform: lorawan` binding in
+    declaration order -- the codec contract relies on this."""
+    d = Design(
+        schema_version="0.1", id="x", name="X",
+        board={"library_id": "ttgo-lora32-v1", "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        target="esphome",
+        lorawan={"payload": [{"sensor": "battery"}, {"sensor": "temp"}, {"sensor": "humidity"}]},
+    )
+    yaml = render_yaml(d, default_library())
+    # Three platform: lorawan entries appear, and in the right order
+    bindings = [line.strip() for line in yaml.splitlines() if "platform: lorawan" in line]
+    assert len(bindings) == 3
+    idx_b = yaml.index("sensor: battery")
+    idx_t = yaml.index("sensor: temp")
+    idx_h = yaml.index("sensor: humidity")
+    assert idx_b < idx_t < idx_h
+
+
 def test_all_boards_still_load():
     # Regression guard: the new radio: field must not break any board YAML.
     boards = default_library().list_boards()

--- a/tests/test_lorawan.py
+++ b/tests/test_lorawan.py
@@ -172,13 +172,18 @@ def test_lorawan_emission_skipped_when_lorawan_block_has_empty_payload():
 
 
 def test_lorawan_emission_pins_the_external_component_ref():
-    """The generator pins lorawan-for-esphome at a known ref (commit SHA per
-    the locked decision); the rendered YAML must carry both `source:` and
-    `ref:` so a future bump is a one-line reviewed change."""
+    """The generator pins lorawan-for-esphome at a known ref. ESPHome's
+    external_components: encodes the ref as a `@<ref>` suffix on the source
+    URL (not a separate `ref:` key -- that was a misread of ESPHome's schema
+    and breaks `esphome config`); the test pins the URL shape so a future
+    bump is a one-line reviewed change."""
     d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
     yaml = render_yaml(d, default_library())
-    assert "source: github://moellere/lorawan-for-esphome" in yaml
-    assert "ref: " in yaml
+    assert "source: github://moellere/lorawan-for-esphome@" in yaml
+    # And NO bare `ref:` line under the external_components entry -- that
+    # spelling is invalid (the validator returns "Did you mean refresh?").
+    assert "\n  ref: " not in yaml
+    assert "\n    ref: " not in yaml
 
 
 def test_lorawan_emission_uses_secret_references_for_keys():

--- a/tests/test_lorawan.py
+++ b/tests/test_lorawan.py
@@ -59,6 +59,69 @@ def test_lorawan_design_validates_against_schema():
     jsonschema.validate(d.model_dump(mode="json", exclude_none=True), SCHEMA)
 
 
+# --- W1: Design.lorawan IR additions for the external-component path --------
+# Adds an ordered `payload` list and broadens `region` to the four bands
+# `lorawan-for-esphome` will support, without touching the standalone Arduino
+# fields. See docs/lorawan/workflow-integration.md.
+
+def test_lorawan_payload_defaults_to_empty():
+    d = _base_design(target="esphome", lorawan={})
+    assert d.lorawan.payload == []
+
+
+def test_lorawan_payload_round_trips_through_the_model():
+    d = _base_design(target="esphome", lorawan={
+        "payload": [{"sensor": "battery"}, {"sensor": "temp"}],
+    })
+    assert [f.sensor for f in d.lorawan.payload] == ["battery", "temp"]
+
+
+def test_lorawan_payload_field_rejects_unknown_keys():
+    # PayloadField is strict (extra="forbid"); a typoed key (e.g. bytes:)
+    # raises rather than silently dropping data the codec would need.
+    with pytest.raises(ValidationError):
+        LoRaWAN(payload=[{"sensor": "x", "bytes": 4}])
+
+
+def test_lorawan_payload_field_requires_sensor():
+    with pytest.raises(ValidationError):
+        LoRaWAN(payload=[{}])
+
+
+@pytest.mark.parametrize("region", ["US915", "EU868", "AU915", "AS923"])
+def test_lorawan_region_accepts_supported_bands(region):
+    d = _base_design(target="esphome", lorawan={"region": region})
+    assert d.lorawan.region == region
+
+
+def test_lorawan_region_rejects_unknown_band():
+    with pytest.raises(ValidationError):
+        LoRaWAN(region="MOON915")
+
+
+def test_lorawan_payload_design_validates_against_schema():
+    d = _base_design(target="esphome", lorawan={
+        "region": "EU868",
+        "sub_band": 0,
+        "payload": [{"sensor": "battery"}],
+    })
+    jsonschema.validate(d.model_dump(mode="json", exclude_none=True), SCHEMA)
+
+
+def test_lorawan_payload_field_rejects_unknown_keys_at_schema_level():
+    # The JSON Schema mirrors the model: extra keys on a payload item fail
+    # schema validation, not just model parsing. Catches a `bytes:` typo even
+    # for callers that bypass the pydantic model.
+    raw = {
+        "schema_version": "0.1", "id": "x", "name": "X",
+        "board": {"library_id": "ttgo-lora32-v1", "mcu": "esp32"},
+        "power": {"supply": "usb", "rail_voltage_v": 3.3},
+        "lorawan": {"payload": [{"sensor": "battery", "bytes": 4}]},
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(raw, SCHEMA)
+
+
 def test_all_boards_still_load():
     # Regression guard: the new radio: field must not break any board YAML.
     boards = default_library().list_boards()

--- a/wirestudio/examples/lorawan-battery-uplink.json
+++ b/wirestudio/examples/lorawan-battery-uplink.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "0.1",
+  "id": "lorawan-battery-uplink",
+  "name": "TTGO LoRa32 v1 battery uplink (lorawan-for-esphome spike)",
+  "description": "W2 worked example for the LoRaWAN external-component path: a TTGO LoRa32 v1 reads its battery voltage via the ADC and uplinks it through `lorawan-for-esphome` to a US915 sub-band 2 gateway. The smallest design that exercises the full new path -- external_components fetch, lorawan: block, payload sensor binding -- so the generator output can be gated by `esphome config` in CI and hand-flashed against the live ChirpStack for the spike's hardware-join test. Keys ride `fleet.secrets_ref` -> `!secret` references; the actual values are minted by the ChirpStack provision step (W3) and written to secrets.yaml. The standalone Arduino path is untouched.",
+  "created_at": "2026-06-19T00:00:00Z",
+  "updated_at": "2026-06-19T00:00:00Z",
+
+  "board": {
+    "library_id": "ttgo-lora32-v1",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "battery-li-ion",
+    "rail_voltage_v": 3.7,
+    "budget_ma": 250
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "uplink battery voltage to ChirpStack via LoRaWAN" }
+  ],
+
+  "components": [
+    {
+      "id": "battery",
+      "library_id": "adc",
+      "label": "Battery",
+      "params": {
+        "attenuation": "11db",
+        "update_interval": "30s",
+        "unit_of_measurement": "V"
+      }
+    }
+  ],
+
+  "buses": [],
+
+  "connections": [
+    { "component_id": "battery", "pin_role": "IN", "target": { "kind": "gpio", "pin": "GPIO36" } }
+  ],
+
+  "passives": [],
+
+  "automations": [],
+
+  "warnings": [],
+
+  "target": "esphome",
+  "lorawan": {
+    "region": "US915",
+    "sub_band": 2,
+    "payload": [
+      { "sensor": "battery" }
+    ]
+  },
+
+  "esphome_extras": {
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "lorawan-battery-uplink",
+    "tags": ["lorawan", "external-component", "spike"],
+    "secrets_ref": {
+      "wifi_ssid":     "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key":       "!secret api_key",
+      "dev_eui":       "!secret dev_eui",
+      "join_eui":      "!secret join_eui",
+      "app_key":       "!secret app_key"
+    }
+  }
+}

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -315,6 +315,75 @@ def _secret_name(ref: str) -> str:
     return ref.removeprefix("!secret ").strip()
 
 
+# Pinned ref for the lorawan-for-esphome external component. Bumps are
+# reviewed changes like any other dependency pin; switch to a tag after the
+# component repo cuts its first stable release post hardware-join validation
+# (decision logged in docs/lorawan/workflow-integration.md).
+_LORAWAN_FOR_ESPHOME_REPO = "github://moellere/lorawan-for-esphome"
+_LORAWAN_FOR_ESPHOME_REF = "main"  # TODO(lorawan): pin to a commit SHA after the join test runs
+
+
+def _emit_lorawan_blocks(out: dict[str, Any], design: Design, library: Library) -> None:
+    """Emit the ESPHome external-component path for `lorawan-for-esphome`:
+    `external_components:`, the `lorawan:` block (radio config from the board
+    library, keys via !secret), and one `sensor: - platform: lorawan` binding
+    per `design.lorawan.payload` entry. No-op unless `design.lorawan.payload`
+    is non-empty -- the standalone Arduino path (target="lorawan") is rendered
+    elsewhere and unaffected.
+    """
+    lw = design.lorawan
+    if lw is None or not lw.payload:
+        return
+
+    out.setdefault("external_components", []).append({
+        "source": _LORAWAN_FOR_ESPHOME_REPO,
+        "ref": _LORAWAN_FOR_ESPHOME_REF,
+        "components": ["lorawan"],
+    })
+
+    board = library.board(design.board.library_id)
+    radio = board.radio
+    if radio is None:
+        # The validator should already flag a LoRaWAN design on a non-radio
+        # board; the generator just skips the lorawan block rather than emit
+        # nonsense.
+        return
+
+    radio_block: dict[str, Any] = {
+        "chip": radio.chip,
+        "cs_pin":  radio.pins.cs,
+        "rst_pin": radio.pins.rst,
+    }
+    if radio.pins.dio0:
+        radio_block["dio0_pin"] = radio.pins.dio0
+    if radio.pins.dio1:
+        radio_block["dio1_pin"] = radio.pins.dio1
+    if radio.pins.busy:
+        radio_block["busy_pin"] = radio.pins.busy
+    if radio.tcxo_voltage:
+        radio_block["tcxo_voltage"] = radio.tcxo_voltage
+    if radio.dio2_as_rf_switch:
+        radio_block["dio2_as_rf_switch"] = radio.dio2_as_rf_switch
+
+    lorawan_block: dict[str, Any] = {
+        "id": "lw",
+        "region": lw.region,
+        "sub_band": lw.sub_band,
+        "dev_eui":  Secret("dev_eui"),
+        "join_eui": Secret("join_eui"),
+        "app_key":  Secret("app_key"),
+        "radio": radio_block,
+    }
+    out["lorawan"] = lorawan_block
+
+    for field in lw.payload:
+        out.setdefault("sensor", []).append({
+            "platform": "lorawan",
+            "lorawan_id": "lw",
+            "sensor": field.sensor,
+        })
+
+
 def build_yaml_dict(design: Design, library: Library) -> dict[str, Any]:
     board = library.board(design.board.library_id)
     out: dict[str, Any] = {}
@@ -402,6 +471,8 @@ def build_yaml_dict(design: Design, library: Library) -> dict[str, Any]:
     auto_params = _lower_automations(design, library)
     for comp in design.components:
         _deep_merge(out, _render_component(comp, design, library, auto_params))
+
+    _emit_lorawan_blocks(out, design, library)
 
     if extras:
         _deep_merge(out, extras)

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -342,11 +342,13 @@ def _secret_name(ref: str) -> str:
     return ref.removeprefix("!secret ").strip()
 
 
-# Pinned ref for the lorawan-for-esphome external component. Bumps are
-# reviewed changes like any other dependency pin; switch to a tag after the
-# component repo cuts its first stable release post hardware-join validation
-# (decision logged in docs/lorawan/workflow-integration.md).
-_LORAWAN_FOR_ESPHOME_REPO = "github://moellere/lorawan-for-esphome"
+# Pinned ref for the lorawan-for-esphome external component. ESPHome's
+# external_components: format embeds the ref in the source URL fragment
+# (`github://owner/repo@<ref>`) rather than as a separate `ref:` key. Bumps
+# are reviewed changes like any other dependency pin; switch to a tag after
+# the component repo cuts its first stable release post hardware-join
+# validation (decision logged in docs/lorawan/workflow-integration.md).
+_LORAWAN_FOR_ESPHOME_REPO = "moellere/lorawan-for-esphome"
 _LORAWAN_FOR_ESPHOME_REF = "main"  # TODO(lorawan): pin to a commit SHA after the join test runs
 
 
@@ -363,8 +365,7 @@ def _emit_lorawan_blocks(out: dict[str, Any], design: Design, library: Library) 
         return
 
     out.setdefault("external_components", []).append({
-        "source": _LORAWAN_FOR_ESPHOME_REPO,
-        "ref": _LORAWAN_FOR_ESPHOME_REF,
+        "source": f"github://{_LORAWAN_FOR_ESPHOME_REPO}@{_LORAWAN_FOR_ESPHOME_REF}",
         "components": ["lorawan"],
     })
 

--- a/wirestudio/model.py
+++ b/wirestudio/model.py
@@ -221,24 +221,59 @@ class Oled(_Strict):
     enabled: bool = True
 
 
-class LoRaWAN(_Strict):
-    """LoRaWAN target parameters. Region/sub-band are hard-pinned to the
-    gateway (US915 sub-band 2); a mismatch makes the device transmit joins
-    on channels the gateway never hears. `dev_eui` is device-authoritative
-    and filled after runtime serial provisioning, not authored by hand.
-    Keys (AppKey/NwkKey) are deliberately absent: they are secrets and
-    never live in design.json.
+class PayloadField(_Strict):
+    """One slot in the LoRaWAN uplink payload, used by the external-component
+    target path (`lorawan-for-esphome`). `sensor` is a design-level
+    `component_id` whose current value is packed into the uplink; the
+    ChirpStack `decodeUplink` codec is generated from the same ordered list so
+    device wire bytes and server-side decoding stay in lockstep. The standalone
+    Arduino path doesn't use this -- its fields are the explicit `gps`,
+    `dht22`, `oled` blocks below.
     """
-    region: Literal["US915"] = "US915"
+    sensor: str
+
+
+class LoRaWAN(_Strict):
+    """LoRaWAN target parameters. Region/sub-band must match the gateway; a
+    mismatch makes the device transmit joins on channels the gateway never
+    hears. Region defaults to US915 -- the only band exercised end-to-end at
+    time of writing.
+
+    Two generation paths share this block during the transition documented in
+    `docs/lorawan/esphome-component-pivot.md` /
+    `docs/lorawan/workflow-integration.md`:
+
+    - **Standalone Arduino (`target="lorawan"`).** Uses `gps` / `dht22` /
+      `oled` for hardcoded sensor blocks, plus `provisioning` for the runtime
+      serial flow. Hardware-validated; stays shipping behind the `[lorawan]`
+      install extra until the new path joins on real hardware.
+    - **ESPHome external component (`target="esphome"` + `lorawan:` set).**
+      Uses `payload` as the ordered uplink field list; the generator emits
+      ESPHome YAML referencing `lorawan-for-esphome`. Keys ride
+      `fleet.secrets_ref` and the rendered config uses `!secret` references --
+      keys never land in design.json.
+
+    `dev_eui` carries the value the device will use, whichever path: the
+    standalone path fills it post-runtime-serial-provision; the new path
+    accepts a manual override here (per the locked decision in
+    workflow-integration.md), or it's filled post-provision after the eFuse
+    MAC is read over WebSerial. Keys (AppKey / NwkKey) are deliberately
+    absent: they are secrets.
+    """
+    region: Literal["US915", "EU868", "AU915", "AS923"] = "US915"
     sub_band: int = 2
     join_eui: Optional[str] = None                   # MSB hex; defaults applied downstream
     chirpstack_application_id: Optional[str] = None  # UUID
-    device_profile_id: Optional[str] = None          # UUID (US915 sub-2 profile)
+    device_profile_id: Optional[str] = None          # UUID
     provisioning: Literal["runtime_serial", "compile_time"] = "runtime_serial"
-    dev_eui: Optional[str] = None                    # device-reported, post-provision
-    gps: Optional[GpsSerial] = None                  # external GPS on a UART
-    dht22: Optional[Dht22] = None                    # DHT22 temp/humidity sensor
-    oled: Optional[Oled] = None                      # SSD1306 status display
+    dev_eui: Optional[str] = None                    # device-reported (standalone) or override / post-provision (new path)
+    # New path (ESPHome external component): ordered uplink payload field list.
+    payload: list[PayloadField] = Field(default_factory=list)
+    # Standalone path: explicit per-feature sensor blocks. Unused by the new
+    # path; retire when the standalone path retires.
+    gps: Optional[GpsSerial] = None
+    dht22: Optional[Dht22] = None
+    oled: Optional[Oled] = None
 
 
 class Design(_Strict):

--- a/wirestudio/schema/design.schema.json
+++ b/wirestudio/schema/design.schema.json
@@ -276,13 +276,25 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "region": { "type": "string", "enum": ["US915"], "default": "US915" },
+        "region": { "type": "string", "enum": ["US915", "EU868", "AU915", "AS923"], "default": "US915" },
         "sub_band": { "type": "integer", "default": 2 },
         "join_eui": { "type": "string" },
         "chirpstack_application_id": { "type": "string" },
         "device_profile_id": { "type": "string" },
         "provisioning": { "type": "string", "enum": ["runtime_serial", "compile_time"], "default": "runtime_serial" },
         "dev_eui": { "type": "string" },
+        "payload": {
+          "type": "array",
+          "description": "Ordered uplink field list for the ESPHome external-component target path (`lorawan-for-esphome`). Each entry packs a sensor's current value into the uplink; the ChirpStack decoder is generated from the same list so device and server stay in lockstep. Unused by the standalone Arduino path.",
+          "items": {
+            "type": "object",
+            "required": ["sensor"],
+            "additionalProperties": false,
+            "properties": {
+              "sensor": { "type": "string", "description": "design-level component_id whose value goes into this slot" }
+            }
+          }
+        },
         "gps": {
           "type": "object",
           "required": ["rx_pin", "tx_pin"],


### PR DESCRIPTION
## Summary

**W1** of the LoRaWAN workflow integration ([scoping doc, PR #110](https://github.com/moellere/WireStudio/pull/110)) — the IR shape `lorawan-for-esphome` will hang off of. Pure data model + schema; no generator branch yet (W2 wires that up), no orchestration (W3).

### What changes

- **`PayloadField { sensor: <component_id> }`** — one slot in the ordered uplink payload.
- **`LoRaWAN.payload: list[PayloadField]`** (default empty) — the codec contract. The ChirpStack `decodeUplink` JS will be generated from the same ordered list so device wire bytes and server-side decoding stay in lockstep.
- **`LoRaWAN.region`** broadened from `{US915}` to `{US915, EU868, AU915, AS923}` (default still US915 — the only band hardware-validated at time of writing).
- **Schema mirrors** — extra keys on a payload item fail JSON-Schema validation, not just pydantic parsing (test covers both paths).

### Standalone path stays untouched

The existing `gps` / `dht22` / `oled` / `provisioning` fields remain — both generation paths share the `LoRaWAN` block during the transition. Per the scoping doc:

- `target="lorawan"` + standalone fields → standalone Arduino path (hardware-validated, kept shipping behind `[lorawan]`).
- `target="esphome"` + `payload:` set → new external-component path (W2+).

### Locked decisions reflected in the IR

- **DevEUI source.** Existing `dev_eui: Optional[str]` already serves as the manual-override field per the locked decision; the docstring is updated to say so explicitly.
- **Pin form.** The external-component `ref: <sha>` lives in the generator (W2), not in `design.json` — wired pin is repo-wide, not per-design.

## Test plan

- [x] `pytest tests/test_lorawan.py` — 24 passed (8 new W1 tests: payload defaults, round-trip, strict-extras at model and schema level, sensor-required, region enum positive + negative, end-to-end design+schema validation)
- [x] `pytest -q` full suite — 776 passed, 11 skipped
- [x] `ruff check .` — clean
- [x] No golden churn (pure IR addition)

## What W2 unblocks

After this merges, **W2** is the generator branch that emits `external_components:` + `lorawan:` + payload `sensor:` bindings when `design.lorawan.payload` is non-empty, plus a worked TTGO LoRa32 v1 example gated by the `esphome config` CI check. Once W2 lands, the hardware-join test against the live ChirpStack can run by hand (manually mint keys → drop in secrets.yaml → render → build → flash) — without waiting for W3's orchestration UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_