### PR TITLE
fix(library + solver): uart_gps optional sensors guard; pin solver respects bus pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`uart_gps` template: optional `params.sensors` guard.** The template
+  referenced `(params.sensors or {}).items()` to default-empty when the
+  user hadn't set the optional sensors map -- but that defense doesn't
+  work under our `StrictUndefined` Jinja env: accessing
+  `params.sensors` on a params dict without that key raises
+  `UndefinedError` BEFORE the `or {}` evaluates, so the fallback never
+  gets a chance. Symptom: adding `uart_gps` via the Inspector (which
+  leaves `params: {}`) failed `/design/render` with 422
+  `'dict object' has no attribute 'sensors'`. Switches to the standard
+  `{%- if params.sensors is defined and params.sensors %}` guard used
+  by `bme280` / `dht` / `sht3xd` / the phase-3 multi-channel sensors.
+- **Pin solver: respect bus pin assignments.** `_used_gpio_pins` walked
+  only `design.connections` for `kind: gpio` targets, but UART tx/rx,
+  I2C sda/scl, SPI clk/miso/mosi/cs, I2S lrclk/bclk, and 1-wire pin
+  live on the bus object itself (a component's bus connection target
+  is `{kind: "bus", bus_id: "uart0"}` and doesn't carry the GPIO). So
+  the solver treated bus pins as free. Symptom: design has UART on
+  `tx=GPIO13`, user adds an HC-SR501 PIR with `OUT` unbound, solver
+  picks `GPIO13` for `OUT` -- the same pin as UART tx. Now harvests
+  bus pin slots into the used set.
+- **Generator error hint: don't suggest "missing bus" for params
+  errors.** The `UndefinedError` -> 422 converter blindly appended
+  "Likely a missing bus connection" to every error message. That was
+  a false friend when the actual error was a missing optional param
+  (the `uart_gps.sensors` case above). Now differentiates: a
+  `'dict object' has no attribute ...` error suggests the optional
+  param / is-defined-guard fix; everything else still suggests the
+  bus connection check.
+
 ## [0.17.0] — 2026-06-20
 
 ### Added

--- a/wirestudio/csp/pin_solver.py
+++ b/wirestudio/csp/pin_solver.py
@@ -133,6 +133,22 @@ def _used_gpio_pins(design: dict) -> set[str]:
         t = c.get("target", {})
         if t.get("kind") == "gpio" and t.get("pin"):
             used.add(t["pin"])
+    # Bus pins are owned by the bus object, not by individual connections --
+    # a component connection target {kind: "bus", bus_id: "uart0"} doesn't
+    # carry the GPIO pin. So harvest bus pin slots directly. Every field
+    # listed in PIN_SLOTS_BY_TYPE on the JS side (Bus model in model.py)
+    # may carry a GPIO -- enumerate them here so the solver treats a UART
+    # tx/rx, I2C sda/scl, SPI clk/miso/mosi/cs, I2S lrclk/bclk, and 1-wire
+    # pin as occupied.
+    _BUS_PIN_SLOTS = (
+        "sda", "scl", "miso", "mosi", "clk", "cs",
+        "rx", "tx", "lrclk", "bclk", "pin",
+    )
+    for b in design.get("buses", []):
+        for slot in _BUS_PIN_SLOTS:
+            v = b.get(slot)
+            if v:
+                used.add(v)
     return used
 
 

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -305,12 +305,33 @@ def _render_component(
     try:
         rendered = _jinja.from_string(template_str).render(**ctx)
     except UndefinedError as e:
-        # Almost always: template references {{ bus.id }} but the component
-        # has no `kind: bus` connection (or the bus_id doesn't match any
-        # design.buses entry). Surface a cleaner error so the API can 422.
+        # Two common shapes:
+        #  - `bus.id` referenced but the component has no kind:bus connection
+        #    (or the bus_id doesn't match any design.buses entry)
+        #  - `params.<key>` referenced without an `is defined` guard for an
+        #    optional param the user hasn't set
+        # Tailor the hint to the message so we don't suggest a bus fix when
+        # the actual error is a missing optional param.
+        msg = e.message or ""
+        # 'dict object' has no attribute 'x' -> the template walked into a
+        # params dict that didn't have key 'x' (optional param without an
+        # is-defined guard). 'None' has no attribute 'x' or any other shape
+        # -> almost always a missing kind:bus connection (template referenced
+        # bus.<...> and bus came back None).
+        if "'dict object'" in msg:
+            hint = (
+                "Likely an optional param the template references without an "
+                "`is defined` guard. Set the param under the component, or "
+                "fix the template to guard the access."
+            )
+        else:
+            hint = (
+                "Likely a missing bus connection; add a matching bus to the "
+                "design or fix the connection target."
+            )
         raise ValueError(
-            f"component '{comp.id}' (library_id={comp.library_id}) cannot be rendered: {e.message}. "
-            f"Likely a missing bus connection; add a matching bus to the design or fix the connection target."
+            f"component '{comp.id}' (library_id={comp.library_id}) cannot be "
+            f"rendered: {msg}. {hint}"
         ) from e
     except TypeError as e:
         # Jinja's StrictUndefined leaks past `tojson` because json.dumps gets

--- a/wirestudio/library/components/uart_gps.yaml
+++ b/wirestudio/library/components/uart_gps.yaml
@@ -76,9 +76,11 @@ esphome:
   yaml_template: |
     gps:
       uart_id: {{ bus.id }}
-    {%- for sensor_key, sensor_cfg in (params.sensors or {}).items() %}
+    {%- if params.sensors is defined and params.sensors %}
+    {%- for sensor_key, sensor_cfg in params.sensors.items() %}
       {{ sensor_key }}: {{ sensor_cfg | tojson }}
     {%- endfor %}
+    {%- endif %}
 
 params_schema:
   sensors:


### PR DESCRIPTION
## Summary

Two bugs hit during the LoRaWAN external-component walkthrough on prod tonight. Both small, both diagnostic-grade clear:

### 1. `uart_gps` template raises on missing optional `params.sensors`

The Jinja template referenced `(params.sensors or {}).items()` to default to an empty dict. That defense doesn't work under our StrictUndefined env — accessing `params.sensors` on a params dict without that key raises **before** the `or {}` evaluates.

**Symptom:** add a `uart_gps` component to a design via the Inspector (which leaves `params: {}`) → `/design/render` returns 422 with `'dict object' has no attribute 'sensors'`. YAML pane shows the last successful render so it looks like *nothing is updating* — that's how the bug surfaced: the user changed UART pins, the pins propagated to design state correctly, but every render kept 422-ing, so the pane stayed stale.

**Fix:** standard `{%- if params.sensors is defined and params.sensors %}` guard, matching what bme280 / dht / sht3xd / all phase-3 multi-channel sensor templates already do.

Also tightens the generator's UndefinedError hint: only suggest "missing bus connection" when the Jinja error implicates a `None` ref (`'None' has no attribute ...`); when it implicates a `dict object` (a params lookup), suggest "missing optional param / template needs an is-defined guard." That was the false-friend hint that made this bug feel like a connection issue.

### 2. Pin solver doesn't treat bus pins as occupied

`_used_gpio_pins` walked `design.connections` looking for `kind: "gpio"` targets. Bus pins (UART tx/rx, I2C sda/scl, SPI clk/miso/mosi/cs, I2S lrclk/bclk, 1-wire pin) live on the **bus object itself**, not in connections — a component's bus connection target is `{kind: "bus", bus_id: "uart0"}` and doesn't carry the GPIO.

**Symptom:** design has UART bus on `tx=GPIO13`, `rx=GPIO15`. User added a PIR (`hc-sr501`) with `OUT` unbound. Pin solver picked `GPIO13` for `OUT` — the exact same pin as UART tx. Real hardware conflict.

**Fix:** harvest bus pin slots into the used set. Verified the original repro now picks GPIO14 instead.

## Test plan

- [x] Reproduced the 422 with a fresh `uart_gps` + `params: {}` — fix renders cleanly
- [x] Confirmed `uart_gps` with `params.sensors` set still emits sub-sensor names
- [x] Confirmed existing standalone-path examples (`wemosgps`, `t-beam`) render unchanged
- [x] Reproduced the pin solver picking GPIO13 — fix picks GPIO14
- [x] `pytest -q` — 804 passed, 11 skipped
- [x] `ruff check .` — clean
- [x] `test_render_missing_bus_returns_422_with_message` still passes (the bus hint still fires on actual missing-bus errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_