### PR TITLE
lorawan: generator emits external-component path (W2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **LoRaWAN workflow integration (W2 — generator emits the external-component
+  block).** When `design.lorawan.payload` is non-empty, the YAML generator now
+  emits an `external_components: - source: github://moellere/lorawan-for-esphome
+  ref: <pinned>` block, the `lorawan:` config (region / sub_band / keys via
+  `!secret` / radio config sourced from the board library's existing
+  metadata), and one `sensor: - platform: lorawan, sensor: <id>` binding per
+  payload field. Keys never enter `design.json` -- `dev_eui` / `join_eui` /
+  `app_key` route through `Design.fleet.secrets_ref`. The radio block adapts
+  to the chip family: SX127x boards emit dio0; SX126x boards emit dio1, busy,
+  optional `tcxo_voltage`, and `dio2_as_rf_switch`. Worked example
+  `lorawan-battery-uplink.json` (TTGO LoRa32 v1 + ADC battery, US915 sub-band
+  2) -- the smallest design that exercises the full new path and can be
+  hand-flashed against the live ChirpStack for the hardware-join test ahead
+  of W3's orchestration UI. The standalone Arduino path is unaffected:
+  emission is gated on `payload` non-empty, so existing non-LoRaWAN designs
+  render byte-identical.
+
 - **LoRaWAN workflow integration (W1 — `Design.lorawan` IR extension).** Adds
   the IR shape the external-component path needs: a `PayloadField` class
   (`{sensor: <component_id>}`) and an ordered `LoRaWAN.payload: list[...]`

--- a/tests/golden/lorawan-battery-uplink.txt
+++ b/tests/golden/lorawan-battery-uplink.txt
@@ -1,0 +1,16 @@
++-----------------------------------------------------+
+|  TTGO LoRa32 V1 (T3)  ---  lorawan-battery-uplink   |
++-----------------------------------------------------+
+|  Rails: 5V, 3V3, GND                                |
+|                                                     |
+|  battery  [Generic analog input]  -- Battery        |
+|    IN    -> GPIO36                                  |
+|                                                     |
+|  BOM:                                               |
+|    - TTGO LoRa32 V1 (T3)                            |
+|    - Generic analog input  (battery)                |
+|                                                     |
+|  Power: ~0mA typical, ~0mA peak (budget 250mA)  OK  |
+|                                                     |
+|  Warnings: none                                     |
++-----------------------------------------------------+

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -1,0 +1,43 @@
+esphome:
+  name: lorawan-battery-uplink
+esp32:
+  board: ttgo-lora32-v1
+  framework:
+    type: arduino
+logger: {}
+api:
+  encryption:
+    key: !secret api_key
+ota:
+- platform: esphome
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+sensor:
+- platform: adc
+  pin: GPIO36
+  name: Battery
+  id: battery
+  attenuation: 11db
+  update_interval: 30s
+  unit_of_measurement: V
+- platform: lorawan
+  lorawan_id: lw
+  sensor: battery
+external_components:
+- source: github://moellere/lorawan-for-esphome
+  ref: main
+  components:
+  - lorawan
+lorawan:
+  id: lw
+  region: US915
+  sub_band: 2
+  dev_eui: !secret dev_eui
+  join_eui: !secret join_eui
+  app_key: !secret app_key
+  radio:
+    chip: sx1276
+    cs_pin: GPIO18
+    rst_pin: GPIO23
+    dio0_pin: GPIO26

--- a/tests/test_lorawan.py
+++ b/tests/test_lorawan.py
@@ -122,6 +122,129 @@ def test_lorawan_payload_field_rejects_unknown_keys_at_schema_level():
         jsonschema.validate(raw, SCHEMA)
 
 
+# --- W2: generator emits external_components: + lorawan: + payload bindings -
+
+from wirestudio.generate.yaml_gen import render_yaml  # noqa: E402
+
+LORAWAN_EXAMPLE = REPO_ROOT / "wirestudio" / "examples" / "lorawan-battery-uplink.json"
+
+
+def test_lorawan_payload_design_matches_golden():
+    """Round-trip: the W2 worked example renders byte-identical to its
+    pinned golden. Catches drift in any of the four moving pieces --
+    external_components ref, radio config emission, !secret routing, payload
+    sensor binding -- in one assertion."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    lib = default_library()
+    expected = (REPO_ROOT / "tests" / "golden" / "lorawan-battery-uplink.yaml").read_text()
+    assert render_yaml(d, lib) == expected
+
+
+def test_lorawan_emission_skipped_when_payload_empty():
+    """Without `payload`, the generator MUST NOT emit external_components or
+    a lorawan: block -- existing non-LoRaWAN designs render byte-identical."""
+    d = Design(
+        schema_version="0.1", id="x", name="X",
+        board={"library_id": "ttgo-lora32-v1", "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        target="esphome",
+        # No lorawan block at all
+    )
+    yaml = render_yaml(d, default_library())
+    assert "external_components" not in yaml
+    assert "lorawan:" not in yaml
+
+
+def test_lorawan_emission_skipped_when_lorawan_block_has_empty_payload():
+    """A lorawan block with an empty payload list is treated the same as no
+    block -- the W2 emission is gated on payload being non-empty, since an
+    uplink with zero fields is meaningless."""
+    d = Design(
+        schema_version="0.1", id="x", name="X",
+        board={"library_id": "ttgo-lora32-v1", "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        target="esphome",
+        lorawan={"payload": []},
+    )
+    yaml = render_yaml(d, default_library())
+    assert "external_components" not in yaml
+    assert "lorawan:" not in yaml
+
+
+def test_lorawan_emission_pins_the_external_component_ref():
+    """The generator pins lorawan-for-esphome at a known ref (commit SHA per
+    the locked decision); the rendered YAML must carry both `source:` and
+    `ref:` so a future bump is a one-line reviewed change."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    yaml = render_yaml(d, default_library())
+    assert "source: github://moellere/lorawan-for-esphome" in yaml
+    assert "ref: " in yaml
+
+
+def test_lorawan_emission_uses_secret_references_for_keys():
+    """Keys (dev_eui / join_eui / app_key) must render as !secret references,
+    not literals -- the CLAUDE.md secrets-never-in-design.json rule applies
+    to the rendered YAML too."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    yaml = render_yaml(d, default_library())
+    for key in ("dev_eui", "join_eui", "app_key"):
+        assert f"{key}: !secret {key}" in yaml
+
+
+def test_lorawan_emission_reads_radio_config_from_board_library():
+    """The radio block (chip, pins, optional tcxo/dio2-rf-switch) comes from
+    the board library's `radio:` metadata -- not duplicated in design.json.
+    Validates by comparing SX1276 (TTGO LoRa32 v1) and SX1262 (Heltec V3)
+    boards: chip differs, pin set differs, and SX1262 carries tcxo +
+    dio2_as_rf_switch."""
+    sx1276 = Design(
+        schema_version="0.1", id="x", name="X",
+        board={"library_id": "ttgo-lora32-v1", "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        target="esphome",
+        lorawan={"payload": [{"sensor": "x"}]},
+    )
+    sx1262 = Design(
+        schema_version="0.1", id="x", name="X",
+        board={"library_id": "heltec-wifi-lora32-v3", "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        target="esphome",
+        lorawan={"payload": [{"sensor": "x"}]},
+    )
+    y1276 = render_yaml(sx1276, default_library())
+    y1262 = render_yaml(sx1262, default_library())
+
+    assert "chip: sx1276" in y1276
+    assert "dio0_pin:" in y1276
+    assert "tcxo_voltage" not in y1276
+
+    assert "chip: sx1262" in y1262
+    assert "dio1_pin:" in y1262
+    assert "busy_pin:" in y1262
+    assert "tcxo_voltage: 1.8" in y1262
+    assert "dio2_as_rf_switch: true" in y1262
+
+
+def test_lorawan_payload_emits_one_sensor_binding_per_field_in_order():
+    """Each payload entry emits one `sensor: - platform: lorawan` binding in
+    declaration order -- the codec contract relies on this."""
+    d = Design(
+        schema_version="0.1", id="x", name="X",
+        board={"library_id": "ttgo-lora32-v1", "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        target="esphome",
+        lorawan={"payload": [{"sensor": "battery"}, {"sensor": "temp"}, {"sensor": "humidity"}]},
+    )
+    yaml = render_yaml(d, default_library())
+    # Three platform: lorawan entries appear, and in the right order
+    bindings = [line.strip() for line in yaml.splitlines() if "platform: lorawan" in line]
+    assert len(bindings) == 3
+    idx_b = yaml.index("sensor: battery")
+    idx_t = yaml.index("sensor: temp")
+    idx_h = yaml.index("sensor: humidity")
+    assert idx_b < idx_t < idx_h
+
+
 def test_all_boards_still_load():
     # Regression guard: the new radio: field must not break any board YAML.
     boards = default_library().list_boards()

--- a/wirestudio/examples/lorawan-battery-uplink.json
+++ b/wirestudio/examples/lorawan-battery-uplink.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "0.1",
+  "id": "lorawan-battery-uplink",
+  "name": "TTGO LoRa32 v1 battery uplink (lorawan-for-esphome spike)",
+  "description": "W2 worked example for the LoRaWAN external-component path: a TTGO LoRa32 v1 reads its battery voltage via the ADC and uplinks it through `lorawan-for-esphome` to a US915 sub-band 2 gateway. The smallest design that exercises the full new path -- external_components fetch, lorawan: block, payload sensor binding -- so the generator output can be gated by `esphome config` in CI and hand-flashed against the live ChirpStack for the spike's hardware-join test. Keys ride `fleet.secrets_ref` -> `!secret` references; the actual values are minted by the ChirpStack provision step (W3) and written to secrets.yaml. The standalone Arduino path is untouched.",
+  "created_at": "2026-06-19T00:00:00Z",
+  "updated_at": "2026-06-19T00:00:00Z",
+
+  "board": {
+    "library_id": "ttgo-lora32-v1",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "battery-li-ion",
+    "rail_voltage_v": 3.7,
+    "budget_ma": 250
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "uplink battery voltage to ChirpStack via LoRaWAN" }
+  ],
+
+  "components": [
+    {
+      "id": "battery",
+      "library_id": "adc",
+      "label": "Battery",
+      "params": {
+        "attenuation": "11db",
+        "update_interval": "30s",
+        "unit_of_measurement": "V"
+      }
+    }
+  ],
+
+  "buses": [],
+
+  "connections": [
+    { "component_id": "battery", "pin_role": "IN", "target": { "kind": "gpio", "pin": "GPIO36" } }
+  ],
+
+  "passives": [],
+
+  "automations": [],
+
+  "warnings": [],
+
+  "target": "esphome",
+  "lorawan": {
+    "region": "US915",
+    "sub_band": 2,
+    "payload": [
+      { "sensor": "battery" }
+    ]
+  },
+
+  "esphome_extras": {
+    "logger": {}
+  },
+
+  "fleet": {
+    "device_name": "lorawan-battery-uplink",
+    "tags": ["lorawan", "external-component", "spike"],
+    "secrets_ref": {
+      "wifi_ssid":     "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key":       "!secret api_key",
+      "dev_eui":       "!secret dev_eui",
+      "join_eui":      "!secret join_eui",
+      "app_key":       "!secret app_key"
+    }
+  }
+}

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -315,6 +315,75 @@ def _secret_name(ref: str) -> str:
     return ref.removeprefix("!secret ").strip()
 
 
+# Pinned ref for the lorawan-for-esphome external component. Bumps are
+# reviewed changes like any other dependency pin; switch to a tag after the
+# component repo cuts its first stable release post hardware-join validation
+# (decision logged in docs/lorawan/workflow-integration.md).
+_LORAWAN_FOR_ESPHOME_REPO = "github://moellere/lorawan-for-esphome"
+_LORAWAN_FOR_ESPHOME_REF = "main"  # TODO(lorawan): pin to a commit SHA after the join test runs
+
+
+def _emit_lorawan_blocks(out: dict[str, Any], design: Design, library: Library) -> None:
+    """Emit the ESPHome external-component path for `lorawan-for-esphome`:
+    `external_components:`, the `lorawan:` block (radio config from the board
+    library, keys via !secret), and one `sensor: - platform: lorawan` binding
+    per `design.lorawan.payload` entry. No-op unless `design.lorawan.payload`
+    is non-empty -- the standalone Arduino path (target="lorawan") is rendered
+    elsewhere and unaffected.
+    """
+    lw = design.lorawan
+    if lw is None or not lw.payload:
+        return
+
+    out.setdefault("external_components", []).append({
+        "source": _LORAWAN_FOR_ESPHOME_REPO,
+        "ref": _LORAWAN_FOR_ESPHOME_REF,
+        "components": ["lorawan"],
+    })
+
+    board = library.board(design.board.library_id)
+    radio = board.radio
+    if radio is None:
+        # The validator should already flag a LoRaWAN design on a non-radio
+        # board; the generator just skips the lorawan block rather than emit
+        # nonsense.
+        return
+
+    radio_block: dict[str, Any] = {
+        "chip": radio.chip,
+        "cs_pin":  radio.pins.cs,
+        "rst_pin": radio.pins.rst,
+    }
+    if radio.pins.dio0:
+        radio_block["dio0_pin"] = radio.pins.dio0
+    if radio.pins.dio1:
+        radio_block["dio1_pin"] = radio.pins.dio1
+    if radio.pins.busy:
+        radio_block["busy_pin"] = radio.pins.busy
+    if radio.tcxo_voltage:
+        radio_block["tcxo_voltage"] = radio.tcxo_voltage
+    if radio.dio2_as_rf_switch:
+        radio_block["dio2_as_rf_switch"] = radio.dio2_as_rf_switch
+
+    lorawan_block: dict[str, Any] = {
+        "id": "lw",
+        "region": lw.region,
+        "sub_band": lw.sub_band,
+        "dev_eui":  Secret("dev_eui"),
+        "join_eui": Secret("join_eui"),
+        "app_key":  Secret("app_key"),
+        "radio": radio_block,
+    }
+    out["lorawan"] = lorawan_block
+
+    for field in lw.payload:
+        out.setdefault("sensor", []).append({
+            "platform": "lorawan",
+            "lorawan_id": "lw",
+            "sensor": field.sensor,
+        })
+
+
 def build_yaml_dict(design: Design, library: Library) -> dict[str, Any]:
     board = library.board(design.board.library_id)
     out: dict[str, Any] = {}
@@ -402,6 +471,8 @@ def build_yaml_dict(design: Design, library: Library) -> dict[str, Any]:
     auto_params = _lower_automations(design, library)
     for comp in design.components:
         _deep_merge(out, _render_component(comp, design, library, auto_params))
+
+    _emit_lorawan_blocks(out, design, library)
 
     if extras:
         _deep_merge(out, extras)


### PR DESCRIPTION
## Summary

**W2** of the LoRaWAN workflow integration ([scoping doc, PR #110](https://github.com/moellere/WireStudio/pull/110)) — the YAML generator branch that emits the external-component path. **After this lands, the hardware-join test can run by hand**, ahead of W3's orchestration UI.

> **Stacked on #112 (W1).** Base is `claude/lorawan-design-block`. Once #112 merges to `main`, retarget/rebase this onto `main`.

### What emits when `design.lorawan.payload` is non-empty

- `external_components: - source: github://moellere/lorawan-for-esphome` with a pinned `ref:` (currently `main`; switch to a commit SHA once the device repo joins on real hardware, per the locked decision in #110).
- `lorawan: { id: lw, region, sub_band, dev_eui: !secret, join_eui: !secret, app_key: !secret, radio: { ... } }`.
- Radio config sourced from the board library's existing `radio:` metadata — SX127x emits `dio0_pin`; SX126x emits `dio1_pin`, `busy_pin`, optional `tcxo_voltage`, `dio2_as_rf_switch`. No duplication into `design.json`.
- One `sensor: - platform: lorawan, lorawan_id: lw, sensor: <id>` binding per payload field, in declaration order — the codec contract.

### Worked example

`lorawan-battery-uplink.json` — TTGO LoRa32 v1 reading ADC battery voltage on GPIO36, uplinking to US915 sub-band 2. The smallest design that exercises the full path. Golden checked in.

### Gating + secrets

- Emission is gated on `payload` non-empty, so existing non-LoRaWAN designs render byte-identical. Test asserts this.
- Keys (`dev_eui`, `join_eui`, `app_key`) ride `Design.fleet.secrets_ref` and render as `!secret` references. Values never enter `design.json` (CLAUDE.md rule preserved at the YAML layer).
- Standalone Arduino path (`target="lorawan"` + `gps`/`dht22`/`oled`) untouched.

### What W2 unblocks (the spike's payoff)

After this merges you can run the hardware-join test **by hand** without W3:

1. Render the YAML for `lorawan-battery-uplink.json`.
2. Mint a DevEUI + AppKey in ChirpStack (or via the existing `targets/lorawan/chirpstack.py`), flush nonces.
3. Drop the keys into `secrets.yaml`.
4. `esphome compile` + flash via the existing WebSerial path.
5. Power-cycle and confirm re-join — validates `lorawan-for-esphome`'s nonce persistence (the device-side spike's main risk).

W3 turns that into one-click.

### Known unknowns surfaced by CI

This is the first WireStudio example that uses `external_components:`. The `esphome config` gate will fetch `lorawan-for-esphome` at validate time; if CI has restricted egress to GitHub or the component's schema differs from what's emitted here, the gate flags it. Treat the first CI run as the source of truth for both — happy to follow up with a fix.

## Test plan

- [x] `pytest tests/test_lorawan.py` — 31 passed (7 new W2 tests: golden match, emission-skipped when payload empty, emission-skipped when no `lorawan` block, pinned `ref:`, all three keys as `!secret`, SX1276 vs SX1262 radio config divergence, payload binding order)
- [x] `pytest -q` full suite — 783 passed, 11 skipped
- [x] `ruff check .` — clean
- [x] No golden churn on existing examples (emission is gated)
- [ ] `esphome config` on the new example runs in CI (first network-fetching `external_components:` example — first CI run validates both the gate and the component's schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_