### PR TITLE
web: LoRaWAN provision dialog for the external-component path (W3 UI)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,6 +23,7 @@ import { CapabilityPickerDialog } from "./components/CapabilityPickerDialog";
 import { EnclosureDialog } from "./components/EnclosureDialog";
 import { SchematicDialog } from "./components/SchematicDialog";
 import { LorawanFlashDialog } from "./components/LorawanFlashDialog";
+import { LorawanProvisionEsphomeDialog } from "./components/LorawanProvisionEsphomeDialog";
 import { InventoryDialog } from "./components/InventoryDialog";
 import { useDebouncedValue } from "./lib/debounce";
 import { useAdvancedMode } from "./lib/uiMode";
@@ -40,7 +41,8 @@ import {
   Download,
   ExternalLink,
   Radio,
-  Boxes
+  Boxes,
+  KeyRound,
 } from "lucide-react";
 import {
   addComponent,
@@ -102,6 +104,7 @@ export default function App() {
   const [showSchematicDialog, setShowSchematicDialog] = useState(false);
   const [showCapabilityDialog, setShowCapabilityDialog] = useState(false);
   const [showFlashDialog, setShowFlashDialog] = useState(false);
+  const [showProvisionEsphomeDialog, setShowProvisionEsphomeDialog] = useState(false);
   const [showInventoryDialog, setShowInventoryDialog] = useState(false);
   const [savingState, setSavingState] = useState<"idle" | "saving" | "saved">("idle");
 
@@ -622,6 +625,15 @@ export default function App() {
               >
                 <Radio className="h-4 w-4" />
               </button>
+              <button
+                disabled={!design}
+                onClick={() => setShowProvisionEsphomeDialog(true)}
+                className="flex items-center gap-1.5 rounded-md p-1.5 text-xs font-medium text-zinc-400 transition-colors enabled:hover:bg-zinc-800 enabled:hover:text-zinc-200 disabled:opacity-40"
+                title="Provision a LoRaWAN device for the lorawan-for-esphome external-component path"
+                aria-label="Provision LoRaWAN device"
+              >
+                <KeyRound className="h-4 w-4" />
+              </button>
 
               <div className="mx-1 h-4 w-px bg-zinc-800"></div>
 
@@ -728,6 +740,12 @@ export default function App() {
           boards={boards}
           onCancel={() => setShowNewDialog(false)}
           onAdopt={handleAdoptNewDesign}
+        />
+      )}
+      {showProvisionEsphomeDialog && design && (
+        <LorawanProvisionEsphomeDialog
+          design={design}
+          onClose={() => setShowProvisionEsphomeDialog(false)}
         />
       )}
       {showFlashDialog && (

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -134,3 +134,41 @@ describe("lorawan factory image", () => {
     await expect(api.lorawanFactory("abc123")).rejects.toThrow(/factory/);
   });
 });
+
+describe("lorawan provision-esphome + activation (W3)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("lorawanProvisionEsphome POSTs to /lorawan/provision-esphome with the body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        secrets: { dev_eui: "70b3d57ed0001234", join_eui: "0000000000000000", app_key: "ff".repeat(16) },
+        chirpstack: { application_id: "app-1", device_profile_id: "dp-1" },
+        band: "US915",
+        sub_band: 2,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const r = await api.lorawanProvisionEsphome({ dev_eui: "70b3d57ed0001234", design: DESIGN });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("/lorawan/provision-esphome");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ dev_eui: "70b3d57ed0001234", design: DESIGN });
+    expect(r.secrets.dev_eui).toBe("70b3d57ed0001234");
+    expect(r.chirpstack.application_id).toBe("app-1");
+  });
+
+  it("lorawanActivation GETs /lorawan/activation/<eui> and URL-encodes the eui", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ dev_eui: "70b3d57ed0001234", joined: true, dev_addr: "01020304" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const r = await api.lorawanActivation("70b3d57ed0001234");
+
+    expect(fetchMock.mock.calls[0][0]).toContain("/lorawan/activation/70b3d57ed0001234");
+    expect(r.joined).toBe(true);
+    expect(r.dev_addr).toBe("01020304");
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -20,6 +20,8 @@ import type {
   LorawanCompileEvent,
   LorawanCompileStatus,
   LorawanProvisionResponse,
+  LorawanProvisionEsphomeResponse,
+  LorawanActivationResponse,
   ModuleSummary,
   RecommendConstraints,
   RecommendResponse,
@@ -239,6 +241,19 @@ export const api = {
       "/lorawan/codec",
       { method: "POST", body: JSON.stringify(body) },
     ),
+  /** Provision a device for the ESPHome external-component path
+   *  (lorawan-for-esphome). Mints an AppKey, registers the device + flushes
+   *  DevNonces, and returns the keys formatted for the secrets.yaml that
+   *  rides next to the rendered ESPHome config. */
+  lorawanProvisionEsphome: (body: { dev_eui: string; design: Design }) =>
+    request<LorawanProvisionEsphomeResponse>("/lorawan/provision-esphome", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  /** Poll ChirpStack for OTAA-join activation status. Used by the
+   *  provision-esphome UI to surface the join landing. */
+  lorawanActivation: (devEui: string) =>
+    request<LorawanActivationResponse>(`/lorawan/activation/${encodeURIComponent(devEui)}`),
   /** Download a built firmware image by its compile cache_key. */
   lorawanFirmware: async (cacheKey: string): Promise<Uint8Array> => {
     const res = await fetch(`${API_BASE}/lorawan/firmware/${encodeURIComponent(cacheKey)}`);

--- a/web/src/components/LorawanProvisionEsphomeDialog.test.tsx
+++ b/web/src/components/LorawanProvisionEsphomeDialog.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Component tests for LorawanProvisionEsphomeDialog. Three surfaces:
+ *
+ *   1. Eligibility gating -- the dialog refuses to call the endpoint when
+ *      the design isn't external-component-shaped, and the Provision button
+ *      stays disabled while the DevEUI is malformed.
+ *   2. The provision flow -- on success the secrets block renders, the
+ *      activation poll starts, and the AppKey copies to the clipboard.
+ *   3. Error paths -- a 422 from the server surfaces in the dialog with the
+ *      detail body, and the activation polling stops on join landing.
+ *
+ * The api/client surface is mocked at the import boundary; no network calls.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { LorawanProvisionEsphomeDialog } from "./LorawanProvisionEsphomeDialog";
+import { api, ApiError } from "../api/client";
+import type { Design } from "../types/api";
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      lorawanProvisionEsphome: vi.fn(),
+      lorawanActivation: vi.fn(),
+    },
+  };
+});
+
+const mockApi = api as unknown as {
+  lorawanProvisionEsphome: ReturnType<typeof vi.fn>;
+  lorawanActivation: ReturnType<typeof vi.fn>;
+};
+
+function design(overrides: Partial<Design> = {}): Design {
+  return {
+    schema_version: "0.1",
+    id: "lw-spike",
+    name: "LoRaWAN spike",
+    target: "esphome",
+    board: { library_id: "ttgo-lora32-v1", mcu: "esp32", framework: "arduino" },
+    components: [{ id: "battery", library_id: "adc", label: "Battery" }],
+    buses: [],
+    connections: [],
+    requirements: [],
+    warnings: [],
+    lorawan: {
+      region: "US915",
+      sub_band: 2,
+      payload: [{ sensor: "battery" }],
+    },
+    ...overrides,
+  } as unknown as Design;
+}
+
+beforeEach(() => {
+  mockApi.lorawanProvisionEsphome.mockReset();
+  mockApi.lorawanActivation.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("eligibility gating", () => {
+  it("hides the provision button when target is not 'esphome' and shows guidance", () => {
+    render(
+      <LorawanProvisionEsphomeDialog
+        design={design({ target: "lorawan" } as Partial<Design>)}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText(/isn't eligible/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Provision →/i })).toBeNull();
+  });
+
+  it("hides the provision button when lorawan.payload is empty and shows guidance", () => {
+    render(
+      <LorawanProvisionEsphomeDialog
+        design={design({
+          lorawan: { region: "US915", sub_band: 2, payload: [] },
+        } as Partial<Design>)}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText(/isn't eligible/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Provision →/i })).toBeNull();
+  });
+
+  it("disables Provision until the DevEUI is 16 hex chars", async () => {
+    const user = userEvent.setup();
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+
+    const btn = screen.getByRole("button", { name: /Provision →/i });
+    expect(btn).toBeDisabled();
+
+    const input = screen.getByPlaceholderText(/70b3d57ed0001234/i);
+    await user.type(input, "70b3d57ed0001234");
+    expect(btn).toBeEnabled();
+  });
+
+  it("flags a non-hex DevEUI inline", async () => {
+    const user = userEvent.setup();
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+
+    await user.type(screen.getByPlaceholderText(/70b3d57ed0001234/i), "not-hex");
+    expect(screen.getByText(/Expected 16 hex characters/i)).toBeTruthy();
+  });
+});
+
+describe("successful provision flow", () => {
+  it("renders the secrets block and starts polling activation on success", async () => {
+    const user = userEvent.setup();
+    mockApi.lorawanProvisionEsphome.mockResolvedValue({
+      secrets: {
+        dev_eui: "70b3d57ed0001234",
+        join_eui: "0000000000000000",
+        app_key: "00112233445566778899aabbccddeeff",
+      },
+      chirpstack: { application_id: "app-1", device_profile_id: "dp-1" },
+      band: "US915",
+      sub_band: 2,
+    });
+    mockApi.lorawanActivation.mockResolvedValue({
+      dev_eui: "70b3d57ed0001234",
+      joined: false,
+    });
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await user.type(screen.getByPlaceholderText(/70b3d57ed0001234/i), "70b3d57ed0001234");
+    await user.click(screen.getByRole("button", { name: /Provision →/i }));
+
+    await waitFor(() => {
+      expect(mockApi.lorawanProvisionEsphome).toHaveBeenCalledWith({
+        dev_eui: "70b3d57ed0001234",
+        design: expect.objectContaining({ id: "lw-spike" }),
+      });
+    });
+
+    // Secrets render in the textarea (readonly, copy-friendly).
+    const textarea = await screen.findByDisplayValue(/dev_eui:\s+"70b3d57ed0001234"/);
+    expect(textarea.tagName).toBe("TEXTAREA");
+    expect((textarea as HTMLTextAreaElement).readOnly).toBe(true);
+    // AppKey is shown so the user can copy it (and only this once, server-side).
+    expect((textarea as HTMLTextAreaElement).value).toContain(
+      'app_key:  "00112233445566778899aabbccddeeff"',
+    );
+
+    // Activation poll fired on success.
+    await waitFor(() => expect(mockApi.lorawanActivation).toHaveBeenCalledWith("70b3d57ed0001234"));
+    expect(screen.getByText(/waiting for OTAA join/i)).toBeTruthy();
+  });
+
+  it("renders the joined state when activation poll reports joined=true", async () => {
+    const user = userEvent.setup();
+    mockApi.lorawanProvisionEsphome.mockResolvedValue({
+      secrets: { dev_eui: "70b3d57ed0001234", join_eui: "0000000000000000", app_key: "ff".repeat(16) },
+      chirpstack: { application_id: "app-1", device_profile_id: "dp-1" },
+      band: "US915",
+      sub_band: 2,
+    });
+    mockApi.lorawanActivation.mockResolvedValue({
+      dev_eui: "70b3d57ed0001234",
+      joined: true,
+      dev_addr: "01020304",
+      f_cnt_up: 7,
+    });
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await user.type(screen.getByPlaceholderText(/70b3d57ed0001234/i), "70b3d57ed0001234");
+    await user.click(screen.getByRole("button", { name: /Provision →/i }));
+
+    expect(await screen.findByText(/joined ·/i)).toBeTruthy();
+    expect(screen.getByText(/01020304/)).toBeTruthy();
+    expect(screen.getByText(/uplink frames: 7/)).toBeTruthy();
+  });
+
+  it("hides the Provision button once a result lands; Cancel turns into Done", async () => {
+    const user = userEvent.setup();
+    mockApi.lorawanProvisionEsphome.mockResolvedValue({
+      secrets: { dev_eui: "70b3d57ed0001234", join_eui: "0000000000000000", app_key: "ff".repeat(16) },
+      chirpstack: { application_id: "app-1", device_profile_id: "dp-1" },
+      band: "US915",
+      sub_band: 2,
+    });
+    mockApi.lorawanActivation.mockResolvedValue({ dev_eui: "70b3d57ed0001234", joined: false });
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await user.type(screen.getByPlaceholderText(/70b3d57ed0001234/i), "70b3d57ed0001234");
+    await user.click(screen.getByRole("button", { name: /Provision →/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /Provision →/i })).toBeNull(),
+    );
+    expect(screen.getByRole("button", { name: /^Done$/i })).toBeTruthy();
+  });
+});
+
+describe("error path", () => {
+  it("renders the server detail when provision returns 422", async () => {
+    const user = userEvent.setup();
+    mockApi.lorawanProvisionEsphome.mockRejectedValue(
+      new ApiError(422, "POST /lorawan/provision-esphome -> 422", {
+        detail: "design.lorawan.payload must be non-empty for the ESPHome external-component path",
+      }),
+    );
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await user.type(screen.getByPlaceholderText(/70b3d57ed0001234/i), "70b3d57ed0001234");
+    await user.click(screen.getByRole("button", { name: /Provision →/i }));
+
+    expect(await screen.findByText(/422: design\.lorawan\.payload/i)).toBeTruthy();
+    // The result block didn't render, so Provision stays available for a retry.
+    expect(screen.getByRole("button", { name: /Provision →/i })).toBeTruthy();
+  });
+});

--- a/web/src/components/LorawanProvisionEsphomeDialog.tsx
+++ b/web/src/components/LorawanProvisionEsphomeDialog.tsx
@@ -1,0 +1,331 @@
+/**
+ * Provisioning UI for the LoRaWAN external-component path
+ * (`lorawan-for-esphome`). The companion of `LorawanFlashDialog`, which is
+ * the standalone Arduino path; this one drives the W3 endpoint
+ * (`POST /lorawan/provision-esphome`) and surfaces the join status from
+ * `GET /lorawan/activation/{dev_eui}`.
+ *
+ * Minimum viable scope: the user takes a design that already has
+ * `target: "esphome"` + `lorawan.payload` set, types in a DevEUI (manual
+ * override per the locked decision in docs/lorawan/workflow-integration.md),
+ * clicks Provision, gets back a copy-friendly `secrets:` block to drop into
+ * the secrets.yaml that rides next to the rendered ESPHome config, and
+ * watches the join land. Build + flash are existing flows (PushToFleetDialog
+ * for the fleet-for-esphome path) -- this dialog is purely the LoRaWAN
+ * orchestration step.
+ */
+import { useEffect, useRef, useState } from "react";
+import { api, ApiError } from "../api/client";
+import type {
+  Design,
+  LorawanActivationResponse,
+  LorawanProvisionEsphomeResponse,
+} from "../types/api";
+
+const ACTIVATION_POLL_INTERVAL_MS = 3000;
+const DEV_EUI_RE = /^[0-9a-fA-F]{16}$/;
+
+interface Props {
+  design: Design;
+  onClose: () => void;
+}
+
+/** The bits of `design.lorawan` this dialog reads. Design itself is typed
+ *  opaquely (Record<string, unknown>) in api.ts; narrow inline rather than
+ *  widening that contract for one consumer. */
+interface LorawanBlock {
+  region?: string;
+  sub_band?: number;
+  payload?: { sensor: string }[];
+  dev_eui?: string;
+}
+
+function readLorawan(design: Design): LorawanBlock | null {
+  const v = (design as { lorawan?: unknown }).lorawan;
+  if (!v || typeof v !== "object") return null;
+  return v as LorawanBlock;
+}
+
+function secretsYamlBody(s: LorawanProvisionEsphomeResponse["secrets"]): string {
+  return [
+    "# LoRaWAN keys for lorawan-for-esphome -- drop next to the rendered",
+    "# ESPHome config. The AppKey was minted server-side and is the same",
+    "# value registered in ChirpStack. Treat it as a secret.",
+    `dev_eui:  "${s.dev_eui}"`,
+    `join_eui: "${s.join_eui}"`,
+    `app_key:  "${s.app_key}"`,
+    "",
+  ].join("\n");
+}
+
+export function LorawanProvisionEsphomeDialog({ design, onClose }: Props) {
+  const lorawan = readLorawan(design);
+  const payloadFields = lorawan?.payload ?? [];
+  const eligible = (design as { target?: string }).target === "esphome" && payloadFields.length > 0;
+
+  const [devEui, setDevEui] = useState<string>(lorawan?.dev_eui ?? "");
+  const [provisioning, setProvisioning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<LorawanProvisionEsphomeResponse | null>(null);
+  const [activation, setActivation] = useState<LorawanActivationResponse | null>(null);
+  const [activationErr, setActivationErr] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Reset the copy-feedback flag a couple seconds after the user copies, so
+  // the button doesn't stay green forever on a multi-paste workflow.
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 1800);
+    return () => clearTimeout(t);
+  }, [copied]);
+
+  // Poll /lorawan/activation/{dev_eui} once provisioning succeeded, until
+  // joined=true (then stop) or the dialog closes.
+  useEffect(() => {
+    if (!result) return;
+    const eui = result.secrets.dev_eui;
+
+    let cancelled = false;
+    async function tick() {
+      try {
+        const a = await api.lorawanActivation(eui);
+        if (cancelled) return;
+        setActivation(a);
+        setActivationErr(null);
+        if (a.joined && pollRef.current) {
+          clearInterval(pollRef.current);
+          pollRef.current = null;
+        }
+      } catch (e) {
+        if (cancelled) return;
+        setActivationErr(e instanceof Error ? e.message : String(e));
+      }
+    }
+    void tick(); // immediate first read
+    pollRef.current = setInterval(tick, ACTIVATION_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [result]);
+
+  async function handleProvision() {
+    setError(null);
+    setProvisioning(true);
+    setActivation(null);
+    setActivationErr(null);
+    try {
+      const r = await api.lorawanProvisionEsphome({
+        dev_eui: devEui,
+        design,
+      });
+      setResult(r);
+    } catch (e) {
+      let msg: string;
+      if (e instanceof ApiError) {
+        const detail = (e.body as { detail?: unknown } | undefined)?.detail;
+        msg = `${e.status}: ${typeof detail === "string" ? detail : e.message}`;
+      } else {
+        msg = e instanceof Error ? e.message : String(e);
+      }
+      setError(msg);
+    } finally {
+      setProvisioning(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!result) return;
+    const text = secretsYamlBody(result.secrets);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+    } catch {
+      // Clipboard API can be blocked (insecure context, missing permission);
+      // selecting the textarea below is the manual fallback.
+      setCopied(false);
+    }
+  }
+
+  const devEuiValid = DEV_EUI_RE.test(devEui);
+  const canProvision = eligible && devEuiValid && !provisioning && !result;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="m-4 max-h-[85vh] w-full max-w-xl overflow-y-auto rounded-lg border border-zinc-800 bg-zinc-950 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
+          <div>
+            <div className="text-sm font-semibold text-zinc-100">Provision LoRaWAN device</div>
+            <div className="text-xs text-zinc-500">
+              Mint keys in ChirpStack for the lorawan-for-esphome external-component path.
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md border border-zinc-800 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-900"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="space-y-4 p-4 text-sm">
+          {/* Eligibility / context */}
+          <div className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+            <div className="text-[11px] uppercase tracking-wide text-zinc-500">design</div>
+            <div className="mt-1 text-xs text-zinc-200">
+              <span className="text-zinc-300">{String((design as { name?: string }).name ?? "")}</span>{" "}
+              <span className="text-zinc-500">({String((design as { id?: string }).id ?? "")})</span>
+            </div>
+            {!eligible ? (
+              <div className="mt-2 text-xs text-amber-300">
+                This design isn't eligible for the external-component path. Set{" "}
+                <code className="rounded-md bg-zinc-800 px-1">target: "esphome"</code> and add at
+                least one entry to{" "}
+                <code className="rounded-md bg-zinc-800 px-1">lorawan.payload</code>, then reopen
+                this dialog. The standalone Arduino path uses{" "}
+                <em>Flash LoRaWAN firmware</em> instead.
+              </div>
+            ) : (
+              <div className="mt-2 space-y-1 text-xs text-zinc-400">
+                <div>
+                  Payload fields:{" "}
+                  <span className="text-zinc-200">
+                    {payloadFields.map((f) => f.sensor).join(", ")}
+                  </span>
+                </div>
+                <div>
+                  Band:{" "}
+                  <span className="text-zinc-200">
+                    {lorawan?.region ?? "US915"} sub-band {lorawan?.sub_band ?? 2}
+                  </span>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* DevEUI input */}
+          {eligible && (
+            <div className="space-y-1">
+              <label className="block text-[11px] uppercase tracking-wide text-zinc-500">
+                DevEUI (16 hex chars)
+              </label>
+              <input
+                type="text"
+                value={devEui}
+                onChange={(e) => setDevEui(e.target.value)}
+                disabled={!!result}
+                placeholder="70b3d57ed0001234"
+                className="w-full rounded-md border border-zinc-800 bg-black/40 px-2 py-1.5 font-mono text-xs text-zinc-100 placeholder:text-zinc-600 focus:border-zinc-600 focus:outline-none disabled:opacity-60"
+              />
+              <div className="text-[11px] text-zinc-500">
+                Manual override per the locked decision. MAC-derivation from the chip's eFuse over
+                WebSerial lands in a follow-up.
+              </div>
+              {!devEuiValid && devEui.length > 0 && (
+                <div className="text-[11px] text-amber-400">
+                  Expected 16 hex characters; got {devEui.length}.
+                </div>
+              )}
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-md border border-rose-700/50 bg-rose-900/20 px-3 py-2 text-xs text-rose-200">
+              {error}
+            </div>
+          )}
+
+          {/* Provisioned secrets */}
+          {result && (
+            <div className="space-y-2 rounded-md border border-emerald-700/50 bg-emerald-900/20 p-3">
+              <div className="flex items-center justify-between">
+                <div className="text-[11px] uppercase tracking-wide text-emerald-300">
+                  provisioned
+                </div>
+                <div className="text-[11px] text-emerald-300/80">
+                  app: <code>{result.chirpstack.application_id}</code> · profile:{" "}
+                  <code>{result.chirpstack.device_profile_id}</code>
+                </div>
+              </div>
+              <textarea
+                readOnly
+                value={secretsYamlBody(result.secrets)}
+                onClick={(e) => (e.target as HTMLTextAreaElement).select()}
+                rows={6}
+                className="w-full rounded-md border border-emerald-800/40 bg-black/60 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-emerald-100/90 focus:outline-none"
+              />
+              <div className="flex items-center justify-between text-[11px]">
+                <div className="text-emerald-200/80">
+                  Drop these alongside the rendered ESPHome YAML as{" "}
+                  <code className="rounded-md bg-emerald-900/40 px-1">secrets.yaml</code>. The
+                  AppKey is shown once.
+                </div>
+                <button
+                  onClick={handleCopy}
+                  className="rounded-md border border-emerald-700/60 bg-emerald-900/40 px-2 py-1 text-[11px] text-emerald-100 hover:bg-emerald-900/60"
+                >
+                  {copied ? "Copied" : "Copy"}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Activation poll */}
+          {result && (
+            <div className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+              <div className="text-[11px] uppercase tracking-wide text-zinc-500">
+                join status
+              </div>
+              {activationErr ? (
+                <div className="mt-1 text-xs text-rose-400">error: {activationErr}</div>
+              ) : activation === null ? (
+                <div className="mt-1 text-xs text-zinc-500">polling ChirpStack…</div>
+              ) : activation.joined ? (
+                <div className="mt-1 space-y-1 text-xs">
+                  <div className="text-emerald-400">
+                    joined · dev_addr <code>{activation.dev_addr}</code>
+                  </div>
+                  {typeof activation.f_cnt_up === "number" && (
+                    <div className="text-zinc-500">uplink frames: {activation.f_cnt_up}</div>
+                  )}
+                </div>
+              ) : (
+                <div className="mt-1 text-xs text-amber-300">
+                  waiting for OTAA join… (build + flash the firmware, then check back)
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              onClick={onClose}
+              className="rounded-md border border-zinc-800 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-900"
+            >
+              {result ? "Done" : "Cancel"}
+            </button>
+            {!result && eligible && (
+              <button
+                disabled={!canProvision}
+                onClick={handleProvision}
+                className="rounded-md bg-blue-500/20 px-3 py-1.5 text-sm text-blue-100 ring-1 ring-blue-400/40 enabled:hover:bg-blue-500/30 disabled:opacity-40"
+              >
+                {provisioning ? "Provisioning…" : "Provision →"}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -345,3 +345,33 @@ export interface LorawanProvisionResponse {
   application_id: string;
   device_profile_id: string;
 }
+
+/** Response shape of POST /lorawan/provision-esphome (W3 — external-component
+ *  path). The `secrets` block is formatted for the `secrets.yaml` that rides
+ *  next to the rendered ESPHome config. The AppKey is ephemeral and only
+ *  appears in this response. */
+export interface LorawanProvisionEsphomeResponse {
+  secrets: {
+    dev_eui: string;
+    join_eui: string;
+    app_key: string;
+  };
+  chirpstack: {
+    application_id: string;
+    device_profile_id: string;
+  };
+  band: string;
+  sub_band: number;
+}
+
+/** Response shape of GET /lorawan/activation/{dev_eui}. `joined` flips true
+ *  once the device's OTAA join lands; the other fields populate from
+ *  ChirpStack's GetActivation. */
+export interface LorawanActivationResponse {
+  dev_eui: string;
+  joined: boolean;
+  dev_addr?: string;
+  f_cnt_up?: number;
+  n_f_cnt_down?: number;
+  a_f_cnt_down?: number;
+}


### PR DESCRIPTION
## Summary

Web UI for the W3 LoRaWAN provision endpoint. The end-user companion to the server-side `POST /lorawan/provision-esphome` that landed in #114.

After this merges, the **hardware-join test against `lorawan-for-esphome`** is doable end-to-end from the studio with no curl:

1. Open a design with `target: "esphome"` + `lorawan.payload` set.
2. Click the **key icon** in the toolbar → "Provision LoRaWAN device".
3. Enter the DevEUI, click Provision.
4. Copy the returned `secrets.yaml` block (one click).
5. The dialog polls `/lorawan/activation/{dev_eui}` and surfaces the join landing.

### What's new

- **`LorawanProvisionEsphomeDialog.tsx`** — eligibility-gated dialog that:
  - Refuses to call the endpoint when `target !== "esphome"` or `payload` is empty, with in-dialog guidance pointing at the standalone flash flow instead.
  - Validates the DevEUI as 16 hex chars inline before enabling Provision.
  - Renders the returned secrets in a copy-friendly textarea formatted as `secrets.yaml` content, with a Clipboard-API copy button.
  - Polls `/lorawan/activation/{dev_eui}` every 3s until `joined=true`; surfaces `dev_addr` + uplink frame count when the join lands.
- **`api/client.ts`** — `lorawanProvisionEsphome()` and `lorawanActivation()` methods.
- **`types/api.ts`** — `LorawanProvisionEsphomeResponse` and `LorawanActivationResponse` types.
- **`App.tsx`** — a key icon button (lucide `KeyRound`) sibling to the existing radio-icon LoRaWAN flash button.

### Decisions reflected

- **DevEUI is the manual override** per the locked decision in `docs/lorawan/workflow-integration.md`. eFuse-MAC derivation from WebSerial is a separate iteration.
- **`Design` stays opaque (`Record<string, unknown>`)** — the dialog narrows inline (`readLorawan` helper) rather than widening that contract for one consumer.
- **Build + flash** are existing flows (PushToFleetDialog for fleet-for-esphome). This dialog is the LoRaWAN orchestration step only — preserves the device/orchestrator boundary called out in the scoping doc.

## Test plan

- [x] `npx vitest run` — 171 passed, 15 files (+10 new tests across the dialog and client)
- [x] `npx tsc -b` — clean
- [x] `npx vite build` — production build OK (364 KB index, 100 KB gzip)
- [x] `npx eslint <new files>` — clean (9 pre-existing errors on main are unrelated)
- [x] `pytest -q` — 798 passed, 11 skipped (server unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_