### PR TITLE
deploy(prod): roll to 0.17.0

### DIFF
--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 
 images:
   - name: ghcr.io/moellere/wirestudio
-    newTag: "0.12.0"
+    newTag: "0.17.0"


### PR DESCRIPTION
## Summary

One-line bump: `deploy/overlays/prod/kustomization.yaml` `newTag: "0.12.0"` → `"0.17.0"`.

## Why

The prod overlay was last set to `0.12.0` when the prod/dev split was introduced in commit `461a419` and has been frozen there since. Releases v0.13 → v0.17 all shipped to PyPI + ghcr.io, but the prod overlay never moved — so ArgoCD prod has been serving whatever was manually patched in the cluster, not what's in this repo. The recent release report ("ArgoCD still thinks 0.16.0 is the latest") is the visible side of that gap.

This is the documented release-promotion step the prod kustomization file's own comment calls out:

> Production overlay. Stable: the image is a pinned, immutable release tag. **To promote a release to prod, bump newTag below (in the same PR that bumps wirestudio/__init__.py + CHANGELOG, or right after the tag is cut)** and let ArgoCD roll it out. One-line diff, one-commit rollback.

The v0.17.0 release PR (#119) missed it; this is the catch-up. Folding the prod bump into the release PR going forward would prevent the gap.

## Workflow run audit (for context)

Both v0.17.0 publish workflows succeeded on the tag:

- `release.yml` run 27859385920 — PyPI publish ✓
- `docker.yml` run 27859385918 — ghcr.io `:0.17.0` / `:0.17` / `:latest` + `-lorawan` variants ✓

So the image is there; only the overlay pin was stale.

## After merge

ArgoCD prod syncs to `ghcr.io/moellere/wirestudio:0.17.0` — the lean image (no PlatformIO). The standalone LoRaWAN flash flow needs the `-lorawan` variant, which prod doesn't run; the external-component LoRaWAN path uses fleet-for-esphome for the build, so the lean image is correct for prod.

## Test plan

- [x] One-line diff to `deploy/overlays/prod/kustomization.yaml`
- [x] Image `ghcr.io/moellere/wirestudio:0.17.0` confirmed published by `docker.yml` run 27859385918
- [ ] ArgoCD prod app picks up the bump and rolls out post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_