### PR TITLE
lorawan: fleet push inlines secrets; restore WebSerial DevEUI auto-derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **LoRaWAN: fleet push inlines per-device secrets.** `POST /fleet/push`
+  gains an optional `lorawan_secrets: {dev_eui, join_eui, app_key}` body
+  field; when present, the renderer substitutes literal values for the
+  matching `!secret <name>` references in the `lorawan:` block, so the
+  YAML the fleet stores carries the keys minted by
+  `/lorawan/provision-esphome` without a separate write to the fleet's
+  `secrets.yaml`. Any key not provided keeps its `!secret` reference; a
+  request with `lorawan_secrets` against a non-LoRaWAN design is a no-op.
+  The provision dialog gains a **"Push to fleet"** button next to the
+  secrets block: provision → push → compile flows through one click, with
+  the resulting filename + compile run id surfaced inline.
+- **LoRaWAN: WebSerial DevEUI auto-derive (restored).** The provision
+  dialog gains a "Detect from chip" button that reads the chip's eFuse
+  MAC over WebSerial via the existing `detectChip()` + `macToEui64()`
+  helpers and fills the DevEUI field. Disabled with a hint when WebSerial
+  isn't available (e.g. Firefox / mobile). Manual entry remains the
+  fallback; editing the field clears the detection hint.
+
 ### Changed
 
 - **ADC component: `attenuation` value renamed `11db` -> `12db`.** ESPHome

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -544,3 +544,78 @@ async def test_fleet_job_log_stream_unknown_run_id_emits_error_event(monkeypatch
     assert any(e["event"] == "error" for e in events), events
     err = next(e for e in events if e["event"] == "error")
     assert "nope" in err["data"]["message"]
+
+
+# --- fleet push with lorawan_secrets (W3 follow-up) ----------------------------
+
+import json as _json  # noqa: E402
+from pathlib import Path as _Path  # noqa: E402
+
+_LORAWAN_EXAMPLE = _Path(__file__).resolve().parent.parent / "wirestudio" / "examples" / "lorawan-battery-uplink.json"
+
+
+def _lorawan_design() -> dict:
+    return _json.loads(_LORAWAN_EXAMPLE.read_text())
+
+
+async def test_fleet_push_lorawan_secrets_inlines_literals_in_pushed_yaml(
+    monkeypatch, tmp_path,
+):
+    """The lorawan_secrets body field replaces !secret references with
+    literal values in the YAML written to the fleet. Removes the manual
+    'edit fleet's secrets.yaml after provisioning' step for the
+    external-component path."""
+    addon = FakeFleetAddon()
+    client = _make_client(monkeypatch, tmp_path, addon=addon)
+    r = client.post("/fleet/push", json={
+        "design": _lorawan_design(),
+        "lorawan_secrets": {
+            "dev_eui": "70b3d57ed0001234",
+            "join_eui": "70b3d57ed0000000",
+            "app_key": "00112233445566778899aabbccddeeff",
+        },
+    })
+    assert r.status_code == 200, r.json()
+    body = r.json()
+    pushed = addon.files[body["filename"]]
+    assert "dev_eui: 70b3d57ed0001234" in pushed
+    assert "join_eui: 70b3d57ed0000000" in pushed
+    assert "app_key: 00112233445566778899aabbccddeeff" in pushed
+    # No !secret references for the three LoRaWAN keys in the pushed YAML.
+    assert "!secret dev_eui" not in pushed
+    assert "!secret join_eui" not in pushed
+    assert "!secret app_key" not in pushed
+
+
+async def test_fleet_push_without_lorawan_secrets_keeps_secret_refs(
+    monkeypatch, tmp_path,
+):
+    """The default push (no lorawan_secrets) still emits !secret references --
+    backward-compatible with the current operator flow that edits fleet's
+    secrets.yaml separately."""
+    addon = FakeFleetAddon()
+    client = _make_client(monkeypatch, tmp_path, addon=addon)
+    r = client.post("/fleet/push", json={"design": _lorawan_design()})
+    assert r.status_code == 200, r.json()
+    pushed = addon.files[r.json()["filename"]]
+    assert "dev_eui: !secret dev_eui" in pushed
+    assert "join_eui: !secret join_eui" in pushed
+    assert "app_key: !secret app_key" in pushed
+
+
+async def test_fleet_push_lorawan_secrets_no_op_for_non_lorawan_designs(
+    monkeypatch, tmp_path, garage_motion_design,
+):
+    """A garage-motion design has no lorawan: block, so a stray
+    lorawan_secrets in the request is harmless -- no error, no churn."""
+    addon = FakeFleetAddon()
+    client = _make_client(monkeypatch, tmp_path, addon=addon)
+    r = client.post("/fleet/push", json={
+        "design": garage_motion_design,
+        "lorawan_secrets": {"dev_eui": "f" * 16, "join_eui": "0" * 16, "app_key": "0" * 32},
+    })
+    assert r.status_code == 200, r.json()
+    pushed = addon.files[r.json()["filename"]]
+    # The pushed YAML has no lorawan block at all; the secrets are ignored.
+    assert "lorawan:" not in pushed
+    assert "dev_eui" not in pushed

--- a/tests/test_lorawan.py
+++ b/tests/test_lorawan.py
@@ -196,6 +196,54 @@ def test_lorawan_emission_uses_secret_references_for_keys():
         assert f"{key}: !secret {key}" in yaml
 
 
+def test_lorawan_secrets_override_emits_literal_values():
+    """The fleet-push path supplies the secrets minted by /lorawan/provision-
+    esphome so the rendered YAML carries them inline -- one less manual step
+    on the operator side. Override replaces !secret refs with literals."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    secrets = {
+        "dev_eui": "70b3d57ed0001234",
+        "join_eui": "70b3d57ed0000000",
+        "app_key": "00112233445566778899aabbccddeeff",
+    }
+    yaml = render_yaml(d, default_library(), lorawan_secrets=secrets)
+    for key, value in secrets.items():
+        assert f"{key}: {value}" in yaml
+        # And no !secret reference for these keys anymore.
+        assert f"{key}: !secret {key}" not in yaml
+
+
+def test_lorawan_secrets_override_quotes_all_digit_join_eui():
+    """An all-digit JoinEUI (e.g. the zero-EUI default used when the design
+    didn't pin a JoinEUI) must be emitted as a string, not as an integer --
+    PyYAML auto-quotes it; this pins the behaviour so a regression is loud."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    yaml = render_yaml(
+        d, default_library(),
+        lorawan_secrets={
+            "dev_eui": "70b3d57ed0001234",
+            "join_eui": "0000000000000000",
+            "app_key": "ff" * 16,
+        },
+    )
+    assert "join_eui: '0000000000000000'" in yaml  # quoted -> string
+
+
+def test_lorawan_secrets_partial_override_keeps_secret_refs_for_missing_keys():
+    """Any key not in the override keeps its !secret reference. Lets the
+    operator inject just one key (e.g. a manually-rotated AppKey) without
+    losing the other two."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    yaml = render_yaml(
+        d, default_library(),
+        lorawan_secrets={"app_key": "ff" * 16},
+    )
+    assert "dev_eui: !secret dev_eui" in yaml
+    assert "join_eui: !secret join_eui" in yaml
+    assert "app_key: " + "ff" * 16 in yaml
+    assert "app_key: !secret app_key" not in yaml
+
+
 def test_lorawan_emission_reads_radio_config_from_board_library():
     """The radio block (chip, pins, optional tcxo/dio2-rf-switch) comes from
     the board library's `radio:` metadata -- not duplicated in design.json.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -214,7 +214,18 @@ export const api = {
     }),
 
   fleetStatus: () => request<FleetStatus>("/fleet/status"),
