### PR TITLE
fix(lorawan): surface gRPC errors as 502; gate provision dialog on chirpstack status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **LoRaWAN: gRPC errors no longer hide behind a bare 500.** Every
+  `ChirpStackClient` helper now wraps `grpc.RpcError` ->
+  `ChirpStackUnavailable(_rpc_msg(exc))`, the same convention `ping()`
+  already used. `/lorawan/provision-esphome`, `/lorawan/provision`,
+  `/lorawan/activation`, and the codec endpoints already caught
+  `ChirpStackUnavailable` -> 502; now they actually receive it, so a bad
+  Bearer token surfaces as `502 "UNAUTHENTICATED:"` with the gRPC
+  details visible in the response body instead of an unhandled 500 the
+  UI couldn't explain. Triggered by a user-side debugging session: the
+  pod had a stale token, the provisioning click 500'd silently, and
+  reproducing it took digging through container logs to find the
+  `_InactiveRpcError` the stack swallowed.
+
 ### Added
 
 - **k8s manifest: ChirpStack provisioning envs.** `deploy/k8s.yaml` now
@@ -15,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   secretKeyRef on `wirestudio-secrets`). A commented `CHIRPSTACK_API_TLS`
   entry covers the TLS-channel case. Closes the gap where `/lorawan/provision*`
   needed the operator to hand-add envs after every `kubectl apply`.
+- **Provision dialog gates on `/lorawan/chirpstack/status`.** The
+  external-component path's `LorawanProvisionEsphomeDialog` now probes
+  ChirpStack reachability + auth on mount. When the probe returns
+  `available: false`, the dialog renders an inline banner with the gRPC
+  reason (plus a nudge that the Bearer token comes from the ChirpStack
+  UI's **API Keys**, not the JWT signing secret -- the §11 footgun the
+  setup doc warns about) and the Provision button stays disabled. Pairs
+  with the wrap above: the banner shows the same `UNAUTHENTICATED:`
+  string the click would otherwise have produced, but at dialog-open
+  time, so the operator catches the misconfiguration before clicking.
 
 ### Changed
 

--- a/tests/test_chirpstack.py
+++ b/tests/test_chirpstack.py
@@ -130,10 +130,13 @@ def test_create_device_swallows_already_exists():
     _client(stubs).create_device("0011223344556677", "dev", "app", "dp")
 
 
-def test_create_device_reraises_other_errors():
+def test_create_device_wraps_other_errors_as_chirpstack_unavailable():
+    # Transport / auth / permission errors get converted to ChirpStackUnavailable
+    # so the FastAPI handlers (which only catch ChirpStackUnavailable) turn them
+    # into a 502 with the gRPC status + details, not a bare unhandled 500.
     stubs = _stubs()
     stubs.device.Create.side_effect = _RpcError(grpc.StatusCode.PERMISSION_DENIED)
-    with pytest.raises(grpc.RpcError):
+    with pytest.raises(cs.ChirpStackUnavailable, match="PERMISSION_DENIED"):
         _client(stubs).create_device("0011223344556677", "dev", "app", "dp")
 
 
@@ -158,6 +161,23 @@ def test_flush_dev_nonces_calls_rpc_with_dev_eui():
     _client(stubs).flush_dev_nonces("0011223344556677")
     req = stubs.device.FlushDevNonces.call_args.args[0]
     assert req.dev_eui == "0011223344556677"
+
+
+def test_default_tenant_id_wraps_rpc_error_as_chirpstack_unavailable():
+    # The first call of every provisioning chain. A bad token surfaces here
+    # (UNAUTHENTICATED), and the wrap is what turns the otherwise-unhandled
+    # 500 the user saw into a 502 with "UNAUTHENTICATED:" in the body.
+    stubs = _stubs()
+    stubs.tenant.List.side_effect = _RpcError(grpc.StatusCode.UNAUTHENTICATED)
+    with pytest.raises(cs.ChirpStackUnavailable, match="UNAUTHENTICATED"):
+        _client(stubs).default_tenant_id()
+
+
+def test_flush_dev_nonces_wraps_rpc_error_as_chirpstack_unavailable():
+    stubs = _stubs()
+    stubs.device.FlushDevNonces.side_effect = _RpcError(grpc.StatusCode.UNAVAILABLE)
+    with pytest.raises(cs.ChirpStackUnavailable, match="UNAVAILABLE"):
+        _client(stubs).flush_dev_nonces("0011223344556677")
 
 
 def test_delete_device_calls_rpc():

