### PR TITLE
ci(release): auto-create GitHub Release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,45 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    # Auto-create the GitHub Release sidebar object on tag push, with the
+    # CHANGELOG section for this version as the body. Without this the
+    # tag publishes to PyPI but the repo page keeps highlighting the
+    # previous release as "Latest" -- mirroring the prod overlay gap that
+    # bump-prod (#121) closed for the deploy side.
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # required to create the Release
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract CHANGELOG section for this version
+        id: notes
+        run: |
+          # GITHUB_REF_NAME is v0.17.0; strip the leading v to match the
+          # CHANGELOG heading shape ("## [0.17.0] — ...").
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          # If the CHANGELOG drifted from the tag (e.g. forgot to date the
+          # section, or the heading shape changed), still create the Release
+          # so the sidebar updates -- with an obvious sentinel body so the
+          # gap is loud.
+          if ! [ -s release-notes.md ]; then
+            printf 'Release %s\n\n(no matching CHANGELOG section found at tag time)\n' "$version" > release-notes.md
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: v${{ steps.notes.outputs.version }}
+          body_path: release-notes.md
+          # Pre-release detection: pep440-style pre-release suffixes
+          # (rc, a, b, dev) on the version make this true. We don't ship
+          # those today; the flag is here so we don't accidentally promote
+          # a future v0.18.0-rc1 to "Latest".
+          prerelease: ${{ contains(steps.notes.outputs.version, '-') || contains(steps.notes.outputs.version, 'rc') || contains(steps.notes.outputs.version, 'a') || contains(steps.notes.outputs.version, 'b') || contains(steps.notes.outputs.version, 'dev') }}


### PR DESCRIPTION
## Summary

Adds a `github-release` job to `.github/workflows/release.yml` that auto-creates the GitHub Release sidebar object on `v*` tag push, with the matching `CHANGELOG.md` section as the body. Closes the gap surfaced by v0.17.0: the tag publishes to PyPI + ghcr.io but the repo page keeps highlighting the previous release as "Latest" until someone manually runs `gh release create`.

Same shape of process gap that #121 closed for the prod overlay: documented as a manual step (or just not documented at all), so quietly skipped on every release until someone went looking.

## Why now

The `v0.17.0` release surfaced this when the WireStudio repo page kept showing `v0.16.0` as "Latest" — PyPI had `0.17.0`, ghcr.io had `:0.17.0` / `:0.17` / `:latest`, and the prod overlay (after #120 + #121) had `newTag: "0.17.0"`, but the GitHub Release object — a separate API resource — was never created.

## Mechanics

```yaml
github-release:
  needs: publish
  runs-on: ubuntu-latest
  permissions:
    contents: write   # required to create the Release
  steps:
    - uses: actions/checkout@v4
    - name: Extract CHANGELOG section
      run: |
        version="${GITHUB_REF_NAME#v}"
        awk -v ver="$version" '
          $0 ~ "^## \\[" ver "\\]" { found=1; next }
          found && /^## \[/ { exit }
          found { print }
        ' CHANGELOG.md > release-notes.md
        # Fallback if CHANGELOG drifted
        if ! [ -s release-notes.md ]; then
          printf 'Release %s\n\n(no matching CHANGELOG section found at tag time)\n' "$version" > release-notes.md
        fi
    - uses: softprops/action-gh-release@v2
      with:
        name: v${{ steps.notes.outputs.version }}
        body_path: release-notes.md
        prerelease: ${{ contains(version, '-') || contains(version, 'rc') || ... }}
```

### Notes

- **Depends on `publish`** so the Release only appears after PyPI has the matching wheel. Avoids the visibility-without-artifacts inversion.
- **Idempotent**: `softprops/action-gh-release@v2` updates an existing Release if one already exists for the tag (so a manual catch-up + the workflow firing later won't double-create).
- **Pre-release flag**: pep440-style suffixes (`-`, `rc`, `a`, `b`, `dev`) flip `prerelease: true`. We don't ship pre-releases today; this is here so a future `v0.18.0-rc1` doesn't accidentally become the "Latest" sidebar entry.
- **Fallback body**: an empty CHANGELOG extraction would still create the Release, with a "no matching CHANGELOG section found at tag time" sentinel — gap is loud, not silent.
- **Local sanity-checked** the awk pattern against `CHANGELOG.md` — extracts the `0.17.0` section cleanly; empty result for a non-existent version triggers the fallback path.

## What this doesn't fix

The `v0.17.0` release itself was tagged **before** this workflow change, so the new job won't fire retroactively. **You still need to manually create the v0.17.0 Release once**:

```sh
gh release create v0.17.0 \
  --title "v0.17.0" \
  --notes "$(awk '/^## \[0.17.0\]/,/^## \[/{if (!/^## \[/) print; else if (NR>1) exit}' CHANGELOG.md)"
```

(or via the GitHub UI). After v0.17.0 is created and this PR merges, every release from v0.18.0 onward will create its Release automatically.

## Test plan

- [x] awk pattern extracts the correct CHANGELOG section locally
- [x] Empty-result fallback fires for a non-existent version
- [ ] First real-world fire on the v0.18.0 tag push (next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_