### PR TITLE
release: 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] — 2026-06-20
+
 ### Added
 
 - **LoRaWAN: fleet push inlines per-device secrets.** `POST /fleet/push`

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.15.0"
+__version__ = "0.17.0"


### PR DESCRIPTION
## Summary

Cuts **v0.17.0**. Bumps `wirestudio.__version__` from `0.15.0` to `0.17.0` and dates the new CHANGELOG section as `2026-06-20`.

### What's in the release

- **LoRaWAN external-component pivot, end-to-end.** Scoping doc + locked decisions (#110), `Design.lorawan` IR (#112), generator emits the `external_components:` + `lorawan:` block (#113), `/lorawan/provision-esphome` endpoint (#114), web provision dialog + WebSerial DevEUI auto-derive (#115), fleet push inlines per-device secrets (#117). The hardware-join workflow against `lorawan-for-esphome` is now one click in the UI: Detect → Provision → Push to fleet (secrets inlined) → Join.
- **Intent-to-device synthesis phases 1.5b → 5.** Single-output sensor triggers, value→transform→action via `!lambda`, multi-channel sensor triggers, `on_value_range` threshold bounds, condition gating via `is_on`/`is_off`. 29 components now carry capability annotations; six worked examples.
- **ADC `attenuation: 11db` → `12db`.** ESPHome 2024.5 deprecation cleanup (#116).
- **Docs freshness pass.** Two-path LoRaWAN narrative across README + index + integrations + user_guide + deployment (#118).

### Test plan

- [x] `pytest -q` — 804 passed, 11 skipped
- [x] `ruff check .` — clean
- [x] `__version__` matches the tag form (`0.17.0` ↔ `v0.17.0`)
- [x] CHANGELOG `[Unreleased]` placeholder kept above the new dated section

### After merge

1. Tag locally: `git tag v0.17.0 && git push origin v0.17.0`
2. `release.yml` publishes to PyPI on tag push (Trusted Publisher OIDC).
3. `docker.yml` publishes `:0.17.0` / `:0.17` / `:latest` and the `-lorawan` variants to ghcr.io.

Hardware-join test can run from `ghcr.io/moellere/wirestudio:0.17-lorawan` once those images land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_