### PR TITLE
fix(adc): rename attenuation value `11db` -> `12db` (ESPHome deprecation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ADC component: `attenuation` value renamed `11db` -> `12db`.** ESPHome
+  2024.5 renamed the value to match the actual ESP-IDF gain; `11db` still
+  parses but emits a deprecation warning that surfaced as noise during the
+  W2 `esphome config` gate. Behaviour is identical -- the same ESP-IDF setting
+  is selected. Updates the `adc.yaml` template (params_schema enum + default
+  + description), the two examples that pin a value explicitly
+  (`analog-node`, `lorawan-battery-uplink`), the matching goldens, and the
+  starter-design generator (`seed.py:_seed_battery_adc`). Verified by
+  diffing goldens: the only golden change is the literal `11db -> 12db`
+  swap on the two affected configs.
+
 ### Added
 
 - **LoRaWAN workflow integration (W3 — orchestration endpoint).** New

--- a/tests/golden/analog-node.yaml
+++ b/tests/golden/analog-node.yaml
@@ -40,6 +40,6 @@ sensor:
   pin: GPIO34
   name: Board 3V3 rail
   id: rail_v
-  attenuation: 11db
+  attenuation: 12db
   update_interval: 60s
   unit_of_measurement: V

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -18,7 +18,7 @@ sensor:
   pin: GPIO36
   name: Battery
   id: battery
-  attenuation: 11db
+  attenuation: 12db
   update_interval: 30s
   unit_of_measurement: V
 - platform: lorawan

--- a/wirestudio/examples/analog-node.json
+++ b/wirestudio/examples/analog-node.json
@@ -48,7 +48,7 @@
       "id": "rail_v",
       "library_id": "adc",
       "label": "Board 3V3 rail",
-      "params": { "attenuation": "11db", "update_interval": "60s", "unit_of_measurement": "V" }
+      "params": { "attenuation": "12db", "update_interval": "60s", "unit_of_measurement": "V" }
     }
   ],
 

--- a/wirestudio/examples/lorawan-battery-uplink.json
+++ b/wirestudio/examples/lorawan-battery-uplink.json
@@ -28,7 +28,7 @@
       "library_id": "adc",
       "label": "Battery",
       "params": {
-        "attenuation": "11db",
+        "attenuation": "12db",
         "update_interval": "30s",
         "unit_of_measurement": "V"
       }

--- a/wirestudio/library/components/adc.yaml
+++ b/wirestudio/library/components/adc.yaml
@@ -57,9 +57,13 @@ capability:
 params_schema:
   attenuation:
     type: string
-    enum: ["0db", "2.5db", "6db", "11db", auto]
-    default: "11db"
-    description: "ESP32 only. 11db caps the readable range at ~3.3V; auto picks per-sample."
+    # ESPHome 2024.5 renamed `11db` to `12db` (the ESP-IDF value didn't
+    # change -- just the label was always off by 1dB from reality). `11db`
+    # still parses but emits a deprecation warning that became blocking on
+    # the matrix runs; the renamed value is identical in behaviour.
+    enum: ["0db", "2.5db", "6db", "12db", auto]
+    default: "12db"
+    description: "ESP32 only. 12db caps the readable range at ~3.3V; auto picks per-sample."
   update_interval:
     type: string
     default: "60s"

--- a/wirestudio/seed.py
+++ b/wirestudio/seed.py
@@ -181,7 +181,7 @@ def _seed_battery_adc(key: str, params: dict, ctx: _SeedContext) -> Optional[tup
     pin = params.get("pin")
     if not pin:
         return None
-    p: dict = {"attenuation": "11db", "unit_of_measurement": "V"}
+    p: dict = {"attenuation": "12db", "unit_of_measurement": "V"}
     if params.get("divider"):
         p["filters"] = [{"multiply": params["divider"]}]
     comp = {"id": "onboard_battery", "library_id": "adc", "label": "Battery voltage", "params": p}


### PR DESCRIPTION
## Summary

Removes the `attenuation: 11db` deprecation warning that surfaced during the W2 `esphome config` gate. ESPHome 2024.5 renamed the value to `12db` to match the actual ESP-IDF gain; `11db` still parses but warns. Behaviour is identical — same ESP-IDF setting selected, just under the correct label.

### Surgical scope

The fix touches every place `11db` was written down. Verified by grep — no remaining `11db` (except an explanatory comment in `adc.yaml`).

| Where | Change |
|---|---|
| `wirestudio/library/components/adc.yaml` | `params_schema.attenuation.enum` + `default` + `description`. New comment explains the rename for future readers. |
| `wirestudio/examples/analog-node.json` | Single explicit pin updated. |
| `wirestudio/examples/lorawan-battery-uplink.json` | Single explicit pin updated. |
| `wirestudio/seed.py:_seed_battery_adc` | Starter-design generator updated. |
| `tests/golden/analog-node.yaml` | Regenerated — diff is the literal `11db → 12db` swap, one line. |
| `tests/golden/lorawan-battery-uplink.yaml` | Same — one line. |

### Audit

Final golden diff is:

```
-  attenuation: 11db
+  attenuation: 12db
```

…on each of the two affected goldens. Nothing else churned. A spurious trailing-newline change on `lorawan-battery-uplink.txt` from the regen script was reverted to keep the diff surgical.

## Test plan

- [x] `grep -rn '11db'` clean across tests/, wirestudio/, scripts/, docs/ (only the explanatory comment in `adc.yaml` remains)
- [x] `pytest -q` — 798 passed, 11 skipped
- [x] `ruff check .` — clean

## Why now

The W2 / W1 esphome-config gate run that landed in #112 surfaced this with a deprecation warning. Fixing it now ahead of ESPHome turning the warning into an error in a future release — the matrix gate would start failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_