### PR TITLE
fix(lorawan): handle cross-application dev_eui collisions explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **LoRaWAN: `create_device` is actually idempotent now.** ChirpStack v4
+  scopes `dev_eui` uniquely per tenant (not per application) and leaks
+  the SQLite UNIQUE constraint as `INTERNAL` rather than `ALREADY_EXISTS`
+  on a duplicate. `create_device` now resolves the conflict via a
+  follow-up `Device.Get`: same application -> the documented idempotent
+  no-op (the rest of `provision_device` re-keys and flushes nonces);
+  different application -> raise with the conflicting `application_id`
+  so the operator removes the device there instead of silently re-homing
+  across paths (standalone vs esphome). `set_device_keys` gets the
+  same INTERNAL/UNIQUE handling for the `device_keys.dev_eui` row, so a
+  re-provision falls through to `UpdateKeys` the same way ALREADY_EXISTS
+  did.
 - **LoRaWAN: gRPC errors no longer hide behind a bare 500.** Every
   `ChirpStackClient` helper now wraps `grpc.RpcError` ->
   `ChirpStackUnavailable(_rpc_msg(exc))`, the same convention `ping()`

--- a/tests/test_chirpstack.py
+++ b/tests/test_chirpstack.py
@@ -13,14 +13,15 @@ from wirestudio.targets.lorawan import chirpstack as cs  # noqa: E402
 
 
 class _RpcError(grpc.RpcError):
-    def __init__(self, code: "grpc.StatusCode") -> None:
+    def __init__(self, code: "grpc.StatusCode", details: str = "simulated") -> None:
         self._code = code
+        self._details = details
 
     def code(self):
         return self._code
 
     def details(self):
-        return "simulated"
+        return self._details
 
 
 def _stubs() -> cs.ChirpStackStubs:
@@ -124,9 +125,13 @@ def test_ensure_device_profile_pins_us915_subband2():
 
 
 def test_create_device_swallows_already_exists():
+    # ALREADY_EXISTS in the same application is the documented idempotent
+    # no-op. Mock Get so the cross-app guard can confirm "same app".
     stubs = _stubs()
     stubs.device.Create.side_effect = _RpcError(grpc.StatusCode.ALREADY_EXISTS)
-    # Must not raise.
+    stubs.device.Get.return_value = SimpleNamespace(
+        device=SimpleNamespace(application_id="app", device_profile_id="dp"),
+    )
     _client(stubs).create_device("0011223344556677", "dev", "app", "dp")
 
 
@@ -138,6 +143,54 @@ def test_create_device_wraps_other_errors_as_chirpstack_unavailable():
     stubs.device.Create.side_effect = _RpcError(grpc.StatusCode.PERMISSION_DENIED)
     with pytest.raises(cs.ChirpStackUnavailable, match="PERMISSION_DENIED"):
         _client(stubs).create_device("0011223344556677", "dev", "app", "dp")
+
+
+def test_create_device_same_app_unique_constraint_is_idempotent_noop():
+    # ChirpStack v4 quirk: re-Create with the same dev_eui returns INTERNAL
+    # carrying the raw SQLite "UNIQUE constraint failed: device.dev_eui"
+    # message rather than ALREADY_EXISTS. When the existing device is in the
+    # SAME application we're targeting, this is the documented idempotent
+    # no-op (the next call -- set_device_keys -- updates the key in place).
+    stubs = _stubs()
+    stubs.device.Create.side_effect = _RpcError(
+        grpc.StatusCode.INTERNAL,
+        details="UNIQUE constraint failed: device.dev_eui",
+    )
+    stubs.device.Get.return_value = SimpleNamespace(
+        device=SimpleNamespace(application_id="app", device_profile_id="dp"),
+    )
+    # Must not raise -- the rest of provision_device proceeds to re-key.
+    _client(stubs).create_device("0011223344556677", "dev", "app", "dp")
+
+
+def test_create_device_cross_app_unique_constraint_raises_with_conflict_info():
+    # dev_eui is scoped per tenant in ChirpStack, not per application. A
+    # device created earlier under a different path (standalone vs esphome)
+    # collides here. Don't silently re-home: surface the conflicting
+    # application_id so the operator can delete the device there first.
+    stubs = _stubs()
+    stubs.device.Create.side_effect = _RpcError(
+        grpc.StatusCode.INTERNAL,
+        details="UNIQUE constraint failed: device.dev_eui",
+    )
+    stubs.device.Get.return_value = SimpleNamespace(
+        device=SimpleNamespace(application_id="standalone-app", device_profile_id="dp"),
+    )
+    with pytest.raises(cs.ChirpStackUnavailable, match="standalone-app"):
+        _client(stubs).create_device("0011223344556677", "dev", "app", "dp")
+
+
+def test_set_device_keys_treats_internal_unique_constraint_as_already_exists():
+    # Same ChirpStack quirk for CreateKeys: a re-key returns INTERNAL with the
+    # device_keys SQLite unique violation, not ALREADY_EXISTS. We fall through
+    # to UpdateKeys the same way we do for the ALREADY_EXISTS path.
+    stubs = _stubs()
+    stubs.device.CreateKeys.side_effect = _RpcError(
+        grpc.StatusCode.INTERNAL,
+        details="UNIQUE constraint failed: device_keys.dev_eui",
+    )
+    _client(stubs).set_device_keys("0011223344556677", "cd" * 16)
+    stubs.device.UpdateKeys.assert_called_once()
 
 
 def test_set_device_keys_writes_appkey_into_nwk_key():

--- a/wirestudio/targets/lorawan/chirpstack.py
+++ b/wirestudio/targets/lorawan/chirpstack.py
@@ -253,13 +253,34 @@ class ChirpStackClient:
         )
         if join_eui:
             device.join_eui = join_eui