--- a/tests/test_lorawan_api.py
+++ b/tests/test_lorawan_api.py
@@ -363,3 +363,24 @@ def test_provision_esphome_503_when_chirpstack_unconfigured(client, monkeypatch)
         json={"dev_eui": "70b3d57ed0001234", "design": _esphome_lorawan_design()},
     )
     assert r.status_code == 503
+
+
+def test_provision_esphome_502_surfaces_grpc_status_on_chirpstack_unavailable(
+    client, monkeypatch
+):
+    """Regression: a UNAUTHENTICATED (bad API token) from any helper used to bubble
+    as a bare 500 with no body because only ChirpStackUnavailable was caught. The
+    helpers now wrap grpc.RpcError -> ChirpStackUnavailable, so the endpoint
+    returns 502 with the gRPC status + details and the dialog can render it."""
+
+    class _Boom(_FakeChirp):
+        def provision_device(self, **_kwargs):
+            raise cs.ChirpStackUnavailable("UNAUTHENTICATED: ")
+
+    monkeypatch.setattr(cs, "ChirpStackClient", lambda: _Boom())
+    r = client.post(
+        "/lorawan/provision-esphome",
+        json={"dev_eui": "70b3d57ed0001234", "design": _esphome_lorawan_design()},
+    )
+    assert r.status_code == 502
+    assert "UNAUTHENTICATED" in r.json()["detail"]

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4,6 +4,7 @@ import type {
   AgentStreamEvent,
   AgentTurnResponse,
   BoardSummary,
+  ChirpstackStatus,
   ComponentSummary,
   EnclosureSearchResponse,
   EnclosureSearchStatus,
@@ -238,6 +239,11 @@ export const api = {
     request<FleetRunStatus>(`/fleet/jobs/${encodeURIComponent(runId)}`),
 
   lorawanCompileStatus: () => request<LorawanCompileStatus>("/lorawan/compile/status"),
+  /** Probe ChirpStack: reachability + token auth. The provision dialog calls
+   *  this on mount so a misconfigured server is flagged inline rather than
+   *  after a Provision click. */
+  lorawanChirpstackStatus: () =>
+    request<ChirpstackStatus>("/lorawan/chirpstack/status"),
   /** Register the device in ChirpStack and get back the band/EUIs/AppKey to
    *  write into its serial provisioning prompt. */
   lorawanProvision: (body: { dev_eui: string; design: Design }) =>

--- a/web/src/components/LorawanProvisionEsphomeDialog.test.tsx
+++ b/web/src/components/LorawanProvisionEsphomeDialog.test.tsx
@@ -25,6 +25,7 @@ vi.mock("../api/client", async () => {
     ...actual,
     api: {
       ...actual.api,
+      lorawanChirpstackStatus: vi.fn(),
       lorawanProvisionEsphome: vi.fn(),
       lorawanActivation: vi.fn(),
       fleetPush: vi.fn(),
@@ -44,6 +45,7 @@ const mockDetectChip = detectChip as unknown as ReturnType<typeof vi.fn>;
 const mockSupported = isWebSerialSupported as unknown as ReturnType<typeof vi.fn>;
 
 const mockApi = api as unknown as {
+  lorawanChirpstackStatus: ReturnType<typeof vi.fn>;
   lorawanProvisionEsphome: ReturnType<typeof vi.fn>;
   lorawanActivation: ReturnType<typeof vi.fn>;
   fleetPush: ReturnType<typeof vi.fn>;
@@ -71,6 +73,13 @@ function design(overrides: Partial<Design> = {}): Design {
 }
 
 beforeEach(() => {
+  mockApi.lorawanChirpstackStatus.mockReset();
+  // Default to a reachable ChirpStack; the unavailable case is its own test.
+  mockApi.lorawanChirpstackStatus.mockResolvedValue({
+    available: true,
+    url: "chirpstack:8080",
+    reason: null,
+  });
   mockApi.lorawanProvisionEsphome.mockReset();
   mockApi.lorawanActivation.mockReset();
   mockApi.fleetPush.mockReset();
@@ -213,6 +222,30 @@ describe("successful provision flow", () => {
       expect(screen.queryByRole("button", { name: /Provision →/i })).toBeNull(),
     );
     expect(screen.getByRole("button", { name: /^Done$/i })).toBeTruthy();
+  });
+});
+
+describe("chirpstack reachability gating", () => {
+  it("disables Provision and renders the reason when /lorawan/chirpstack/status reports unavailable", async () => {
+    mockApi.lorawanChirpstackStatus.mockResolvedValue({
+      available: false,
+      url: "chirpstack:8080",
+      reason: "ChirpStack unreachable: UNAUTHENTICATED: ",
+    });
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    // Banner with the gRPC reason renders.
+    await waitFor(() =>
+      expect(screen.getByText(/ChirpStack unavailable/i)).toBeTruthy(),
+    );
+    expect(screen.getByText(/UNAUTHENTICATED/i)).toBeTruthy();
+    // Provision stays disabled even with a valid DevEUI typed -- there's
+    // nothing useful to do when the server can't be reached.
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText(/70b3d57ed0001234/i), "70b3d57ed0001234");
+    const provisionBtn = screen.getByRole("button", { name: /Provision →/i });
+    expect((provisionBtn as HTMLButtonElement).disabled).toBe(true);
+    expect(mockApi.lorawanProvisionEsphome).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/components/LorawanProvisionEsphomeDialog.tsx
+++ b/web/src/components/LorawanProvisionEsphomeDialog.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useRef, useState } from "react";
 import { api, ApiError } from "../api/client";
 import type {
+  ChirpstackStatus,
   Design,
   LorawanActivationResponse,
   LorawanProvisionEsphomeResponse,
@@ -75,8 +76,36 @@ export function LorawanProvisionEsphomeDialog({ design, onClose }: Props) {
   const [detecting, setDetecting] = useState(false);
   const [detected, setDetected] = useState<{ chipName: string; mac: string } | null>(null);
   const [detectErr, setDetectErr] = useState<string | null>(null);
+  const [chirpStatus, setChirpStatus] = useState<ChirpstackStatus | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const webSerial = isWebSerialSupported() === "yes";
+
+  // Probe ChirpStack reachability + auth on mount so a misconfigured server
+  // (bad token, unreachable, no tenant) is flagged inline instead of after a
+  // Provision click that 502s. Failure here disables the Provision button --
+  // there's nothing useful to do when ChirpStack is unreachable, and prior
+  // behaviour was to let the click through and surface a bare 500.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const s = await api.lorawanChirpstackStatus();
+        if (!cancelled) setChirpStatus(s);
+      } catch (e) {
+        if (cancelled) return;
+        // The endpoint itself failed (network, not configured). Surface as
+        // unavailable so the Provision button stays disabled.
+        setChirpStatus({
+          available: false,
+          url: null,
+          reason: e instanceof Error ? e.message : String(e),
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Reset the copy-feedback flag a couple seconds after the user copies, so
   // the button doesn't stay green forever on a multi-paste workflow.
@@ -227,7 +256,12 @@ export function LorawanProvisionEsphomeDialog({ design, onClose }: Props) {
   }
 
   const devEuiValid = DEV_EUI_RE.test(devEui);
-  const canProvision = eligible && devEuiValid && !provisioning && !result;
+  // ChirpStack-not-available gates the Provision button. Status is null while
+  // the initial probe is in flight; treat that as "not yet". When the probe
+  // settles to available=true we let provisioning proceed.
+  const chirpReady = chirpStatus?.available === true;
+  const canProvision =
+    eligible && devEuiValid && chirpReady && !provisioning && !result;
 
   return (
     <div
@@ -338,6 +372,30 @@ export function LorawanProvisionEsphomeDialog({ design, onClose }: Props) {
                   Expected 16 hex characters; got {devEui.length}.
                 </div>
               )}
+            </div>
+          )}
+
+          {/* ChirpStack reachability/auth -- gates the Provision button. The
+              endpoint is the same `chirpstack_status()` the CLI smoke uses;
+              when it returns available=false, the reason is the gRPC status
+              from the helper that wraps RpcError -> ChirpStackUnavailable. */}
+          {eligible && chirpStatus && !chirpStatus.available && (
+            <div className="rounded-md border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-200">
+              <div className="font-semibold">ChirpStack unavailable</div>
+              <div className="mt-1 text-amber-200/80">
+                {chirpStatus.reason ?? "unknown reason"}
+                {chirpStatus.url && (
+                  <>
+                    {" "}
+                    (server <code>{chirpStatus.url}</code>)
+                  </>
+                )}
+              </div>
+              <div className="mt-1 text-amber-300/70">
+                Check <code>CHIRPSTACK_API_URL</code> / <code>CHIRPSTACK_API_TOKEN</code>
+                {" "}on the server; the Bearer token comes from the ChirpStack UI under
+                {" "}<strong>API Keys</strong>, not the JWT signing secret.
+              </div>
             </div>
           )}
 
@@ -464,6 +522,15 @@ export function LorawanProvisionEsphomeDialog({ design, onClose }: Props) {
               <button
                 disabled={!canProvision}
                 onClick={handleProvision}
+                title={
+                  !chirpStatus
+                    ? "Probing ChirpStack…"
+                    : !chirpStatus.available
+                      ? `ChirpStack unavailable: ${chirpStatus.reason ?? "unknown"}`
+                      : !devEuiValid
+                        ? "Enter a 16-hex-char DevEUI"
+                        : undefined
+                }
                 className="rounded-md bg-blue-500/20 px-3 py-1.5 text-sm text-blue-100 ring-1 ring-blue-400/40 enabled:hover:bg-blue-500/30 disabled:opacity-40"
               >
                 {provisioning ? "Provisioning…" : "Provision →"}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -346,6 +346,15 @@ export interface LorawanProvisionResponse {
   device_profile_id: string;
 }
 
+/** Response shape of GET /lorawan/chirpstack/status. `available` is the
+ *  headline the UI keys off (matches the other feature-gate status
+ *  endpoints). `reason` carries the gRPC status when unavailable. */
+export interface ChirpstackStatus {
+  available: boolean;
+  url: string | null;
+  reason: string | null;
+}
+
 /** Response shape of POST /lorawan/provision-esphome (W3 — external-component
  *  path). The `secrets` block is formatted for the `secrets.yaml` that rides
  *  next to the rendered ESPHome config. The AppKey is ephemeral and only

--- a/wirestudio/targets/lorawan/chirpstack.py
+++ b/wirestudio/targets/lorawan/chirpstack.py
@@ -133,9 +133,12 @@ class ChirpStackClient:
 
     def default_tenant_id(self) -> str:
         grpc, m = _load()
-        resp = self._get_stubs().tenant.List(
-            m.tenant.ListTenantsRequest(limit=1), metadata=self._auth
-        )
+        try:
+            resp = self._get_stubs().tenant.List(
+                m.tenant.ListTenantsRequest(limit=1), metadata=self._auth
+            )
+        except grpc.RpcError as exc:
+            raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
         if not resp.result:
             raise ChirpStackUnavailable("ChirpStack has no tenant to provision under")
         return resp.result[0].id
@@ -151,7 +154,7 @@ class ChirpStackClient:
         except grpc.RpcError as exc:
             if exc.code() == grpc.StatusCode.NOT_FOUND:
                 return None
-            raise
+            raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
         act = resp.device_activation
         if not act.dev_addr:
             return None
@@ -162,19 +165,22 @@ class ChirpStackClient:
     def ensure_application(self, name: str, *, tenant_id: str) -> str:
         grpc, m = _load()
         stubs = self._get_stubs()
-        resp = stubs.application.List(
-            m.app.ListApplicationsRequest(limit=100, tenant_id=tenant_id, search=name),
-            metadata=self._auth,
-        )
-        for item in resp.result:
-            if item.name == name:
-                return item.id
-        created = stubs.application.Create(
-            m.app.CreateApplicationRequest(
-                application=m.app.Application(name=name, tenant_id=tenant_id)
-            ),
-            metadata=self._auth,
-        )
+        try:
+            resp = stubs.application.List(
+                m.app.ListApplicationsRequest(limit=100, tenant_id=tenant_id, search=name),
+                metadata=self._auth,
+            )
+            for item in resp.result:
+                if item.name == name:
+                    return item.id
+            created = stubs.application.Create(
+                m.app.CreateApplicationRequest(
+                    application=m.app.Application(name=name, tenant_id=tenant_id)
+                ),
+                metadata=self._auth,
+            )
+        except grpc.RpcError as exc:
+            raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
         return created.id
 
     def ensure_device_profile(
@@ -189,40 +195,43 @@ class ChirpStackClient:
         """
         grpc, m = _load()
         stubs = self._get_stubs()
-        resp = stubs.device_profile.List(
-            m.dp.ListDeviceProfilesRequest(limit=100, tenant_id=tenant_id, search=name),
-            metadata=self._auth,
-        )
-        for item in resp.result:
-            if item.name == name and item.region == m.common.Region.US915:
-                if codec is not None:
-                    existing = stubs.device_profile.Get(
-                        m.dp.GetDeviceProfileRequest(id=item.id), metadata=self._auth
-                    ).device_profile
-                    existing.payload_codec_runtime = m.dp.CodecRuntime.JS
-                    existing.payload_codec_script = codec
-                    stubs.device_profile.Update(
-                        m.dp.UpdateDeviceProfileRequest(device_profile=existing),
-                        metadata=self._auth,
-                    )
-                return item.id
-        profile = m.dp.DeviceProfile(
-            name=name,
-            tenant_id=tenant_id,
-            region=m.common.Region.US915,
-            region_config_id="us915_1",
-            mac_version=m.common.MacVersion.LORAWAN_1_0_4,
-            reg_params_revision=m.common.RegParamsRevision.RP002_1_0_0,
-            adr_algorithm_id="default",
-            supports_otaa=True,
-            uplink_interval=3600,
-        )
-        if codec is not None:
-            profile.payload_codec_runtime = m.dp.CodecRuntime.JS
-            profile.payload_codec_script = codec
-        created = stubs.device_profile.Create(
-            m.dp.CreateDeviceProfileRequest(device_profile=profile), metadata=self._auth
-        )
+        try:
+            resp = stubs.device_profile.List(
+                m.dp.ListDeviceProfilesRequest(limit=100, tenant_id=tenant_id, search=name),
+                metadata=self._auth,
+            )
+            for item in resp.result:
+                if item.name == name and item.region == m.common.Region.US915:
+                    if codec is not None:
+                        existing = stubs.device_profile.Get(
+                            m.dp.GetDeviceProfileRequest(id=item.id), metadata=self._auth
+                        ).device_profile
+                        existing.payload_codec_runtime = m.dp.CodecRuntime.JS
+                        existing.payload_codec_script = codec
+                        stubs.device_profile.Update(
+                            m.dp.UpdateDeviceProfileRequest(device_profile=existing),
+                            metadata=self._auth,
+                        )
+                    return item.id
+            profile = m.dp.DeviceProfile(
+                name=name,
+                tenant_id=tenant_id,
+                region=m.common.Region.US915,
+                region_config_id="us915_1",
+                mac_version=m.common.MacVersion.LORAWAN_1_0_4,
+                reg_params_revision=m.common.RegParamsRevision.RP002_1_0_0,
+                adr_algorithm_id="default",
+                supports_otaa=True,
+                uplink_interval=3600,
+            )
+            if codec is not None:
+                profile.payload_codec_runtime = m.dp.CodecRuntime.JS
+                profile.payload_codec_script = codec
+            created = stubs.device_profile.Create(
+                m.dp.CreateDeviceProfileRequest(device_profile=profile), metadata=self._auth
+            )
+        except grpc.RpcError as exc:
+            raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
         return created.id
 
     def create_device(
@@ -250,7 +259,7 @@ class ChirpStackClient:
             )
         except grpc.RpcError as exc:
             if exc.code() != grpc.StatusCode.ALREADY_EXISTS:
-                raise
+                raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
 
     def set_device_keys(self, dev_eui: str, app_key: str) -> None:
         """Set the device's root key. For our pinned LoRaWAN 1.0.4 devices the
@@ -265,11 +274,14 @@ class ChirpStackClient:
             )
         except grpc.RpcError as exc:
             if exc.code() == grpc.StatusCode.ALREADY_EXISTS:
-                stubs.device.UpdateKeys(
-                    m.dev.UpdateDeviceKeysRequest(device_keys=keys), metadata=self._auth
-                )
+                try:
+                    stubs.device.UpdateKeys(
+                        m.dev.UpdateDeviceKeysRequest(device_keys=keys), metadata=self._auth
+                    )
+                except grpc.RpcError as upd_exc:
+                    raise ChirpStackUnavailable(_rpc_msg(upd_exc)) from upd_exc
             else:
-                raise
+                raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
 
     def delete_device(self, dev_eui: str) -> None:
         """Delete a device. Idempotent: a missing DevEUI is a no-op. Used to
@@ -281,7 +293,7 @@ class ChirpStackClient:
             )
         except grpc.RpcError as exc:
             if exc.code() != grpc.StatusCode.NOT_FOUND:
-                raise
+                raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
 
     def set_device_codec(self, dev_eui: str, codec: str) -> str:
         """Set the JS decodeUplink codec on the device's profile so ChirpStack
@@ -289,19 +301,22 @@ class ChirpStackClient:
         whatever profile it's on. Returns the device_profile_id."""
         grpc, m = _load()
         stubs = self._get_stubs()
-        dev = stubs.device.Get(
-            m.dev.GetDeviceRequest(dev_eui=dev_eui), metadata=self._auth
-        )
-        profile_id = dev.device.device_profile_id
-        resp = stubs.device_profile.Get(
-            m.dp.GetDeviceProfileRequest(id=profile_id), metadata=self._auth
-        )
-        profile = resp.device_profile
-        profile.payload_codec_runtime = m.dp.CodecRuntime.JS
-        profile.payload_codec_script = codec
-        stubs.device_profile.Update(
-            m.dp.UpdateDeviceProfileRequest(device_profile=profile), metadata=self._auth
-        )
+        try:
+            dev = stubs.device.Get(
+                m.dev.GetDeviceRequest(dev_eui=dev_eui), metadata=self._auth
+            )
+            profile_id = dev.device.device_profile_id
+            resp = stubs.device_profile.Get(
+                m.dp.GetDeviceProfileRequest(id=profile_id), metadata=self._auth
+            )
+            profile = resp.device_profile
+            profile.payload_codec_runtime = m.dp.CodecRuntime.JS
+            profile.payload_codec_script = codec
+            stubs.device_profile.Update(
+                m.dp.UpdateDeviceProfileRequest(device_profile=profile), metadata=self._auth
+            )
+        except grpc.RpcError as exc:
+            raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
         return profile_id
 
     def get_device_codec(self, dev_eui: str) -> dict:
@@ -309,13 +324,16 @@ class ChirpStackClient:
         whether ``object`` decoding will happen."""
         grpc, m = _load()
         stubs = self._get_stubs()
-        dev = stubs.device.Get(
-            m.dev.GetDeviceRequest(dev_eui=dev_eui), metadata=self._auth
-        )
-        profile_id = dev.device.device_profile_id
-        profile = stubs.device_profile.Get(
-            m.dp.GetDeviceProfileRequest(id=profile_id), metadata=self._auth
-        ).device_profile
+        try:
+            dev = stubs.device.Get(
+                m.dev.GetDeviceRequest(dev_eui=dev_eui), metadata=self._auth
+            )
+            profile_id = dev.device.device_profile_id
+            profile = stubs.device_profile.Get(
+                m.dp.GetDeviceProfileRequest(id=profile_id), metadata=self._auth
+            ).device_profile
+        except grpc.RpcError as exc:
+            raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
         script = profile.payload_codec_script or ""
         return {
             "device_profile_id": profile_id,
@@ -331,9 +349,12 @@ class ChirpStackClient:
         whose nonce counter reset, joins cleanly instead of being dropped as a
         replay."""
         grpc, m = _load()
-        self._get_stubs().device.FlushDevNonces(
-            m.dev.FlushDevNoncesRequest(dev_eui=dev_eui), metadata=self._auth
-        )
+        try:
+            self._get_stubs().device.FlushDevNonces(
+                m.dev.FlushDevNoncesRequest(dev_eui=dev_eui), metadata=self._auth
+            )
+        except grpc.RpcError as exc:
+            raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
 
     def provision_device(
         self,


### PR DESCRIPTION
## Summary

Fixes the bare 500 you hit on `/lorawan/provision-esphome` and the
matching dialog UX gap that let the click through even though
`/lorawan/chirpstack/status` was already reporting the failure.

### A — convert gRPC errors to actionable 502s

The endpoint already caught `ChirpStackUnavailable` and returned 502
with the message. But only `ping()` translated `grpc.RpcError` into that
type. Every helper in the provisioning chain
(`default_tenant_id`, `ensure_application`, `ensure_device_profile`,
`create_device`, `set_device_keys`, `flush_dev_nonces`,
`set_device_codec`, `get_device_codec`, `get_activation`,
`delete_device`) let `RpcError` propagate as-is, so FastAPI emitted an
unhandled-exception 500 with an empty body. The traceback was only
visible in the container log.

Now every helper wraps `grpc.RpcError -> ChirpStackUnavailable(_rpc_msg(exc))`
(same pattern `ping()` already used). The four affected endpoints
(`/provision`, `/provision-esphome`, `/activation`, `/codec` × 2) already
catch `ChirpStackUnavailable` -> 502, so the gRPC status string
(`"UNAUTHENTICATED: "`, `"PERMISSION_DENIED: ..."`, etc.) lands in
`response.json().detail` and renders inline in the dialog's error banner.

### B — gate the provision dialog on `/lorawan/chirpstack/status`

`LorawanProvisionEsphomeDialog` now probes the status endpoint on mount.
When the probe returns `available: false`:

- An amber banner renders with the gRPC reason (the same string from A
  above) and a nudge about the **Bearer token vs JWT signing secret**
  footgun (the `docs/lorawan/chirpstack-lorawan-setup.md` §11 thing
  that bit during the debugging session).
- The Provision button stays disabled with a `title` explaining why.
- The Provision click never fires, so this exact failure becomes a
  banner at dialog-open time, not after a `Provision →` round-trip.

## Test plan

- [x] `pytest tests/test_chirpstack.py tests/test_lorawan_api.py` — 50 passed (was 28 + 2 new + 1 flipped from old swallow-and-reraise semantics + existing).
- [x] `pytest` full suite — 826 passed, 10 skipped.
- [x] `vitest run` full suite — 181 passed.
- [x] `ruff check`, `tsc --noEmit`, `eslint` clean.
- [ ] Roll the image to a pod with the existing bad token and hit the dialog: banner renders `"ChirpStack unavailable: UNAUTHENTICATED:"`, Provision stays disabled. Replace the token, refresh: banner disappears, Provision enables.

## Notes

- Doesn't touch `/lorawan/chirpstack/status` itself — that endpoint was
  already correct (and reporting the failure you observed via
  `kubectl exec`). The bug was only that the **provisioning click** ignored
  status and the **helpers** swallowed the underlying gRPC code.
- The dialog test for the new gating uses a fresh `describe` block so
  the existing flows (eligibility, success, error, push-to-fleet, detect)
  pin the default `available: true` behaviour via `beforeEach`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_