### PR TITLE
ci(docker): auto-bump dev overlay on tag push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -198,3 +198,39 @@ jobs:
           git add "$file"
           git commit -m "deploy(prod): roll to ${version} [skip ci]"
           git push origin main
+
+  bump-dev-on-tag:
+    # On tag push, also roll the dev overlay to the released -lorawan
+    # variant (`0.17.0-lorawan` for `v0.17.0`). Complements bump-dev, which
+    # tracks dev-branch HEAD via the rolling sha tag: a release moves dev
+    # to the released image; the next dev-branch push rolls it forward to
+    # the next sha. Lets the dev cluster briefly serve the release version
+    # for smoke-testing without a manual edit.
+    #
+    # Dev runs the -lorawan variant, so this needs lorawan-image too --
+    # the same gating as bump-dev avoids ArgoCD ImagePullBackOff.
+    needs: [build, lorawan-image]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+      - name: Pin dev overlay to the freshly tagged release
+        run: |
+          # refs/tags/v0.17.0 -> 0.17.0-lorawan
+          version="${GITHUB_REF#refs/tags/v}"
+          tag="${version}-lorawan"
+          file=deploy/overlays/dev/kustomization.yaml
+          sed -i -E "s|^( *newTag: ).*|\1${tag}|" "$file"
+          if git diff --quiet -- "$file"; then
+            echo "dev overlay already at ${tag}"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$file"
+          git commit -m "deploy(dev): roll to ${tag} [skip ci]"
+          git push origin dev


### PR DESCRIPTION
## Summary

Adds a `bump-dev-on-tag` job to `.github/workflows/docker.yml` that complements the existing `bump-dev` (which tracks dev-branch HEAD via rolling sha tags). On `v*` tag push, rolls `deploy/overlays/dev/kustomization.yaml`'s `newTag` to the freshly tagged `-lorawan` variant — `0.17.0-lorawan` for `v0.17.0` — and commits to `dev` with `[skip ci]`.

## Behaviour

| Trigger | Existing `bump-dev` | New `bump-dev-on-tag` |
|---|---|---|
| Push to `dev` branch | Rolls to `sha-<short>-lorawan` | (no-op) |
| Push of `v*` tag | (no-op) | Rolls to `<version>-lorawan` |

A release moves the dev cluster to the release image; the next dev-branch push rolls dev forward to the next sha. Lets you briefly smoke-test the release version on the dev cluster without a manual overlay edit.

## Pairs with the prod automation

This is the dev side of the same gap **#121** closes for prod. After both merge, **on each release tag push**:

- Prod overlay → `<version>` on main (lean image)
- Dev overlay → `<version>-lorawan` on dev (PlatformIO-baked image)

Both clusters sync without manual catch-up PRs.

## Mechanics

```yaml
bump-dev-on-tag:
  needs: [build, lorawan-image]
  if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
  steps:
    - uses: actions/checkout@v4
      with: { ref: dev }
    - run: |
        version="${GITHUB_REF#refs/tags/v}"
        tag="${version}-lorawan"
        # sed-rewrite, idempotent guard, commit + push to dev with [skip ci]
```

### Notes

- **Dev runs the `-lorawan` variant**, so this needs both `[build, lorawan-image]` — same gating as the existing `bump-dev` to avoid ArgoCD `ImagePullBackOff` while the slower `-lorawan` build finishes.
- **Pushes to `dev` with `[skip ci]`** so the auto-commit doesn't re-trigger the regular `bump-dev`, which would roll dev back to a fresh sha and obliterate the tag pin.
- **Idempotent guard**: if dev overlay is already at the target tag, exit cleanly without a commit.

## Sanity checks

Verified locally:
- `refs/tags/v0.17.0` → `0.17.0-lorawan` ✓
- Sed rewrite of the dev kustomization file produces a correct one-line diff with the rest of the file (patches block etc.) untouched ✓

## Test plan

- [x] Workflow syntax matches the existing `bump-dev` job structure
- [x] Sed pattern + tag→version extraction sanity-checked locally
- [ ] First real-world fire on the v0.18.0 tag push (next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_