+        stubs = self._get_stubs()
         try:
-            self._get_stubs().device.Create(
+            stubs.device.Create(
                 m.dev.CreateDeviceRequest(device=device), metadata=self._auth
             )
         except grpc.RpcError as exc:
-            if exc.code() != grpc.StatusCode.ALREADY_EXISTS:
+            if not _is_already_exists(exc, "device"):
                 raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
+            # The dev_eui is registered somewhere in this tenant -- ChirpStack
+            # scopes dev_eui uniquely per tenant, NOT per application, so a
+            # device created earlier under a different path (standalone vs
+            # esphome) collides here even though the application differs.
+            # Resolve the existing device's application: same as ours -> the
+            # documented idempotent no-op; different -> raise with the
+            # conflicting application_id so the operator can remove the device
+            # there (we don't silently re-home devices across apps).
+            try:
+                existing = stubs.device.Get(
+                    m.dev.GetDeviceRequest(dev_eui=dev_eui), metadata=self._auth
+                ).device
+            except grpc.RpcError as get_exc:
+                raise ChirpStackUnavailable(_rpc_msg(get_exc)) from get_exc
+            if existing.application_id != application_id:
+                raise ChirpStackUnavailable(
+                    f"dev_eui {dev_eui} is already registered in a different "
+                    f"application ({existing.application_id}); remove it from "
+                    "that application before re-provisioning here."
+                )
 
     def set_device_keys(self, dev_eui: str, app_key: str) -> None:
         """Set the device's root key. For our pinned LoRaWAN 1.0.4 devices the
@@ -273,7 +294,10 @@ class ChirpStackClient:
                 m.dev.CreateDeviceKeysRequest(device_keys=keys), metadata=self._auth
             )
         except grpc.RpcError as exc:
-            if exc.code() == grpc.StatusCode.ALREADY_EXISTS:
+            # ChirpStack v4 leaks the raw SQLite UNIQUE constraint as INTERNAL
+            # instead of ALREADY_EXISTS for CreateKeys -- treat both as
+            # "keys row already there, update it."
+            if _is_already_exists(exc, "device_keys"):
                 try:
                     stubs.device.UpdateKeys(
                         m.dev.UpdateDeviceKeysRequest(device_keys=keys), metadata=self._auth
@@ -396,6 +420,25 @@ def _rpc_msg(exc) -> str:
         return f"{exc.code().name}: {exc.details()}"
     except Exception:  # pragma: no cover - defensive
         return str(exc)
+
+
+def _is_already_exists(exc, table: str) -> bool:
+    """ChirpStack v4 *should* return ALREADY_EXISTS on a duplicate row, but
+    the SQLite backend's UNIQUE-constraint error leaks straight through as
+    INTERNAL with the raw SQLite message. Detect both so Create RPCs that are
+    documented as idempotent (device, device_keys) actually are."""
+    import grpc as _grpc  # local: chirpstack.py's other helpers already _load()
+
+    try:
+        code = exc.code()
+    except Exception:  # pragma: no cover - defensive
+        return False
+    if code == _grpc.StatusCode.ALREADY_EXISTS:
+        return True
+    if code == _grpc.StatusCode.INTERNAL:
+        details = exc.details() or ""
+        return f"UNIQUE constraint failed: {table}" in details
+    return False
 
 
 def chirpstack_status(client: Optional[ChirpStackClient] = None) -> dict:


### PR DESCRIPTION
## Summary

Follow-up to #131. With #131 merged, `/lorawan/provision-esphome` no
longer 500s — it returns 502 with the gRPC status. The next 502 we hit
was the cross-application case:

```
INTERNAL: UNIQUE constraint failed: device.dev_eui
```

Two ChirpStack v4 quirks fold into this:

- `dev_eui` is unique per **tenant**, not per application. A device
  created earlier under the standalone path's application blocks the new
  Create in the esphome path's application even though the application
  name differs.
- A duplicate `device.Create` returns `INTERNAL` carrying the raw SQLite
  `"UNIQUE constraint failed: device.dev_eui"` instead of
  `ALREADY_EXISTS`. Same for `CreateKeys` on `device_keys.dev_eui`.

## Changes

- **`create_device`** treats both `ALREADY_EXISTS` and `INTERNAL` +
  `UNIQUE constraint failed: device` as "device exists somewhere in this
  tenant" and does a follow-up `Device.Get` to resolve which application.
  - Same `application_id` → documented idempotent no-op
    (the rest of `provision_device` re-keys + flushes nonces).
  - Different `application_id` → raise `ChirpStackUnavailable`
    naming the conflicting app id, surfaced to the dialog as
    `502 "dev_eui … is already registered in a different application
    (standalone-app); remove it from that application before
    re-provisioning here."`
- **`set_device_keys`** gets the same `INTERNAL`/`UNIQUE` handling for
  the `device_keys.dev_eui` row → falls through to `UpdateKeys` the same
  way `ALREADY_EXISTS` does.
- **Tests** pin the same-app idempotent path and the cross-app conflict
  message, plus the `INTERNAL`/`UNIQUE` swallow on `CreateKeys`. 53
  lorawan-target tests pass.

## Test plan

- [x] `pytest tests/test_chirpstack.py tests/test_lorawan_api.py` — 53 passed.
- [ ] Re-provision a `dev_eui` already registered in the standalone path's application: 502 with the cross-app error message, not 500 and not silent re-home.
- [ ] Re-provision a `dev_eui` already registered in the *same* esphome application: success with the same `application_id`, `set_device_keys` updates the key, nonces flushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_