### PR TITLE
release: 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] — 2026-06-20
+
 ### Fixed
 
+- **Inspector: editable JSON for object/array params.** The Inspector's
+  `ParamForm` rendered scalar params (string/int/number/bool/enum)
+  inline, but for `object` and `array` schemas it just stringified the
+  value as read-only and showed "structured editing not yet supported."
+  That left whole classes of params un-editable through the UI --
+  `uart_gps.sensors` (the visible LoRaWAN-external-component blocker --
+  sub-sensor IDs need to live here so `lorawan.payload` bindings can
+  reference them), `pulse_counter.filters` / `count_mode`,
+  `gpio_input.on_press` and the other `on_*` action lists. Now a JSON
+  textarea per object/array param: parses on every keystroke and
+  commits to the design only when the buffer is valid; kind-mismatched
+  input (`[1,2]` on an `object` schema, `{"a":1}` on `array`) shows an
+  inline parse error and doesn't commit; textarea auto-sizes 3-12 rows.
+- **DesignPane: visible "stale" signal when render fails.** When the
+  auto-debounced `/design/render` fails, the YAML/ASCII pane kept
+  showing the prior successful render -- intentional context, but
+  nothing visually flagged that the content was no longer current.
+  Three coordinated signals: a rose dot on the ASCII / YAML tab labels
+  (JSON stays clean since it reads design state directly), a sub-line
+  on the "Render failed" banner naming the stale tab and pointing at
+  the JSON tab for live state, and an `opacity-50` transition on the
+  stale content itself. Surfaced during the LoRaWAN walkthrough: user
+  edits weren't visibly ignored, but a series of small renderer
+  rejections made it look that way.
 - **`uart_gps` template: optional `params.sensors` guard.** The template
   referenced `(params.sensors or {}).items()` to default-empty when the
   user hadn't set the optional sensors map -- but that defense doesn't

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"


### PR DESCRIPTION
## Summary

Cuts **v0.17.1** — a patch release covering the three small fixes surfaced during the LoRaWAN external-component walkthrough on the prod 0.17.0 image.

Bumps `wirestudio.__version__` from `0.17.0` to `0.17.1` and dates the new CHANGELOG section as `2026-06-20`.

### What's in the release

- **Inspector: editable JSON for object/array params** (#124). Was the visible blocker for setting `uart_gps.sensors` via the UI — the LoRaWAN external-component path needs sub-sensor IDs there for `lorawan.payload` bindings. The old read-only "structured editing not yet supported" view is replaced with a JSON textarea that parses on every keystroke and commits only on valid input. Also unblocks `pulse_counter.filters`, `count_mode`, and the `on_*` action lists.

- **`uart_gps` template: optional `params.sensors` guard + pin solver respects bus pins + cleaner generator error hint** (#125). The Jinja template's `(params.sensors or {})` defense didn't work under StrictUndefined; switched to the standard `is defined` guard used by every multi-channel sensor. The pin solver was assigning bus-occupied GPIOs (UART tx, etc.) to new components because `_used_gpio_pins` only walked `connections`. The generator's "Likely a missing bus connection" hint was a false friend for params errors and now branches on the error shape.

- **DesignPane: visible "stale" signal when render fails** (#126). When the auto-debounced render fails, the YAML pane kept showing the prior successful render with no visual cue. Three coordinated signals (tab dot, banner sub-line naming the stale tab, opacity-50 on the stale content) make the state legible without being intrusive.

### Test plan

- [x] `pytest -q` — 804 passed, 11 skipped
- [x] `ruff check .` — clean
- [x] `__version__` matches the tag form (`0.17.1` ↔ `v0.17.1`)
- [x] CHANGELOG `[Unreleased]` placeholder kept above the new dated section

### After merge

1. `git tag v0.17.1 origin/main && git push origin v0.17.1`
2. Automation cascades fire on the tag push:
   - `release.yml` → PyPI publish
   - `docker.yml` build + lorawan-image → `:0.17.1` / `:0.17` / `:latest` (+ `-lorawan` variants) on ghcr.io
   - `bump-prod` (#121) → rolls `deploy/overlays/prod` to `"0.17.1"` on main
   - `bump-dev-on-tag` (#122) → rolls `deploy/overlays/dev` to `"0.17.1-lorawan"` on dev
   - `github-release` (#123) → creates the v0.17.1 Release sidebar entry with this section as the body

ArgoCD prod and dev auto-sync to the new tags. No manual catch-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_