### PR TITLE
ci(docker): auto-bump prod overlay on tag push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -161,3 +161,40 @@ jobs:
           git add "$file"
           git commit -m "deploy(dev): roll to ${tag} [skip ci]"
           git push origin dev
+
+  bump-prod:
+    # Mirrors bump-dev but keyed on tag push, not dev-branch push. Rolls
+    # deploy/overlays/prod/kustomization.yaml's newTag to the bare semver
+    # extracted from the tag (refs/tags/v0.17.0 -> 0.17.0). Closes the
+    # process gap that left prod pinned at 0.12.0 across v0.13..v0.17:
+    # the prod-bump-during-release step was documented as a comment in the
+    # file but never automated, so it got missed every release.
+    #
+    # Prod runs the LEAN image (no PlatformIO), so we only need the build
+    # job here -- not lorawan-image. ArgoCD prod doesn't need the LoRaWAN
+    # compile worker; the external-component LoRaWAN path uses
+    # fleet-for-esphome for the build.
+    needs: [build]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Pin prod overlay to the freshly tagged release
+        run: |
+          # refs/tags/v0.17.0 -> 0.17.0
+          version="${GITHUB_REF#refs/tags/v}"
+          file=deploy/overlays/prod/kustomization.yaml
+          sed -i -E "s|^( *newTag: ).*|\1\"${version}\"|" "$file"
+          if git diff --quiet -- "$file"; then
+            echo "prod overlay already at ${version}"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$file"
+          git commit -m "deploy(prod): roll to ${version} [skip ci]"
+          git push origin main


### PR DESCRIPTION
## Summary

Adds a `bump-prod` job to `.github/workflows/docker.yml` that mirrors the existing `bump-dev` job but is keyed on **tag push**, not dev-branch push. On `v*` tag push, rewrites `deploy/overlays/prod/kustomization.yaml`'s `newTag` to the bare semver extracted from the tag (`refs/tags/v0.17.0` → `0.17.0`) and commits to `main` with `[skip ci]`.

## Why

This closes the process gap diagnosed during the v0.17.0 release rollout:

- `461a419` set prod's `newTag` to `"0.12.0"` when the prod/dev split was introduced.
- Every release since (v0.13, v0.14, v0.15, v0.16, v0.17) shipped to PyPI + ghcr.io **without touching the prod overlay**.
- The file's comment documents the manual bump step, but a comment isn't enforcement; nobody noticed because the dev overlay WAS getting bumped automatically (by the existing `bump-dev` job), masking the prod gap.
- The catch-up bump for v0.17.0 went out as **#120**; this PR ensures v0.18.0+ don't need a catch-up PR.

## Job shape

```yaml
bump-prod:
  needs: [build]
  if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
  runs-on: ubuntu-latest
  permissions:
    contents: write
  steps:
    - uses: actions/checkout@v4
      with:
        ref: main
    - run: |
        version="${GITHUB_REF#refs/tags/v}"
        # sed-rewrite newTag, commit if changed, push to main with [skip ci]
```

### Notes

- **Prod runs the lean image** (no PlatformIO), so this only needs `[build]` — not `[build, lorawan-image]` like `bump-dev`. ArgoCD prod doesn't need the LoRaWAN compile worker; the external-component LoRaWAN path uses fleet-for-esphome for the build.
- **`[skip ci]`** in the auto-commit message prevents the push-to-main from re-triggering `docker.yml` / `esphome-config.yml` / the rest of the gate suite.
- **Race safety**: if main has advanced between the tag push and this job running, `git push origin main` would fast-forward fail. That's a rare race and the manual recovery is a one-line PR (which is what #120 is). Not worth `pull --rebase` complexity here.

## Sanity checks

Verified locally with `python3` simulation:

- `refs/tags/v0.17.0` → `0.17.0` ✓
- `refs/tags/v0.18.0` → `0.18.0` ✓
- `refs/tags/v1.0.0` → `1.0.0` ✓
- `sed` rewrite of the prod kustomization file produces a correct one-line diff with quotes preserved ✓

## Test plan

- [x] Workflow syntax matches the existing `bump-dev` job structure
- [x] Sed pattern + tag→version extraction sanity-checked locally
- [ ] First real-world fire on the v0.18.0 tag push (next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_