### PR TITLE
deploy(k8s): wire ChirpStack envs; scrub local network details from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`deploy/k8s.yaml` image pin bumped `v0.12.0` → `v0.17.1`.** The
+  standalone manifest's hardcoded image tag was five releases stale (the
+  kustomize overlays roll forward, but the plain manifest doesn't).
 - **`CHIRPSTACK_API_URL` default is now `chirpstack:8080`.** Was a
   specific LAN IP that meant something only on the original author's
   network; the new default is the typical in-cluster Service name and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **k8s manifest: ChirpStack provisioning envs.** `deploy/k8s.yaml` now
+  wires `CHIRPSTACK_API_URL` (plain env, defaults to the in-cluster
+  Service name `chirpstack:8080`) and `CHIRPSTACK_API_TOKEN` (optional
+  secretKeyRef on `wirestudio-secrets`). A commented `CHIRPSTACK_API_TLS`
+  entry covers the TLS-channel case. Closes the gap where `/lorawan/provision*`
+  needed the operator to hand-add envs after every `kubectl apply`.
+
+### Changed
+
+- **`CHIRPSTACK_API_URL` default is now `chirpstack:8080`.** Was a
+  specific LAN IP that meant something only on the original author's
+  network; the new default is the typical in-cluster Service name and
+  works out of the box for the k8s manifest. Non-k8s deploys still set
+  the env explicitly.
+- **Scrubbed local-environment specifics from `docs/lorawan/`.** Replaced
+  real gateway hostname, private IP addresses, gateway silicon ID, and
+  personal DNS names with documentation placeholders (`mygw`, `10.0.x.x`,
+  `*.example.com`, `0000000000000000`). The setup snapshot keeps its
+  structure but no longer leaks a single operator's network into a public
+  repo.
+
 ## [0.17.1] — 2026-06-20
 
 ### Fixed

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -54,7 +54,7 @@ docker compose up -d
 
 `k8s.yaml` is a minimal manifest covering the single-image pattern:
 one Deployment, a 1 Gi PVC mounted at `/data`, a ClusterIP Service
-on `:80 -> :8765`. Optional `wirestudio-secrets` for the four feature-
+on `:80 -> :8765`. Optional `wirestudio-secrets` for the feature-
 gating env vars (none required to boot).
 
 ```sh
@@ -64,8 +64,14 @@ kubectl create secret generic wirestudio-secrets \
   --from-literal=anthropic-api-key=sk-ant-... \
   --from-literal=fleet-url=http://homeassistant.local:8765 \
   --from-literal=fleet-token=xxx \
-  --from-literal=thingiverse-api-key=xxx
+  --from-literal=thingiverse-api-key=xxx \
+  --from-literal=chirpstack-api-token=xxx
 ```
+
+The manifest pre-wires `CHIRPSTACK_API_URL` to `chirpstack:8080`
+(typical in-cluster Service name). Override on the Deployment if
+ChirpStack lives elsewhere; set `CHIRPSTACK_API_TLS=true` for a TLS
+channel.
 
 **Constraints to be aware of**:
 

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -27,7 +27,8 @@
 #     --from-literal=anthropic-api-key=sk-ant-... \
 #     --from-literal=fleet-url=http://homeassistant.local:8765 \
 #     --from-literal=fleet-token=xxx \
-#     --from-literal=thingiverse-api-key=xxx
+#     --from-literal=thingiverse-api-key=xxx \
+#     --from-literal=chirpstack-api-token=xxx
 #
 # All keys are optional; the studio runs without any of them, just
 # with the corresponding feature gated off.
@@ -103,6 +104,21 @@ spec:
                   name: wirestudio-secrets
                   key: thingiverse-api-key
                   optional: true
+            # ChirpStack provisioning (/lorawan/provision*). URL is the gRPC
+            # host:port -- a plain env, since it varies per cluster and isn't
+            # secret. Default targets a Service named `chirpstack` in the same
+            # namespace; override if ChirpStack lives elsewhere.
+            - name: CHIRPSTACK_API_URL
+              value: "chirpstack:8080"
+            - name: CHIRPSTACK_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: wirestudio-secrets
+                  key: chirpstack-api-token
+                  optional: true
+            # Uncomment to use a TLS gRPC channel to ChirpStack.
+            # - name: CHIRPSTACK_API_TLS
+            #   value: "true"
           volumeMounts:
             - { name: data, mountPath: /data }
           readinessProbe:

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -70,7 +70,7 @@ spec:
         runAsGroup: 1000
       containers:
         - name: wirestudio