-  fleetPush: (body: { design: Design; compile?: boolean; device_name?: string; strict?: boolean }) =>
+  fleetPush: (body: {
+    design: Design;
+    compile?: boolean;
+    device_name?: string;
+    strict?: boolean;
+    /** Optional `{dev_eui, join_eui, app_key}` — when present, the server
+     *  inlines these literal values into the pushed YAML in place of the
+     *  matching !secret references, so the fleet's secrets.yaml doesn't
+     *  need a separate write for the LoRaWAN keys minted by
+     *  /lorawan/provision-esphome. */
+    lorawan_secrets?: Record<string, string>;
+  }) =>
     request<FleetPushResponse>("/fleet/push", {
       method: "POST",
       body: JSON.stringify(body),

--- a/web/src/components/LorawanProvisionEsphomeDialog.test.tsx
+++ b/web/src/components/LorawanProvisionEsphomeDialog.test.tsx
@@ -27,13 +27,26 @@ vi.mock("../api/client", async () => {
       ...actual.api,
       lorawanProvisionEsphome: vi.fn(),
       lorawanActivation: vi.fn(),
+      fleetPush: vi.fn(),
     },
   };
 });
 
+// usb-detect.ts dynamic-imports esptool-js, which is browser-only. Mock both
+// functions so the WebSerial detect button can be exercised in jsdom.
+vi.mock("../lib/usb-detect", () => ({
+  detectChip: vi.fn(),
+  isWebSerialSupported: vi.fn(() => "yes"),
+}));
+
+import { detectChip, isWebSerialSupported } from "../lib/usb-detect";
+const mockDetectChip = detectChip as unknown as ReturnType<typeof vi.fn>;
+const mockSupported = isWebSerialSupported as unknown as ReturnType<typeof vi.fn>;
+
 const mockApi = api as unknown as {
   lorawanProvisionEsphome: ReturnType<typeof vi.fn>;
   lorawanActivation: ReturnType<typeof vi.fn>;
+  fleetPush: ReturnType<typeof vi.fn>;
 };
 
 function design(overrides: Partial<Design> = {}): Design {
@@ -60,6 +73,9 @@ function design(overrides: Partial<Design> = {}): Design {
 beforeEach(() => {
   mockApi.lorawanProvisionEsphome.mockReset();
   mockApi.lorawanActivation.mockReset();
+  mockApi.fleetPush.mockReset();
+  mockDetectChip.mockReset();
+  mockSupported.mockReturnValue("yes");
 });
 
 afterEach(() => {
@@ -216,5 +232,154 @@ describe("error path", () => {
     expect(await screen.findByText(/422: design\.lorawan\.payload/i)).toBeTruthy();
     // The result block didn't render, so Provision stays available for a retry.
     expect(screen.getByRole("button", { name: /Provision →/i })).toBeTruthy();
+  });
+});
+
+describe("DevEUI auto-derive from chip", () => {
+  it("fills the DevEUI field from the eFuse MAC and shows a chip + MAC hint", async () => {
+    const user = userEvent.setup();
+    // 10:52:1c:66:b6:e0 -> EUI-64 by inserting 0xFFFE → 10521cfffe66b6e0
+    mockDetectChip.mockResolvedValue({ chipName: "ESP32-D0WD-V3", mac: "10:52:1c:66:b6:e0" });
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await user.click(screen.getByRole("button", { name: /Detect from chip/i }));
+
+    await waitFor(() => {
+      const input = screen.getByPlaceholderText(/70b3d57ed0001234/i) as HTMLInputElement;
+      expect(input.value).toBe("10521cfffe66b6e0");
+    });
+    expect(screen.getByText(/Derived from ESP32-D0WD-V3.*10:52:1c:66:b6:e0/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Provision →/i })).toBeEnabled();
+  });
+
+  it("surfaces a friendly error when the chip detects but no MAC is available", async () => {
+    const user = userEvent.setup();
+    mockDetectChip.mockResolvedValue({ chipName: "ESP32-D0WD-V3", mac: undefined });
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await user.click(screen.getByRole("button", { name: /Detect from chip/i }));
+
+    expect(await screen.findByText(/no MAC available/i)).toBeTruthy();
+    expect((screen.getByPlaceholderText(/70b3d57ed0001234/i) as HTMLInputElement).value).toBe("");
+  });
+
+  it("surfaces detectChip errors (user cancel, sync failure) inline", async () => {
+    const user = userEvent.setup();
+    mockDetectChip.mockRejectedValue(new Error("port-picker dismissed"));
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await user.click(screen.getByRole("button", { name: /Detect from chip/i }));
+
+    expect(await screen.findByText(/detect failed: port-picker dismissed/i)).toBeTruthy();
+  });
+
+  it("disables Detect when WebSerial isn't available and explains why", () => {
+    mockSupported.mockReturnValue("no");
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    expect(screen.getByRole("button", { name: /Detect from chip/i })).toBeDisabled();
+    expect(screen.getByText(/WebSerial isn't available/i)).toBeTruthy();
+    expect(mockDetectChip).not.toHaveBeenCalled();
+  });
+
+  it("clears the detection hint when the user manually edits the DevEUI", async () => {
+    const user = userEvent.setup();
+    mockDetectChip.mockResolvedValue({ chipName: "ESP32-D0WD-V3", mac: "10:52:1c:66:b6:e0" });
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await user.click(screen.getByRole("button", { name: /Detect from chip/i }));
+    await waitFor(() => expect(screen.queryByText(/Derived from/i)).toBeTruthy());
+
+    await user.type(screen.getByPlaceholderText(/70b3d57ed0001234/i), "0");
+    expect(screen.queryByText(/Derived from/i)).toBeNull();
+  });
+});
+
+describe("push to fleet", () => {
+  async function provisionFirst(user: ReturnType<typeof userEvent.setup>) {
+    mockApi.lorawanProvisionEsphome.mockResolvedValue({
+      secrets: {
+        dev_eui: "70b3d57ed0001234",
+        join_eui: "0000000000000000",
+        app_key: "00112233445566778899aabbccddeeff",
+      },
+      chirpstack: { application_id: "app-1", device_profile_id: "dp-1" },
+      band: "US915",
+      sub_band: 2,
+    });
+    mockApi.lorawanActivation.mockResolvedValue({ dev_eui: "70b3d57ed0001234", joined: false });
+    await user.type(screen.getByPlaceholderText(/70b3d57ed0001234/i), "70b3d57ed0001234");
+    await user.click(screen.getByRole("button", { name: /Provision →/i }));
+    // Wait for the success block (and the push button) to render.
+    await waitFor(() => expect(screen.getByRole("button", { name: /Push to fleet →/i })).toBeTruthy());
+  }
+
+  it("hides the push button until provision succeeds", () => {
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    expect(screen.queryByRole("button", { name: /Push to fleet →/i })).toBeNull();
+  });
+
+  it("posts the secrets minted by provision-esphome through to /fleet/push", async () => {
+    const user = userEvent.setup();
+    mockApi.fleetPush.mockResolvedValue({
+      filename: "lw-spike.yaml",
+      created: true,
+      run_id: "run-1",
+      enqueued: 1,
+    });
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await provisionFirst(user);
+    await user.click(screen.getByRole("button", { name: /Push to fleet →/i }));
+
+    await waitFor(() => {
+      expect(mockApi.fleetPush).toHaveBeenCalledWith({
+        design: expect.objectContaining({ id: "lw-spike" }),
+        compile: true,
+        lorawan_secrets: {
+          dev_eui: "70b3d57ed0001234",
+          join_eui: "0000000000000000",
+          app_key: "00112233445566778899aabbccddeeff",
+        },
+      });
+    });
+    // Text is split across nested <code> elements; assert on the parts
+    // separately rather than reaching for a regex across element boundaries.
+    expect(await screen.findByText(/Created/i)).toBeTruthy();
+    expect(screen.getByText("lw-spike.yaml")).toBeTruthy();
+    expect(screen.getByText("run-1")).toBeTruthy();
+  });
+
+  it("disables the push button after a successful push (no double-push)", async () => {
+    const user = userEvent.setup();
+    mockApi.fleetPush.mockResolvedValue({
+      filename: "lw-spike.yaml",
+      created: true,
+      run_id: null,
+      enqueued: 0,
+    });
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await provisionFirst(user);
+    await user.click(screen.getByRole("button", { name: /Push to fleet →/i }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /^Pushed$/i })).toBeDisabled());
+  });
+
+  it("surfaces the server detail on fleet push failure (e.g. 503 unconfigured)", async () => {
+    const user = userEvent.setup();
+    mockApi.fleetPush.mockRejectedValue(
+      new ApiError(503, "POST /fleet/push -> 503", {
+        detail: "fleet not configured (set FLEET_URL and FLEET_TOKEN)",
+      }),
+    );
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await provisionFirst(user);
+    await user.click(screen.getByRole("button", { name: /Push to fleet →/i }));
+
+    expect(await screen.findByText(/push failed: 503: fleet not configured/i)).toBeTruthy();
+    // Pre-failed state — Push to fleet stays available for a retry.
+    expect(screen.getByRole("button", { name: /Push to fleet →/i })).toBeEnabled();
   });
 });

--- a/web/src/components/LorawanProvisionEsphomeDialog.tsx
+++ b/web/src/components/LorawanProvisionEsphomeDialog.tsx
@@ -21,6 +21,8 @@ import type {
   LorawanActivationResponse,
   LorawanProvisionEsphomeResponse,
 } from "../types/api";
+import { detectChip, isWebSerialSupported } from "../lib/usb-detect";
+import { macToEui64 } from "../lib/provision";
 
 const ACTIVATION_POLL_INTERVAL_MS = 3000;
 const DEV_EUI_RE = /^[0-9a-fA-F]{16}$/;
@@ -70,7 +72,11 @@ export function LorawanProvisionEsphomeDialog({ design, onClose }: Props) {
   const [activation, setActivation] = useState<LorawanActivationResponse | null>(null);
   const [activationErr, setActivationErr] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [detecting, setDetecting] = useState(false);
+  const [detected, setDetected] = useState<{ chipName: string; mac: string } | null>(null);
+  const [detectErr, setDetectErr] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const webSerial = isWebSerialSupported() === "yes";
 
   // Reset the copy-feedback flag a couple seconds after the user copies, so
   // the button doesn't stay green forever on a multi-paste workflow.
@@ -151,6 +157,75 @@ export function LorawanProvisionEsphomeDialog({ design, onClose }: Props) {
     }
   }
 
+  async function handleDetect() {
+    setDetectErr(null);
+    setDetected(null);
+    setDetecting(true);
+    try {
+      // detectChip() triggers the WebSerial port-picker, runs esptool-js's
+      // sync, reads the eFuse MAC, then disconnects. The chip name + MAC come
+      // back; macToEui64 derives a stable EUI-64 from the MAC-48 by inserting
+      // 0xFFFE in the middle (standard IEEE mapping).
+      const chip = await detectChip();
+      if (!chip.mac) {
+        throw new Error(
+          "chip detected but no MAC available -- try unplugging/reconnecting, or enter the DevEUI manually",
+        );
+      }
+      const eui = macToEui64(chip.mac);
+      setDetected({ chipName: chip.chipName, mac: chip.mac });
+      setDevEui(eui);
+    } catch (e) {
+      setDetectErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setDetecting(false);
+    }
+  }
+
+  // "Push to fleet" wires the secrets returned by /lorawan/provision-esphome
+  // through to /fleet/push so the rendered YAML the fleet stores carries
+  // them inline -- skipping the manual "edit fleet's secrets.yaml" step.
+  // State machine: idle -> pushing -> pushed | error. Independent of the
+  // activation poll so the user can fire the push and watch the join in
+  // parallel.
+  type PushState =
+    | { kind: "idle" }
+    | { kind: "pushing" }
+    | { kind: "pushed"; filename: string; created: boolean; run_id: string | null }
+    | { kind: "error"; message: string };
+  const [pushState, setPushState] = useState<PushState>({ kind: "idle" });
+
+  async function handlePushToFleet() {
+    if (!result) return;
+    setPushState({ kind: "pushing" });
+    try {
+      const r = await api.fleetPush({
+        design,
+        compile: true,
+        lorawan_secrets: {
+          dev_eui: result.secrets.dev_eui,
+          join_eui: result.secrets.join_eui,
+          app_key: result.secrets.app_key,
+        },
+      });
+      setPushState({
+        kind: "pushed",
+        filename: r.filename,
+        created: r.created,
+        run_id: r.run_id ?? null,
+      });
+    } catch (e) {
+      let msg: string;
+      if (e instanceof ApiError) {
+        const detail = (e.body as { detail?: unknown } | undefined)?.detail;
+        msg = `${e.status}: ${typeof detail === "string" ? detail : e.message}`;
+      } else {
+        msg = e instanceof Error ? e.message : String(e);
+      }
+      setPushState({ kind: "error", message: msg });
+    }
+  }
+
   const devEuiValid = DEV_EUI_RE.test(devEui);
   const canProvision = eligible && devEuiValid && !provisioning && !result;
 
@@ -219,18 +294,45 @@ export function LorawanProvisionEsphomeDialog({ design, onClose }: Props) {
               <label className="block text-[11px] uppercase tracking-wide text-zinc-500">
                 DevEUI (16 hex chars)
               </label>
-              <input
-                type="text"
-                value={devEui}
-                onChange={(e) => setDevEui(e.target.value)}
-                disabled={!!result}
-                placeholder="70b3d57ed0001234"
-                className="w-full rounded-md border border-zinc-800 bg-black/40 px-2 py-1.5 font-mono text-xs text-zinc-100 placeholder:text-zinc-600 focus:border-zinc-600 focus:outline-none disabled:opacity-60"
-              />
-              <div className="text-[11px] text-zinc-500">
-                Manual override per the locked decision. MAC-derivation from the chip's eFuse over
-                WebSerial lands in a follow-up.
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={devEui}
+                  onChange={(e) => {
+                    setDevEui(e.target.value);
+                    // A manual edit invalidates the previous detection hint.
+                    setDetected(null);
+                  }}
+                  disabled={!!result}
+                  placeholder="70b3d57ed0001234"
+                  className="flex-1 rounded-md border border-zinc-800 bg-black/40 px-2 py-1.5 font-mono text-xs text-zinc-100 placeholder:text-zinc-600 focus:border-zinc-600 focus:outline-none disabled:opacity-60"
+                />
+                <button
+                  onClick={handleDetect}
+                  disabled={!webSerial || detecting || !!result}
+                  className="rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-[11px] text-zinc-200 hover:bg-zinc-800 disabled:opacity-40"
+                  title={
+                    webSerial
+                      ? "Read the chip's eFuse MAC over WebSerial and derive the DevEUI (MAC-48 → EUI-64)"
+                      : "WebSerial is unavailable in this browser; enter the DevEUI manually."
+                  }
+                >
+                  {detecting ? "Detecting…" : "Detect from chip"}
+                </button>
               </div>
+              <div className="text-[11px] text-zinc-500">
+                {webSerial
+                  ? "Derive from the chip's eFuse MAC over WebSerial, or type a manual override."
+                  : "Manual entry only — WebSerial isn't available (try Chrome/Edge on desktop)."}
+              </div>
+              {detected && (
+                <div className="text-[11px] text-emerald-300">
+                  Derived from {detected.chipName} (MAC {detected.mac}).
+                </div>
+              )}
+              {detectErr && (
+                <div className="text-[11px] text-amber-400">detect failed: {detectErr}</div>
+              )}
               {!devEuiValid && devEui.length > 0 && (
                 <div className="text-[11px] text-amber-400">
                   Expected 16 hex characters; got {devEui.length}.
@@ -277,6 +379,50 @@ export function LorawanProvisionEsphomeDialog({ design, onClose }: Props) {
                   {copied ? "Copied" : "Copy"}
                 </button>
               </div>
+            </div>
+          )}
+
+          {/* Push to fleet -- inline the secrets in the YAML so the operator
+              doesn't need to edit fleet's secrets.yaml separately. */}
+          {result && (
+            <div className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-[11px] uppercase tracking-wide text-zinc-500">
+                    push to fleet
+                  </div>
+                  <div className="mt-1 text-xs text-zinc-400">
+                    Push the rendered YAML to fleet-for-esphome with these LoRaWAN keys
+                    inlined, and enqueue an OTA compile.
+                  </div>
+                </div>
+                <button
+                  onClick={handlePushToFleet}
+                  disabled={pushState.kind === "pushing" || pushState.kind === "pushed"}
+                  className="rounded-md bg-blue-500/20 px-3 py-1.5 text-sm text-blue-100 ring-1 ring-blue-400/40 enabled:hover:bg-blue-500/30 disabled:opacity-40"
+                >
+                  {pushState.kind === "pushing"
+                    ? "Pushing…"
+                    : pushState.kind === "pushed"
+                      ? "Pushed"
+                      : "Push to fleet →"}
+                </button>
+              </div>
+              {pushState.kind === "pushed" && (
+                <div className="mt-2 text-xs text-emerald-300">
+                  {pushState.created ? "Created" : "Updated"}{" "}
+                  <code className="rounded-md bg-emerald-900/40 px-1">{pushState.filename}</code>{" "}
+                  on the fleet.
+                  {pushState.run_id && (
+                    <> Compile enqueued (<code>{pushState.run_id}</code>).</>
+                  )}
+                </div>
+              )}
+              {pushState.kind === "error" && (
+                <div className="mt-2 text-xs text-rose-400">
+                  push failed: {pushState.message}
+                </div>
+              )}
             </div>
           )}
 

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -1043,8 +1043,17 @@ def create_app(
             raise HTTPException(status_code=422, detail=e.errors()) from e
         try:
             target = get_target(d.target)
-            artifacts = target.generate(d, lib)
-            yaml_text = artifacts.get("firmware.yaml")
+            # When the caller supplies lorawan_secrets, render directly so the
+            # literals are substituted for the !secret references in the
+            # `lorawan:` block. The TargetPlugin contract stays fixed; only the
+            # esphome target consumes the override today (the standalone
+            # lorawan target's serial-provisioning flow doesn't need it).
+            if req.lorawan_secrets and d.target == "esphome":
+                from wirestudio.generate import yaml_gen
+                yaml_text = yaml_gen.render_yaml(d, lib, lorawan_secrets=req.lorawan_secrets)
+            else:
+                artifacts = target.generate(d, lib)
+                yaml_text = artifacts.get("firmware.yaml")
             if not yaml_text:
                 raise ValueError(f"target '{d.target}' does not produce firmware.yaml")
         except (FileNotFoundError, ValueError, KeyError) as e:

--- a/wirestudio/api/schemas.py
+++ b/wirestudio/api/schemas.py
@@ -236,6 +236,17 @@ class FleetPushRequest(_S):
     strict: bool = Field(
         default=False, description="Refuse the push when warn/error compatibility entries remain."
     )
+    lorawan_secrets: Optional[dict[str, str]] = Field(
+        default=None,
+        description=(
+            "Optional `{dev_eui, join_eui, app_key}` mapping. When present, "
+            "the renderer substitutes these literal values for the matching "
+            "`!secret <name>` references in the lorawan: block, so the pushed "
+            "YAML carries the keys minted by /lorawan/provision-esphome "
+            "without needing a separate write to the fleet's secrets.yaml. "
+            "Any key not provided keeps its !secret reference."
+        ),
+    )
 
 
 class FleetPushResponse(_S):

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -352,13 +352,27 @@ _LORAWAN_FOR_ESPHOME_REPO = "moellere/lorawan-for-esphome"
 _LORAWAN_FOR_ESPHOME_REF = "main"  # TODO(lorawan): pin to a commit SHA after the join test runs
 
 
-def _emit_lorawan_blocks(out: dict[str, Any], design: Design, library: Library) -> None:
+def _emit_lorawan_blocks(
+    out: dict[str, Any],
+    design: Design,
+    library: Library,
+    lorawan_secrets: dict[str, str] | None = None,
+) -> None:
     """Emit the ESPHome external-component path for `lorawan-for-esphome`:
     `external_components:`, the `lorawan:` block (radio config from the board
     library, keys via !secret), and one `sensor: - platform: lorawan` binding
     per `design.lorawan.payload` entry. No-op unless `design.lorawan.payload`
     is non-empty -- the standalone Arduino path (target="lorawan") is rendered
     elsewhere and unaffected.
+
+    `lorawan_secrets` is an optional mapping with the three literal keys
+    (`dev_eui` / `join_eui` / `app_key`); when present, each key replaces the
+    matching `!secret <name>` reference with a literal string in the rendered
+    YAML. Used by the fleet push path so the rendered config carries the keys
+    the provisioning step minted, without requiring a separate write to the
+    fleet's secrets.yaml. Falls back to `!secret <name>` references for any
+    key not in the override -- the dev-loop / `esphome config` gate keeps
+    working.
     """
     lw = design.lorawan
     if lw is None or not lw.payload:
@@ -393,13 +407,19 @@ def _emit_lorawan_blocks(out: dict[str, Any], design: Design, library: Library) 
     if radio.dio2_as_rf_switch:
         radio_block["dio2_as_rf_switch"] = radio.dio2_as_rf_switch
 
+    overrides = lorawan_secrets or {}
+
+    def _secret_or_literal(name: str) -> Any:
+        value = overrides.get(name)
+        return value if value else Secret(name)
+
     lorawan_block: dict[str, Any] = {
         "id": "lw",
         "region": lw.region,
         "sub_band": lw.sub_band,
-        "dev_eui":  Secret("dev_eui"),
-        "join_eui": Secret("join_eui"),
-        "app_key":  Secret("app_key"),
+        "dev_eui":  _secret_or_literal("dev_eui"),
+        "join_eui": _secret_or_literal("join_eui"),
+        "app_key":  _secret_or_literal("app_key"),
         "radio": radio_block,
     }
     out["lorawan"] = lorawan_block
@@ -412,7 +432,12 @@ def _emit_lorawan_blocks(out: dict[str, Any], design: Design, library: Library) 
         })
 
 
-def build_yaml_dict(design: Design, library: Library) -> dict[str, Any]:
+def build_yaml_dict(
+    design: Design,
+    library: Library,
+    *,
+    lorawan_secrets: dict[str, str] | None = None,
+) -> dict[str, Any]:
     board = library.board(design.board.library_id)
     out: dict[str, Any] = {}
 
@@ -500,7 +525,7 @@ def build_yaml_dict(design: Design, library: Library) -> dict[str, Any]:
     for comp in design.components:
         _deep_merge(out, _render_component(comp, design, library, auto_params))
 
-    _emit_lorawan_blocks(out, design, library)
+    _emit_lorawan_blocks(out, design, library, lorawan_secrets=lorawan_secrets)
 
     if extras:
         _deep_merge(out, extras)
@@ -541,8 +566,13 @@ def _unquote_quoted_tag(match: re.Match[str]) -> str:
     return match.group(0)
 
 
-def render_yaml(design: Design, library: Library) -> str:
-    data = build_yaml_dict(design, library)
+def render_yaml(
+    design: Design,
+    library: Library,
+    *,
+    lorawan_secrets: dict[str, str] | None = None,
+) -> str:
+    data = build_yaml_dict(design, library, lorawan_secrets=lorawan_secrets)
     text = yaml.dump(
         data,
         sort_keys=False,


### PR DESCRIPTION
## Summary

Two pieces for tomorrow's hardware-join test, both folding the manual "edit fleet's secrets.yaml" step out of the spike flow.

### 1. Fleet push inlines LoRaWAN secrets (the requested follow-up)

- `POST /fleet/push` gains optional `lorawan_secrets: {dev_eui, join_eui, app_key}` in the body.
- When present, `render_yaml()` substitutes literal values for the matching `!secret <name>` references in the `lorawan:` block, so the YAML the fleet stores carries the keys minted by `/lorawan/provision-esphome` **without a separate write to the fleet's `secrets.yaml`**.
- Default behaviour unchanged: no override → `!secret` references as today (backward compatible).
- Partial override allowed (one key only — defaults the others to `!secret`).
- All-digit `join_eui` (e.g. zero EUI) auto-quotes as a string (PyYAML default; pinned in a test so a regression is loud).
- No-op on non-LoRaWAN designs.
- **The provision dialog** gains a **"Push to fleet"** button next to the secrets block: provision → push → compile flows through one click, with the resulting filename + compile run id surfaced inline.

### 2. WebSerial DevEUI auto-derive (restoration)

The "Detect from chip" button + handler I added in a follow-up commit on #115's branch **didn't make it into main** (single-commit push lost the follow-up commit on the same branch). Restored here in the same file edit.

- Reuses the existing `detectChip()` + `macToEui64()` helpers.
- Disabled with a hint when WebSerial isn't available (Firefox / mobile).
- Manual entry remains; editing the field clears the detection hint.

### Why both in one PR

Both touch `LorawanProvisionEsphomeDialog.tsx` and both are needed for the hardware-join test tomorrow. Splitting would mean two diffs against the same component and two reviews.

### Boundary preserved

The `TargetPlugin.generate()` contract is unchanged — the fleet_push handler calls `render_yaml()` directly only when `lorawan_secrets` is supplied AND `d.target == "esphome"`. The standalone Arduino target's serial-provisioning flow is untouched.

## Test plan

- [x] `pytest -q` — 804 passed, 11 skipped (+6 server-side: 4 yaml_gen override paths, 3 fleet endpoint paths)
- [x] `npx vitest run` — 180 passed (+9: 4 push-to-fleet dialog, 5 detect-from-chip dialog)
- [x] `npx tsc -b` — clean
- [x] `npx eslint <new files>` — clean
- [x] `npx vite build` — production build OK (367 KB index, 101 KB gzip)
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_