### PR TITLE
docs: freshness pass ahead of the v0.17 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@ Agent-driven IoT device design tool. Describe a goal (or pick parts);
 get ESPHome YAML, an ASCII wiring diagram, and a BOM that compile
 under upstream ESPHome.
 
-A second generation target builds and flashes **LoRaWAN** firmware
-(RadioLib + LoRaWAN_ESP32) for US915 radio boards — TTGO T-Beam /
-LoRa32, Heltec WiFi LoRa 32 V2/V3 — over WebSerial from the browser, and
-provisions the device against ChirpStack.
+Two LoRaWAN paths share the studio. The standalone target builds and
+flashes RadioLib + LoRaWAN_ESP32 firmware over WebSerial. The newer
+external-component path emits ESPHome YAML referencing
+[`lorawan-for-esphome`](https://github.com/moellere/lorawan-for-esphome),
+so the LoRaWAN device joins the same ESPHome / fleet-for-esphome build
+pipeline as every other device — provisioning, key handling, and
+join-status polling all from the web UI. Both paths target US915 radio
+boards (TTGO T-Beam / LoRa32, Heltec WiFi LoRa 32 V2 / V3) and
+provision against ChirpStack.
 
 Produces ESPHome configs but is not affiliated with the ESPHome
 project — see [`weirded/fleet-for-esphome`](https://github.com/weirded/fleet-for-esphome)
@@ -28,10 +33,12 @@ Detailed docs live in [`docs/`](docs/):
 
 ## Status
 
-`v0.13.0` — on PyPI (`pip install wirestudio`). The studio has wide
+`v0.16.0` — on PyPI (`pip install wirestudio`). The studio has wide
 surface area (YAML, schematic, enclosure, agent, MCP server, fleet
-handoff, web UI, a LoRaWAN flash/provision target) and a set of things
-actually verified against upstream tools. Three of the four priority
+handoff, web UI, two LoRaWAN flash/provision paths — standalone Arduino
+and an external-component path that emits ESPHome YAML referencing
+`lorawan-for-esphome`) and a set of things actually verified against
+upstream tools. Three of the four priority
 tiers (YAML, wiring schema, enclosure) are now gated in CI, and **every
 library component and board is exercised by a bundled example** that
 passes those gates. This section is honest about which is which, ordered
@@ -72,7 +79,7 @@ that pin moves, this line moves with it.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:v0.13.0
+  ghcr.io/moellere/wirestudio:v0.16.0
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,7 +11,7 @@ FastAPI serves the API and the built SPA from one process.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:v0.13.0
+  ghcr.io/moellere/wirestudio:v0.16.0
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +
@@ -23,7 +23,7 @@ Available tags:
 
 | Tag | What it tracks |
 |---|---|
-| `:0.13.0` / `:0.13` / `:latest` | the v0.13.0 release |
+| `:0.16.0` / `:0.16` / `:latest` | the v0.16.0 release |
 | `:main` | latest commit on `main` (rolling) |
 | `:dev` | latest commit on `dev` (rolling, pre-release) |
 | `:sha-<short>` | a specific commit |
@@ -39,22 +39,31 @@ of them, just with the corresponding feature turned off. See
 | `FLEET_URL` + `FLEET_TOKEN` | fleet-for-esphome push (`/fleet/*`) |
 | `THINGIVERSE_API_KEY` | enclosure search (`/enclosure/search`) |
 | `WIRESTUDIO_MCP_TOKEN` | bearer token for the `/mcp` endpoint (auto-generated if unset) |
-| `CHIRPSTACK_API_URL` + `CHIRPSTACK_API_TOKEN` | LoRaWAN device provisioning against ChirpStack (`/lorawan/provision`) |
+| `CHIRPSTACK_API_URL` + `CHIRPSTACK_API_TOKEN` | LoRaWAN device provisioning against ChirpStack (`/lorawan/provision`, `/lorawan/provision-esphome`) |
 
 ### LoRaWAN compile worker
 
-The default image is lean — it has no PlatformIO toolchain, so the LoRaWAN
-target's `/lorawan/compile` endpoint returns "PlatformIO not found" and the
-**Flash LoRaWAN firmware** flow can't build. To run that feature in a
-deployment, use the **`-lorawan` image variant** (or build it yourself:
-`docker build --build-arg WITH_LORAWAN=true -t wirestudio:lorawan .`). It adds
-PlatformIO + the `[lorawan]` extra and pre-compiles every radio board so the
-espressif32 toolchain is already warm — a bigger image, but `/lorawan/compile`
-returns a cache hit on first use. Pair it with `CHIRPSTACK_API_URL` +
-`CHIRPSTACK_API_TOKEN` (see
-[Integrations](integrations.md#lorawan--chirpstack)). WebSerial flashing happens
-in the user's browser, so the device only needs to reach *their* machine, not
-the server.
+The default image is lean — it has no PlatformIO toolchain, so the
+**standalone Arduino LoRaWAN target's** `/lorawan/compile` endpoint
+returns "PlatformIO not found" and the **Flash LoRaWAN firmware** flow
+can't build. To run that feature in a deployment, use the **`-lorawan`
+image variant** (or build it yourself:
+`docker build --build-arg WITH_LORAWAN=true -t wirestudio:lorawan .`). It
+adds PlatformIO + the `[lorawan]` extra and pre-compiles every radio
+board so the espressif32 toolchain is already warm — a bigger image, but
+`/lorawan/compile` returns a cache hit on first use.
+
+The **external-component LoRaWAN path** (`Design.target: "esphome"` +
+`lorawan.payload`) doesn't need the `-lorawan` image variant — the
+LoRaWAN device's firmware is built by ESPHome inside fleet-for-esphome
+the same way every other device is, so the studio image stays lean. The
+default image is enough; only the `/lorawan/provision-esphome` endpoint
+needs ChirpStack credentials.
+
+Pair either path with `CHIRPSTACK_API_URL` + `CHIRPSTACK_API_TOKEN` (see
+[Integrations](integrations.md#lorawan--chirpstack)). WebSerial flashing
+happens in the user's browser, so the device only needs to reach *their*
+machine, not the server.
 
 ## Kubernetes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,17 +118,36 @@ gate (every component + board names a real KiCad footprint that resolves
 in the pinned libraries) landed as step 1 — the foundation a `.kicad_pcb`
 emit builds on — but the layout itself is not yet in flight.
 
-**LoRaWAN target (0.13).** *Works — hardware-validated.* A second
-generation target alongside ESPHome, on a `wirestudio.targets` plugin
-seam (the `esphome` target wraps the existing generators in place).
-Builds RadioLib + LoRaWAN_ESP32 firmware for US915 radio boards (TTGO
-LoRa32 / T-Beam, Heltec WiFi LoRa 32 V2/V3), flashes it over WebSerial
-from the browser, and provisions the device against ChirpStack — the
-uplink payload and the ChirpStack `decodeUplink` codec are generated
-from one field spec so they stay in lockstep. Every radio board's
-firmware builds in CI ([`lorawan-firmware`](../.github/workflows/lorawan-firmware.yml));
-validated end-to-end on a TTGO T-Beam against live ChirpStack 4.17.
-Behind a `[lorawan]` install extra. See the [LoRaWAN docs](lorawan/).
+**LoRaWAN target (0.13 standalone, 0.16+ external-component).** *Works —
+hardware-validated on the standalone path; external-component path
+shipped, hardware join verification in progress.* Two paths share the
+`wirestudio.targets` plugin seam:
+
+- **Standalone Arduino path** (`target: "lorawan"`). Builds RadioLib +
+  LoRaWAN_ESP32 firmware for US915 radio boards (TTGO LoRa32 / T-Beam,
+  Heltec WiFi LoRa 32 V2/V3), flashes it over WebSerial from the
+  browser, and provisions the device against ChirpStack. Every radio
+  board's firmware builds in CI
+  ([`lorawan-firmware`](../.github/workflows/lorawan-firmware.yml));
+  validated end-to-end on a TTGO T-Beam against live ChirpStack 4.17.
+- **External-component path** (`target: "esphome"` + `lorawan.payload`).
+  When `design.lorawan.payload` is set, the YAML generator emits an
+  `external_components: github://moellere/lorawan-for-esphome@<ref>`
+  block plus a `lorawan:` config (radio block, region, keys via
+  `!secret`, payload sensor bindings). The device joins the same
+  ESPHome / fleet-for-esphome pipeline as every other device.
+  Provisioning is one endpoint
+  (`POST /lorawan/provision-esphome`) that mints an AppKey, registers
+  the device in ChirpStack, flushes its DevNonces, and returns the
+  three secrets ready for `secrets.yaml`. The web flasher has a
+  one-click flow: detect chip → derive DevEUI from eFuse MAC → provision
+  → push to fleet (secrets inlined) → poll activation. See the
+  [LoRaWAN docs](lorawan/) — `esphome-component-pivot.md` for the
+  architecture, `workflow-integration.md` for the orchestration.
+
+Both paths sit behind a `[lorawan]` install extra. The uplink payload
+and the ChirpStack `decodeUplink` codec are generated from one field
+spec so they stay in lockstep.
 
 **Plumbing — already shipped.** API (`0.2`), web UI (`0.3` +
 `0.6+`), USB bootstrap (`0.4`), agent (`0.5` + streaming), CSP

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -85,10 +85,13 @@ pin map.
 
 ## LoRaWAN / ChirpStack
 
-A second generation target (`Design.target: "lorawan"`) for US915 radio
-boards — TTGO LoRa32 / T-Beam (SX1276) and Heltec WiFi LoRa 32 V2 (SX1276)
-/ V3 (SX1262). The **Flash LoRaWAN firmware** header button (advanced
-mode) drives the full loop in the browser:
+Two paths for US915 radio boards — TTGO LoRa32 / T-Beam (SX1276), Heltec
+WiFi LoRa 32 V2 (SX1276) / V3 (SX1262).
+
+### Standalone Arduino path (`Design.target: "lorawan"`)
+
+The **Flash LoRaWAN firmware** header button (advanced mode) drives the
+full loop in the browser:
 
 1. **Build** — `POST /lorawan/compile` builds RadioLib + LoRaWAN_ESP32
    firmware in an in-pod PlatformIO worker, streaming the log over SSE
@@ -104,22 +107,55 @@ mode) drives the full loop in the browser:
 
 The uplink payload packing (C++) and the ChirpStack JS codec come from
 **one field spec** (`wirestudio/targets/lorawan/codec.py`), so they never
-drift. ChirpStack access is configured by `CHIRPSTACK_API_URL` +
+drift.
+
+### External-component path (`Design.target: "esphome"` + `lorawan.payload`)
+
+The newer path emits ESPHome YAML referencing
+[`lorawan-for-esphome`](https://github.com/moellere/lorawan-for-esphome),
+so the LoRaWAN device joins the same ESPHome / fleet-for-esphome
+pipeline as every other device. When `design.lorawan.payload` is
+non-empty, the renderer adds an `external_components:` block pinned to
+a ref, a `lorawan:` config (radio block from the board library, region,
+keys via `!secret`), and one `sensor: - platform: lorawan` binding per
+payload field. The **Provision LoRaWAN device** header button (key
+icon) drives the orchestration loop:
+
+1. **Detect** — "Detect from chip" reads the eFuse MAC over WebSerial
+   and derives the EUI-64 DevEUI (`detectChip()` + `macToEui64()`).
+   Manual override remains.
+2. **Provision** — `POST /lorawan/provision-esphome` mints an AppKey,
+   registers the device against a path-specific device profile
+   (`wirestudio-esphome-<region>-sub<n>`), flushes its DevNonces, and
+   returns the three keys formatted for `secrets.yaml`. The AppKey is
+   ephemeral and never persisted to `design.json`.
+3. **Push** — "Push to fleet" forwards the rendered YAML to
+   fleet-for-esphome with the minted secrets inlined into the
+   `lorawan:` block (via the `lorawan_secrets` field on
+   `POST /fleet/push`), so the fleet's `secrets.yaml` doesn't need a
+   separate write. Compile is enqueued in the same call.
+4. **Join** — the dialog polls `GET /lorawan/activation/{dev_eui}`
+   every few seconds; the join indicator flips when ChirpStack reports
+   the OTAA join landed.
+
+Both paths share ChirpStack config: `CHIRPSTACK_API_URL` +
 `CHIRPSTACK_API_TOKEN` (a UI-generated API token, never the JWT signing
-secret); the AppKey is ephemeral and never written to `design.json`.
+secret).
 
 Heavy deps (`grpcio`, `chirpstack-api`, `platformio`) live behind a
 `pip install wirestudio[lorawan]` extra and are lazy-imported, so a plain
 install stays light. Background + the live ChirpStack setup are in
-[`docs/lorawan/`](lorawan/).
+[`docs/lorawan/`](lorawan/) — `esphome-component-pivot.md` covers the
+architecture decision, `workflow-integration.md` the orchestration steps.
 
-**Limitations (current).** The LoRaWAN target is **US915 sub-band 2 only**
-and **ChirpStack only**. Region/sub-band are hard-pinned end to end (the
-device firmware's datarate caps, the ChirpStack device profile, and the
-provisioning response), so a device built for any other band (EU868, AU915,
-AS923, …) silently won't join — multi-region is a tracked backlog item
-(safety-sensitive, so it's not half-shipped). The network server is
-ChirpStack v4 over gRPC; TTN / other servers aren't wired yet.
+**Limitations (current).** Both paths are **US915 sub-band 2 only** and
+**ChirpStack only** in practice — the IR accepts EU868 / AU915 / AS923
+on the external-component path, but the device-side support and the
+ChirpStack profile naming have only been exercised end to end on US915
+sub-2. Multi-region is a tracked backlog item (safety-sensitive, so
+it's not half-shipped). The network server is ChirpStack v4 over gRPC;
+TTN / other servers aren't wired yet. The external-component path is
+hardware-join-verified pending a live test against a real gateway.
 
 ## MCP server
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -27,11 +27,18 @@
   parametric OpenSCAD enclosure (`.scad`), and a SKiDL Python script
   the user runs locally to produce a `.kicad_sch`. Bundled examples
   pinned as goldens.
-- **LoRaWAN (radio boards).** Build RadioLib + LoRaWAN_ESP32 firmware
-  for a US915 radio board (TTGO LoRa32 / T-Beam, Heltec WiFi LoRa 32
-  V2/V3), flash it over WebSerial, and provision the device against
-  ChirpStack — from the **Flash LoRaWAN firmware** header button. See
-  [Integrations](integrations.md#lorawan--chirpstack).
+- **LoRaWAN (radio boards).** Two flows for US915 radio boards (TTGO
+  LoRa32 / T-Beam, Heltec WiFi LoRa 32 V2 / V3):
+  - **Flash LoRaWAN firmware** (radio icon, advanced mode) builds the
+    standalone RadioLib + LoRaWAN_ESP32 path and flashes over WebSerial
+    with runtime serial provisioning. Hardware-validated.
+  - **Provision LoRaWAN device** (key icon) drives the
+    `lorawan-for-esphome` external-component path: detect the chip's
+    eFuse MAC, mint keys against ChirpStack, push to fleet with the
+    secrets inlined, watch the OTAA join land. The device joins the
+    same ESPHome / fleet-for-esphome compile path as every other
+    design.
+  See [Integrations](integrations.md#lorawan--chirpstack).
 
 For driving the studio over MCP, the fleet handoff, and enclosure
 search, see [Integrations](integrations.md).


### PR DESCRIPTION
## Summary

Docs freshness pass ahead of cutting **v0.17.0**. Two themes:

### 1. `v0.13.0` → `v0.16.0`

Every published-release reference was stale (the actual most recent tag is `v0.16.0`). Updated:
- `README.md` — Status line, two docker quickstart blocks.
- `docs/deployment.md` — docker run command, image tag table.

`v0.17.0` is the next tag the user will cut after this and #117 merge — not yet referenced anywhere (gets pinned in the same commit that bumps `__version__`).

### 2. LoRaWAN is two paths now, not one

The old docs assumed "LoRaWAN target" meant the standalone Arduino path (RadioLib + LoRaWAN_ESP32, `target: "lorawan"`). The W1/W2/W3 + UI work added a second path — the external-component path (`target: "esphome"` + `lorawan.payload`) that emits ESPHome YAML referencing `lorawan-for-esphome`. Each doc now surfaces both:

- **`README.md`** — intro paragraph reframes LoRaWAN as two paths; Status row reflects both flows.
- **`docs/index.md`** roadmap — splits the LoRaWAN entry; mentions the new `Provision LoRaWAN device` key-icon flow + the pivot/workflow-integration docs.
- **`docs/integrations.md#lorawan--chirpstack`** — section split between standalone and external-component, with the external-component walkthrough documenting `Detect → Provision → Push (with secrets inlined) → Join`. Endpoints listed: `/lorawan/provision-esphome`, `/lorawan/activation/{eui}`, and the `lorawan_secrets` field on `/fleet/push`. Limitations section flags external-component as hardware-join-verified pending a real-gateway test.
- **`docs/user_guide.md`** — surfaces the second header button (key icon for Provision LoRaWAN device) so users know which is which.
- **`docs/deployment.md`** LoRaWAN compile worker section — clarifies the `-lorawan` image variant is for the standalone path only; the external-component path uses the default lean image since fleet-for-esphome owns the ESPHome build.

### Audit

```sh
$ grep -rn 'v0\.13' README.md docs/   # clean
$ grep -rn 'v0\.1[0-9]' README.md docs/ | grep -v 'v0\.16'   # clean
```

Five files changed. No code changes; no CHANGELOG entry (this is a doc-only refresh, not a behaviour change — the user-visible behaviour was already in CHANGELOG entries from the merged W1/W2/W3 PRs).

## Test plan

- [x] All `v0.13.0` references replaced with `v0.16.0`
- [x] No other stale version mentions on the README or docs surface
- [x] LoRaWAN dual-path mention is consistent across README + index + integrations + user_guide + deployment
- [ ] Read-through after merge to catch any phrasing that's awkward without the surrounding context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_