-          image: ghcr.io/moellere/wirestudio:v0.12.0
+          image: ghcr.io/moellere/wirestudio:v0.17.1
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/docs/lorawan/LORAWAN_TARGET_PLAN.md
+++ b/docs/lorawan/LORAWAN_TARGET_PLAN.md
@@ -271,8 +271,8 @@ Secondary (compile-time) path: server injects literal DevEUI (server-derived fro
 ## 8. ChirpStack integration
 
 **Endpoints (see §10 / bundled `chirpstack-lorawan-setup.md`):** gRPC/REST/UI multiplexed at
-`http://10.254.0.11:8080`. Auth = a **Bearer API token generated in the UI** (NOT the JWT signing secret).
-App-layer MQTT is bridged to the HA broker at `10.250.0.41:1883` (user `chirpstack`).
+`http://<chirpstack-host>:8080`. Auth = a **Bearer API token generated in the UI** (NOT the JWT signing secret).
+App-layer MQTT is bridged to the HA broker at `<ha-mqtt-host>:1883` (user `chirpstack`).
 
 **gRPC sequence (`chirpstack-api` Python):**
 1. `DeviceProfileService` — ensure a **US915, sub-band 2** profile exists (MAC version, OTAA, ADR). Cache its UUID.
@@ -343,14 +343,15 @@ job/log-polling shape for the build-status API so the web UI can stream logs.
 
 ## 10. ChirpStack infra essentials (full detail in bundled `chirpstack-lorawan-setup.md`)
 
-- Gateway `wyolora` @ `10.254.0.11` (remote, behind VPN). RAK2287 / SX1302, **US915 sub-band 2** (`us915_1`):
-  903.9–905.3 MHz multi-SF + 904.6 MHz 500 kHz. Gateway ID `0016c001ff18560f`.
-- ChirpStack 4.17 @ `http://10.254.0.11:8080` (gRPC + REST + UI on one port). Token via UI → API Keys.
-- App MQTT bridged to HA broker `10.250.0.41:1883`, user `chirpstack`. Topics:
+- Gateway `<gw-host>` @ `<gw-ip>` (typical setup: remote, behind VPN). RAK2287 / SX1302, **US915 sub-band 2**
+  (`us915_1`): 903.9–905.3 MHz multi-SF + 904.6 MHz 500 kHz. Gateway ID is the chip-silicon EUI-64
+  (read off your hardware).
+- ChirpStack 4.17 @ `http://<chirpstack-host>:8080` (gRPC + REST + UI on one port). Token via UI → API Keys.
+- App MQTT bridged to HA broker `<ha-mqtt-host>:1883`, user `chirpstack`. Topics:
   `application/{app_id}/device/{dev_eui}/event/{up,join,ack,txack,status,...}` (consume), `.../command/down`
   (downlink). Decoded sensor fields arrive under the payload `object` key (from the device profile codec).
-- Bridge health: `gateway/wyolora/bridge/state` (`1`/`0`, retained). The flasher backend should reach the
-  ChirpStack gRPC API and the HA MQTT broker over the VPN; both are reachable from the HA-site network.
+- Bridge health: `gateway/<gw-host>/bridge/state` (`1`/`0`, retained). The flasher backend should reach the
+  ChirpStack gRPC API and the HA MQTT broker; both need to be reachable from the network the studio runs on.
 
 ---
 

--- a/docs/lorawan/chirpstack-lorawan-setup.md
+++ b/docs/lorawan/chirpstack-lorawan-setup.md
@@ -6,7 +6,9 @@ change, MQTT topic structure, and the operational properties to design around.
 
 > Credentials are redacted to `<placeholders>`; supply the real values at deploy
 > time from the environment / a secret store (see §11). Nothing secret is committed
-> in this repo.
+> in this repo. Hostnames, IP addresses, gateway IDs, and DNS names in this doc
+> are illustrative placeholders (`mygw`, `10.0.x.x`, `*.example.com`) -- swap in
+> your own when adapting.
 
 ---
 
@@ -14,8 +16,8 @@ change, MQTT topic structure, and the operational properties to design around.
 
 | Component | Detail |
 |---|---|
-| Gateway hostname | `wyolora` |
-| Gateway IP | `10.254.0.11` (remote site, behind VPN) |
+| Gateway hostname | `mygw` |
+| Gateway IP | `10.0.0.10` (remote site, behind VPN) |
 | Host | Raspberry Pi 4 Model B Rev 1.1, 4 GB RAM, armv7l |
 | Concentrator | RAK2287 on RAK Pi Hat (SX1302 + dual SX1250) |
 | Antenna | External 8 dBi, SMA via u.fl pigtail |
@@ -23,9 +25,9 @@ change, MQTT topic structure, and the operational properties to design around.
 | SPI | `/dev/spidev0.0` (CS0), reset on GPIO 17 |
 | I²C | `/dev/i2c-1` (concentrator temp sensor) |
 | Region / band | US915, sub-band 2 (`us915_1` in ChirpStack) — 903.9–905.3 MHz multi-SF + 904.6 MHz 500 kHz LoRa-Std |
-| Gateway ID (from chip silicon) | `0016c001ff18560f` |
+| Gateway ID (from chip silicon) | `0000000000000000` (per-device; read from your gateway) |
 
-Access: `ssh root@10.254.0.11` (key auth, no password).
+Access: `ssh root@10.0.0.10` (key auth, no password).
 
 ---
 
@@ -34,9 +36,9 @@ Access: `ssh root@10.254.0.11` (key auth, no password).
 Two separate sites connected over VPN:
 
 ```
-┌── Gateway site (10.254.0.0/24) ──────┐    VPN    ┌── HA site (10.250.0.0/24) ──┐
+┌── Gateway site (10.0.0.0/24) ────────┐    VPN    ┌── HA site (10.0.1.0/24) ────┐
 │                                       │           │                              │
-│  wyolora (10.254.0.11)                │◄═════════►│  HAOS VM (10.250.0.41)       │
+│  mygw (10.0.0.10)                │◄═════════►│  HAOS VM (10.0.1.10)       │
 │   ├─ ChirpStack 4.17 (port 8080)      │           │   ├─ mosquitto (port 1883)   │
 │   ├─ mosquitto (port 1883, local)     │           │   ├─ Home Assistant Core     │
 │   ├─ chirpstack-concentratord-sx1302  │           │   ├─ HACS                    │
@@ -46,9 +48,9 @@ Two separate sites connected over VPN:
 ```
 
 Other reachable hosts you may need:
-- `home.dorktool.com:8123` — HA web UI
-- `argo.dorktool.com` — ArgoCD
-- `authentik.dorktool.com` — SSO
+- `home.example.com:8123` — HA web UI
+- `argo.example.com` — ArgoCD
+- `auth.example.com` — SSO
 
 ---
 
@@ -75,7 +77,7 @@ upgrade ChirpStack you wait for a Gateway OS release with a newer version and ru
 **Everything terminates on the Pi's local mosquitto. A mosquitto bridge handles the VPN.**
 
 ```
-                              Pi (10.254.0.11)
+                              Pi (10.0.0.10)
    ┌──────────────────────────────────────────────────────────┐
    │                                                          │
    │  [RAK2287/SX1302] ──SPI──> [concentratord-sx1302]        │
@@ -102,7 +104,7 @@ upgrade ChirpStack you wait for a Gateway OS release with a newer version and ru
    │                                  ┊  /srv/mosquitto/      │
    └──────────────────────────────────┊───────────────────────┘
                                       ┊ VPN
-                              HAOS VM (10.250.0.41)
+                              HAOS VM (10.0.1.10)
    ┌──────────────────────────────────▼───────────────────────┐
    │  [mosquitto :1883] ──> [chirp custom_component]          │
    │                                  │                       │
@@ -129,7 +131,7 @@ upgrade ChirpStack you wait for a Gateway OS release with a newer version and ru
 | HA chirp integration | Sees no new events until VPN recovers. |
 | Recovery | Bridge auto-reconnects (`restart_timeout 5 30`), drains queue at QoS 1, state topic flips back to `1`. HA gets all the buffered events in order. |
 
-Verified live: blackholed route to 10.250.0.41 → bridge state went `1→0` after ~45 s
+Verified live: blackholed route to 10.0.1.10 → bridge state went `1→0` after ~45 s
 → 5 test messages queued → route restored → state `1` → messages drained to HA broker.
 
 ---
@@ -213,17 +215,17 @@ allow_anonymous true
 
 # --- bridge to HA mosquitto over the VPN ---
 connection ha_bridge
-address 10.250.0.41:1883
+address 10.0.1.10:1883
 remote_username chirpstack
 remote_password <ha-mqtt-password>
-remote_clientid wyolora-bridge
-local_clientid  wyolora-bridge-local
+remote_clientid mygw-bridge
+local_clientid  mygw-bridge-local
 cleansession false
 start_type automatic
 restart_timeout 5 30
 keepalive_interval 30
 notifications true
-notification_topic gateway/wyolora/bridge/state
+notification_topic gateway/mygw/bridge/state
 try_private false
 bridge_protocol_version mqttv311
 
@@ -234,7 +236,7 @@ topic application/+/device/+/state/+ out 1 "" ""
 # downlinks remote -> local
 topic application/+/device/+/command/+ in 1 "" ""
 # bridge connection state -> remote (for HA bridge-health sensor)
-topic gateway/wyolora/bridge/state out 1 "" ""
+topic gateway/mygw/bridge/state out 1 "" ""
 ```
 
 ### 5.5 Disabled service
@@ -245,7 +247,7 @@ topic gateway/wyolora/bridge/state out 1 "" ""
 
 ## 6. MQTT Topic Structure (the contract your project depends on)
 
-All topics live on the HA mosquitto at `10.250.0.41:1883` (creds `chirpstack` / `<ha-mqtt-password>`, see §11) because the bridge ferries them.
+All topics live on the HA mosquitto at `10.0.1.10:1883` (creds `chirpstack` / `<ha-mqtt-password>`, see §11) because the bridge ferries them.
 
 ### 6.1 Gateway-layer topics (`us915_1/...`)
 
@@ -284,7 +286,7 @@ ChirpStack publishes to / subscribes from these. They cross the bridge to HA's b
 
 | Topic | Payload | Meaning |
 |---|---|---|
-| `gateway/wyolora/bridge/state` | `1` or `0` (retained) | VPN/bridge health from local mosquitto's perspective. Exposed in HA as `binary_sensor.wyolora_vpn_bridge`. |
+| `gateway/mygw/bridge/state` | `1` or `0` (retained) | VPN/bridge health from local mosquitto's perspective. Exposed in HA as `binary_sensor.mygw_vpn_bridge`. |
 
 ---
 
@@ -292,12 +294,12 @@ ChirpStack publishes to / subscribes from these. They cross the bridge to HA's b
 
 | Endpoint | Detail |
 |---|---|
-| URL | `http://10.254.0.11:8080` |
+| URL | `http://10.0.0.10:8080` |
 | Protocol | gRPC + HTTP/REST + Web UI multiplexed on the same port |
 | Web UI | Browser to the same URL |
 | API token | Generate in the UI under **API Keys** (or **Tenant → API Keys**). Do **not** use the JWT signing secret in `/etc/config/chirpstack` — that's not a usable token. |
 | gRPC client libs | `chirpstack-api` on pip, also Go/JS/Rust |
-| OpenAPI / Swagger | `http://10.254.0.11:8080/api` (UI at `/api/`) |
+| OpenAPI / Swagger | `http://10.0.0.10:8080/api` (UI at `/api/`) |
 | Region config | `us915_1` (sub-band 2) only |
 | Tenant model | Multi-tenant, but for a single-org install create devices under the default tenant |
 
@@ -307,7 +309,7 @@ ChirpStack publishes to / subscribes from these. They cross the bridge to HA's b
 import grpc, os
 from chirpstack_api import api
 
-server = "10.254.0.11:8080"
+server = "10.0.0.10:8080"
 api_token = os.environ["CHIRPSTACK_API_TOKEN"]   # generated in the ChirpStack UI; see §11
 channel = grpc.insecure_channel(server)
 auth_token = [("authorization", f"Bearer {api_token}")]
@@ -337,7 +339,7 @@ def on_message(c, u, msg):
 c = mqtt.Client()
 c.username_pw_set(os.environ["HA_MQTT_USERNAME"], os.environ["HA_MQTT_PASSWORD"])
 c.on_message = on_message
-c.connect("10.250.0.41", 1883)
+c.connect("10.0.1.10", 1883)
 c.subscribe("application/+/device/+/event/up")
 c.loop_forever()
 ```
@@ -364,9 +366,9 @@ c.publish(f"application/{app_id}/device/{dev_eui}/command/down",
 | Custom component | `github.com/modrisb/chirp` (NOT `chirpha` — that's the broken addon) |
 | Install path | Via HACS as a custom repository, type Integration |
 | Config flow | Settings → Devices & Services → Add Integration → "Chirp" |
-| ChirpStack API endpoint | `http://10.254.0.11:8080` |
+| ChirpStack API endpoint | `http://10.0.0.10:8080` |
 | ChirpStack API token | Generated in the ChirpStack UI |
-| MQTT broker | Reuses HA's MQTT integration (10.250.0.41:1883) |
+| MQTT broker | Reuses HA's MQTT integration (10.0.1.10:1883) |
 
 ### HA YAML — bridge health sensor
 
@@ -374,8 +376,8 @@ c.publish(f"application/{app_id}/device/{dev_eui}/command/down",
 mqtt:
   binary_sensor:
     - name: "Wyolora VPN Bridge"
-      unique_id: wyolora_vpn_bridge_state
-      state_topic: "gateway/wyolora/bridge/state"
+      unique_id: mygw_vpn_bridge_state
+      state_topic: "gateway/mygw/bridge/state"
       payload_on: "1"
       payload_off: "0"
       device_class: connectivity
@@ -423,7 +425,7 @@ The codec has an in-UI tester — paste raw bytes, see the decoded output before
 
 ## 10. Diagnostic Commands
 
-Run on the Pi (`ssh root@10.254.0.11`):
+Run on the Pi (`ssh root@10.0.0.10`):
 
 ```sh
 # Process check
@@ -445,7 +447,7 @@ mosquitto_sub -h 127.0.0.1 -t 'us915_1/#' -v
 mosquitto_sub -h 127.0.0.1 -t 'application/#' -v
 
 # Watch bridge state
-mosquitto_sub -h 127.0.0.1 -t 'gateway/wyolora/bridge/state' -v
+mosquitto_sub -h 127.0.0.1 -t 'gateway/mygw/bridge/state' -v
 
 # Check persistence queue file
 ls -lh /srv/mosquitto/
@@ -455,12 +457,12 @@ ls -lh /srv/mosquitto/
 logread -l 50 | grep concentratord
 ```
 
-From the dev VM (`10.250.0.99` or whatever your VPN-side host is), to sanity-check
+From the dev VM (`10.0.1.20` or whatever your VPN-side host is), to sanity-check
 the HA broker side:
 
 ```sh
-mosquitto_sub -h 10.250.0.41 -p 1883 -u chirpstack -P "$HA_MQTT_PASSWORD" -t 'application/#' -v
-mosquitto_sub -h 10.250.0.41 -p 1883 -u chirpstack -P "$HA_MQTT_PASSWORD" -t 'gateway/wyolora/bridge/state' -v
+mosquitto_sub -h 10.0.1.10 -p 1883 -u chirpstack -P "$HA_MQTT_PASSWORD" -t 'application/#' -v
+mosquitto_sub -h 10.0.1.10 -p 1883 -u chirpstack -P "$HA_MQTT_PASSWORD" -t 'gateway/mygw/bridge/state' -v
 ```
 
 ---
@@ -478,7 +480,7 @@ rule. The `<placeholders>` in §5 and the code examples mark where the real valu
 | HA mosquitto password | `mosquitto.conf` bridge block (§5.4), client examples | `HA_MQTT_PASSWORD` |
 | ChirpStack API token | Generated in the ChirpStack UI under **API Keys** | `CHIRPSTACK_API_TOKEN` |
 | ChirpStack API JWT signing secret (gateway-side; NOT a usable API token) | `chirpstack.toml` `[api] secret` (§5.3) | `CHIRPSTACK_API_SECRET` |
-| Pi SSH | `root@10.254.0.11`, key auth (no password in this repo) | n/a — SSH key on the operator host |
+| Pi SSH | `root@10.0.0.10`, key auth (no password in this repo) | n/a — SSH key on the operator host |
 
 ### Deploy-time injection
 
@@ -525,8 +527,8 @@ When you start building on this from `ubuntu-dev`:
 
 - [ ] Install `python3 chirpstack-api paho-mqtt` (or whatever language SDK)
 - [ ] Generate a ChirpStack API token in the UI, store securely
-- [ ] Verify access: `nc -vz 10.254.0.11 8080` (gRPC/HTTP) and `nc -vz 10.250.0.41 1883` (MQTT)
-- [ ] Subscribe to `application/+/device/+/event/up` on `10.250.0.41:1883` with the chirpstack creds — that's your firehose of decoded sensor data
+- [ ] Verify access: `nc -vz 10.0.0.10 8080` (gRPC/HTTP) and `nc -vz 10.0.1.10 1883` (MQTT)
+- [ ] Subscribe to `application/+/device/+/event/up` on `10.0.1.10:1883` with the chirpstack creds — that's your firehose of decoded sensor data
 - [ ] Decide whether your project consumes via MQTT (push), gRPC list/get (pull), or both
 - [ ] Add HA bridge-health sensor YAML if not already done
-- [ ] Subscribe to `gateway/wyolora/bridge/state` in your project too if you want to gate logic on VPN health
+- [ ] Subscribe to `gateway/mygw/bridge/state` in your project too if you want to gate logic on VPN health

--- a/docs/lorawan/workflow-integration.md
+++ b/docs/lorawan/workflow-integration.md
@@ -199,7 +199,7 @@ gateway and the WireStudio integration is correct end-to-end.
    `github://moellere/lorawan-for-esphome@<sha>`.
 4. Flash: WebSerial flash succeeds; device boots.
 5. Join: serial monitor shows the component's join log; ChirpStack `event/join`
-   fires (on the HA broker at `10.250.0.41:1883`, app topic).
+   fires (on the HA MQTT broker, app topic).
 6. Uplink: first `event/up` decodes through the codec, fields appear under
    `object`; HA chirp integration creates the entity.
 7. **Power-cycle re-joins without nonce flush** — proves nonce persistence

--- a/scripts/chirpstack_provision_smoke.py
+++ b/scripts/chirpstack_provision_smoke.py
@@ -10,7 +10,8 @@ the gRPC writes against the 4.17 server.
     CHIRPSTACK_API_TOKEN=<token> python scripts/chirpstack_provision_smoke.py provision
     CHIRPSTACK_API_TOKEN=<token> python scripts/chirpstack_provision_smoke.py cleanup
 
-CHIRPSTACK_API_URL defaults to 10.254.0.11:8080. Run `cleanup` when done.
+CHIRPSTACK_API_URL defaults to chirpstack:8080 (typical in-cluster Service
+name). Set the env var to point at your own server. Run `cleanup` when done.
 """
 from __future__ import annotations
 

--- a/tests/test_lorawan_api.py
+++ b/tests/test_lorawan_api.py
@@ -166,11 +166,11 @@ def test_provision_rejects_bad_dev_eui(client, monkeypatch):
 def test_chirpstack_status_passthrough(client, monkeypatch):
     monkeypatch.setattr(
         cs, "chirpstack_status",
-        lambda *a, **k: {"available": True, "url": "10.254.0.11:8080", "reason": None},
+        lambda *a, **k: {"available": True, "url": "chirpstack:8080", "reason": None},
     )
     r = client.get("/lorawan/chirpstack/status")
     assert r.status_code == 200
-    assert r.json() == {"available": True, "url": "10.254.0.11:8080", "reason": None}
+    assert r.json() == {"available": True, "url": "chirpstack:8080", "reason": None}
 
 
 def test_provision_503_when_chirpstack_unconfigured(client, monkeypatch):

--- a/wirestudio/targets/lorawan/chirpstack.py
+++ b/wirestudio/targets/lorawan/chirpstack.py
@@ -19,7 +19,8 @@ Heavy deps (grpcio, chirpstack-api) are the ``lorawan`` extra and imported
 lazily; without them every call raises ``ChirpStackUnavailable``. Credentials
 come from the environment, never ``design.json``:
 
-* ``CHIRPSTACK_API_URL``   gRPC host:port (default ``10.254.0.11:8080``)
+* ``CHIRPSTACK_API_URL``   gRPC host:port (default ``chirpstack:8080``,
+  the typical in-cluster Service name; override for non-k8s deploys)
 * ``CHIRPSTACK_API_TOKEN`` Bearer token generated in the ChirpStack UI
 * ``CHIRPSTACK_API_TLS``   ``true`` for a TLS channel (default plaintext)
 """
@@ -30,7 +31,7 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Optional
 
-DEFAULT_URL = "10.254.0.11:8080"
+DEFAULT_URL = "chirpstack:8080"
 
 
 class ChirpStackUnavailable(RuntimeError):


### PR DESCRIPTION
## Summary

Two things bundled because they're both about the ChirpStack k8s
deployment story:

1. **Wire ChirpStack envs into `deploy/k8s.yaml`** so
   `/lorawan/provision*` works after a `kubectl apply` without
   hand-editing the Deployment:
   - `CHIRPSTACK_API_URL` — plain env, defaults to `chirpstack:8080`
     (typical in-cluster Service name).
   - `CHIRPSTACK_API_TOKEN` — `secretKeyRef` on `wirestudio-secrets`
     with `optional: true` (matches the other gated features).
   - `CHIRPSTACK_API_TLS` — commented stub for the TLS case.
   - `deploy/README.md` `kubectl create secret` example extended with
     `--from-literal=chirpstack-api-token=xxx`.

2. **Flip `DEFAULT_URL` in `chirpstack.py` to `chirpstack:8080`.** The
   prior default was a specific LAN IP that was only meaningful on the
   original author's network. The new default matches the k8s manifest
   and works out of the box; non-k8s deploys still set the env
   explicitly. `tests/test_lorawan_api.py` updated to match.

3. **Scrub local-environment specifics from `docs/lorawan/`** (also
   driven by the public-repo concern). Replaced with documentation
   placeholders:

| Was | Now |
|---|---|
| `wyolora` (gateway hostname) | `mygw` |
| `10.254.0.11` (gateway/ChirpStack) | `10.0.0.10` |
| `10.250.0.41` (HA MQTT broker) | `10.0.1.10` |
| `10.250.0.99` (dev VM) | `10.0.1.20` |
| `10.254.0.0/24` / `10.250.0.0/24` (subnets) | `10.0.0.0/24` / `10.0.1.0/24` |
| `0016c001ff18560f` (gateway silicon ID) | `0000000000000000` |
| `home.dorktool.com`, `argo.dorktool.com`, `authentik.dorktool.com` | `home.example.com`, `argo.example.com`, `auth.example.com` |

Standard HAOS mDNS `homeassistant.local` left alone — that's a default,
not a leak. Hardware identifiers (RAK2287/SX1302, US915 sub-band 2)
left alone — they're public hardware specs, not network info.

## Heads-up on git history

This PR cleans the **current** tree. The original values are still
visible in the repo's git history (the commits that introduced the
docs/lorawan/ files). Fully expunging them needs a history rewrite
(`git filter-repo`) + a force-push to `main` + every clone re-fetching.
Worth doing if the IPs/hostnames are sensitive; if they're just
embarrassing-but-low-risk, this PR + token/password rotation is
usually enough. Happy to follow up with the rewrite PR if you want.

## Test plan

- [x] `pytest tests/test_lorawan_api.py tests/test_chirpstack.py` — 28 passed.
- [ ] `kubectl apply -f deploy/k8s.yaml` on a cluster that has a ChirpStack Service named `chirpstack:8080` and verify `/api/lorawan/chirpstack/status` returns `available: true` once the secret holds a valid token.
- [ ] Re-skim `docs/lorawan/*` for any host/IP/ID I missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_