### PR TITLE
fix(lorawan): headless YAML + emit SPI pins (gated on upstream lorawan-for-esphome PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **LoRaWAN external-component path now renders headless.** The renderer
+  emitted `wifi:` / `api:` / network `ota:` / `captive_portal:` whenever
+  the design carried a `fleet.secrets_ref`, including on
+  `lorawan-for-esphome` designs. Per the upstream README, all four
+  blocks reboot-loop the device when the network is unreachable
+  (`wifi:` and `api:` default to `reboot_timeout: 15min`), and every
+  reboot burns a DevNonce in the OTAA flow -- the device eventually
+  stops joining. The fleet/HA addon path's headless field nodes need
+  *no* network stack. The renderer now drops the four blocks (including
+  any set via `esphome_extras`) whenever `design.lorawan.payload` is
+  non-empty. The `lorawan-battery-uplink` golden was regenerated to
+  match. User-reported during a Push-to-fleet flow that produced YAML
+  the fleet wouldn't compile cleanly.
 - **LoRaWAN: `create_device` is actually idempotent now.** ChirpStack v4
   scopes `dev_eui` uniquely per tenant (not per application) and leaks
   the SQLite UNIQUE constraint as `INTERNAL` rather than `ALREADY_EXISTS`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-empty. The `lorawan-battery-uplink` golden was regenerated to
   match. User-reported during a Push-to-fleet flow that produced YAML
   the fleet wouldn't compile cleanly.
+- **LoRaWAN: render passes SCK / MISO / MOSI to lorawan-for-esphome.**
+  v0 of the upstream component constructed RadioLib's `Module` without
+  calling `SPI.begin(sck, miso, mosi, cs)`, so it used arduino-esp32's
+  VSPI defaults (18/19/23/5). TTGO LoRa32 v1 (and most LoRa boards)
+  wire the radio to non-VSPI pins (5/19/27/18) -- the SX1276
+  chip-version readback returned garbage and the join failed with
+  `ERR_CHIP_NOT_FOUND (-2)`. Renderer now emits `sck_pin` / `miso_pin`
+  / `mosi_pin` in the radio block, sourced from the board library's
+  `default_buses.spi`. Requires the matching upstream lorawan-for-esphome
+  patch that accepts the three fields and calls `SPI.begin()` before
+  constructing the RadioLib Module -- the ref pin will be bumped to the
+  SHA carrying that change before this PR merges. User-reported during
+  the first hardware join attempt on a freshly flashed TTGO LoRa32 v1.
 - **LoRaWAN: `create_device` is actually idempotent now.** ChirpStack v4
   scopes `dev_eui` uniquely per tenant (not per application) and leaks
   the SQLite UNIQUE constraint as `INTERNAL` rather than `ALREADY_EXISTS`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chip-version readback returned garbage and the join failed with
   `ERR_CHIP_NOT_FOUND (-2)`. Renderer now emits `sck_pin` / `miso_pin`
   / `mosi_pin` in the radio block, sourced from the board library's
-  `default_buses.spi`. Requires the matching upstream lorawan-for-esphome
-  patch that accepts the three fields and calls `SPI.begin()` before
-  constructing the RadioLib Module -- the ref pin will be bumped to the
-  SHA carrying that change before this PR merges. User-reported during
-  the first hardware join attempt on a freshly flashed TTGO LoRa32 v1.
+  `default_buses.spi`. Pinned to `lorawan-for-esphome` @
+  `1f7ee9a` (lorawan-for-esphome#2) which adds the matching schema
+  fields and calls `SPI.begin()` before constructing the RadioLib
+  Module. Also moves `_LORAWAN_FOR_ESPHOME_REF` off `main` to that
+  pinned SHA, closing the `# TODO: pin to a commit SHA` left from the
+  W2 spike. User-reported during the first hardware join attempt on a
+  freshly flashed TTGO LoRa32 v1.
 - **LoRaWAN: `create_device` is actually idempotent now.** ChirpStack v4
   scopes `dev_eui` uniquely per tenant (not per application) and leaks
   the SQLite UNIQUE constraint as `INTERNAL` rather than `ALREADY_EXISTS`

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -31,4 +31,7 @@ lorawan:
     chip: sx1276
     cs_pin: GPIO18
     rst_pin: GPIO23
+    sck_pin: GPIO5
+    miso_pin: GPIO19
+    mosi_pin: GPIO27
     dio0_pin: GPIO26

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -5,14 +5,6 @@ esp32:
   framework:
     type: arduino
 logger: {}
-api:
-  encryption:
-    key: !secret api_key
-ota:
-- platform: esphome
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
 sensor:
 - platform: adc
   pin: GPIO36

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -17,7 +17,7 @@ sensor:
   lorawan_id: lw
   sensor: battery
 external_components:
-- source: github://moellere/lorawan-for-esphome@main
+- source: github://moellere/lorawan-for-esphome@1f7ee9a011c09502240fcd77e99afb6c35db375a
   components:
   - lorawan
 lorawan:

--- a/tests/test_lorawan.py
+++ b/tests/test_lorawan.py
@@ -244,6 +244,38 @@ def test_lorawan_secrets_partial_override_keeps_secret_refs_for_missing_keys():
     assert "app_key: !secret app_key" not in yaml
 
 
+def test_lorawan_external_path_is_headless_no_wifi_api_ota():
+    """`lorawan-for-esphome` README: field nodes are out of WiFi range and on
+    battery, so `wifi:` / `api:` / network `ota:` reboot-loop the device when
+    unreachable, and every reboot burns a DevNonce in OTAA. The renderer
+    drops them whenever `design.lorawan.payload` is set, even if the design
+    has a `fleet.secrets_ref` (which is the trigger for wifi/api/ota on the
+    non-LoRaWAN path)."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    yaml = render_yaml(d, default_library())
+    for block in ("wifi:", "api:", "ota:", "captive_portal:"):
+        assert f"\n{block}" not in yaml, f"{block} must be omitted on the external-component LoRaWAN path"
+    # The lorawan: block itself is still there -- this isn't a "no LoRaWAN" check.
+    assert "lorawan:" in yaml
+
+
+def test_lorawan_external_path_drops_esphome_extras_wifi_api_ota():
+    """An esphome_extras override that sets `wifi:` / `api:` / `ota:` /
+    `captive_portal:` is silently dropped on the LoRaWAN path so an example
+    author who shares extras across targets doesn't have to scrub them."""
+    raw = json.loads(LORAWAN_EXAMPLE.read_text())
+    raw["esphome_extras"] = {
+        "wifi": {"ssid": "test"},
+        "api": {"encryption": {"key": "x"}},
+        "ota": [{"platform": "esphome"}],
+        "captive_portal": {},
+    }
+    d = Design.model_validate(raw)
+    yaml = render_yaml(d, default_library())
+    for block in ("wifi:", "api:", "ota:", "captive_portal:"):
+        assert f"\n{block}" not in yaml
+
+
 def test_lorawan_emission_reads_radio_config_from_board_library():
     """The radio block (chip, pins, optional tcxo/dio2-rf-switch) comes from
     the board library's `radio:` metadata -- not duplicated in design.json.

--- a/tests/test_lorawan.py
+++ b/tests/test_lorawan.py
@@ -276,6 +276,24 @@ def test_lorawan_external_path_drops_esphome_extras_wifi_api_ota():
         assert f"\n{block}" not in yaml
 
 
+def test_lorawan_emission_passes_spi_pins_from_board_default_bus():
+    """`lorawan-for-esphome` v0 constructed RadioLib's Module without calling
+    SPI.begin(sck, miso, mosi, cs), so it used arduino-esp32's VSPI defaults
+    (18/19/23/5). TTGO LoRa32 v1 wires its SX1276 to 5/19/27/18 -- the
+    chip-version readback returned garbage and join failed with
+    ERR_CHIP_NOT_FOUND (-2). The renderer now emits sck_pin / miso_pin /
+    mosi_pin into the radio: block, sourced from the board library's
+    default SPI bus, so the component can call SPI.begin() with the right
+    pins before constructing the RadioLib Module. Paired with the upstream
+    schema addition in lorawan-for-esphome that accepts these fields."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    yaml = render_yaml(d, default_library())
+    # TTGO LoRa32 v1 SPI pinout (matches ttgo-lora32-v1.yaml:17).
+    assert "sck_pin: GPIO5" in yaml
+    assert "miso_pin: GPIO19" in yaml
+    assert "mosi_pin: GPIO27" in yaml
+
+
 def test_lorawan_emission_reads_radio_config_from_board_library():
     """The radio block (chip, pins, optional tcxo/dio2-rf-switch) comes from
     the board library's `radio:` metadata -- not duplicated in design.json.

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -481,7 +481,15 @@ def build_yaml_dict(
     extras = dict(design.esphome_extras or {})
     out["logger"] = extras.pop("logger", {})
 
-    if design.fleet and design.fleet.secrets_ref:
+    # The external-component LoRaWAN path is *headless*. Field nodes are
+    # typically out of WiFi range and on battery, and `wifi:` / `api:` /
+    # network `ota:` default to `reboot_timeout: 15min` -- an unreachable
+    # network reboot-loops the device, each reboot burns a fresh DevNonce
+    # in the OTAA flow, and the device stops joining cleanly.
+    # `captive_portal:` depends on `wifi:`. See lorawan-for-esphome README.
+    lorawan_external = bool(design.lorawan and design.lorawan.payload)
+
+    if design.fleet and design.fleet.secrets_ref and not lorawan_external:
         secrets = design.fleet.secrets_ref
         api_block: dict[str, Any] = {}
         if "api_key" in secrets:
@@ -495,7 +503,15 @@ def build_yaml_dict(
 
     if "captive_portal" in extras:
         cp = extras.pop("captive_portal")
-        out["captive_portal"] = cp if cp else {}
+        if not lorawan_external:
+            out["captive_portal"] = cp if cp else {}
+    # captive_portal entries silently dropped when LoRaWAN is active so an
+    # example author who left it in esphome_extras doesn't have to scrub
+    # it per-target. Also drop any wifi/api/ota the user might have set
+    # via esphome_extras (header-level overrides).
+    if lorawan_external:
+        for k in ("wifi", "api", "ota", "captive_portal"):
+            extras.pop(k, None)
 
     for bus in design.buses:
         if bus.type == "i2c":

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -370,7 +370,10 @@ def _secret_name(ref: str) -> str:
 # the component repo cuts its first stable release post hardware-join
 # validation (decision logged in docs/lorawan/workflow-integration.md).
 _LORAWAN_FOR_ESPHOME_REPO = "moellere/lorawan-for-esphome"
-_LORAWAN_FOR_ESPHOME_REF = "main"  # TODO(lorawan): pin to a commit SHA after the join test runs
+# Pinned to the SPI-pin schema PR's merge (lorawan-for-esphome#2). Required
+# for the rendered radio: block's sck_pin / miso_pin / mosi_pin keys to
+# validate; `main` doesn't carry those fields until this commit.
+_LORAWAN_FOR_ESPHOME_REF = "1f7ee9a011c09502240fcd77e99afb6c35db375a"
 
 
 def _emit_lorawan_blocks(

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -417,6 +417,23 @@ def _emit_lorawan_blocks(
         "cs_pin":  radio.pins.cs,
         "rst_pin": radio.pins.rst,
     }
+    # lorawan-for-esphome v0 constructed RadioLib's Module without calling
+    # SPI.begin(sck, miso, mosi, cs), so it relied on Arduino's default SPI
+    # bus -- which on arduino-esp32 is VSPI (18/19/23/5). TTGO LoRa32 v1 and
+    # most LoRa boards wire the radio to non-VSPI pins (e.g. 5/19/27/18), so
+    # the component returned ERR_CHIP_NOT_FOUND on real hardware. Once
+    # upstream merges the patch that takes sck_pin/miso_pin/mosi_pin in the
+    # radio schema and calls SPI.begin() before constructing the Module, we
+    # emit them from the board library's `default_buses.spi` so the YAML
+    # works on any board the studio supports.
+    spi_default = board.default_buses.get("spi") if board.default_buses else None
+    if spi_default:
+        if spi_default.get("clk"):
+            radio_block["sck_pin"] = spi_default["clk"]
+        if spi_default.get("miso"):
+            radio_block["miso_pin"] = spi_default["miso"]
+        if spi_default.get("mosi"):
+            radio_block["mosi_pin"] = spi_default["mosi"]
     if radio.pins.dio0:
         radio_block["dio0_pin"] = radio.pins.dio0
     if radio.pins.dio1:


### PR DESCRIPTION
## Summary

Two coordinated fixes to the LoRaWAN external-component path, both
surfaced by the first hardware join attempt on a TTGO LoRa32 v1.

### 1. Render headless YAML (no `wifi:` / `api:` / `ota:` / `captive_portal:`)

The renderer emitted those four blocks whenever the design carried a
`fleet.secrets_ref`, including on `lorawan-for-esphome` designs. Per the
upstream README:

> Do not just leave WiFi configured and let it fail: ESPHome's `wifi:`
> and `api:` both default to `reboot_timeout: 15min`, so an unreachable
> network reboot-loops the device — and every reboot re-joins, burning
> a DevNonce.

`yaml_gen.py` introduces a single gate
(`lorawan_external = bool(design.lorawan and design.lorawan.payload)`)
that suppresses the `fleet.secrets_ref → wifi/api/ota` branch and
strips matching keys from `esphome_extras` too.

### 2. Pass SPI pins (`sck_pin` / `miso_pin` / `mosi_pin`) into the radio block

`lorawan-for-esphome` v0 constructs RadioLib's `Module` without calling
`SPI.begin(sck, miso, mosi, cs)`, so it falls back to arduino-esp32's
VSPI defaults (18/19/23/5). TTGO LoRa32 v1 wires its SX1276 to
**5/19/27/18** — chip-version readback returns garbage, RadioLib
reports `ERR_CHIP_NOT_FOUND (-2)`:

```
[E][lorawan:050]: radio begin failed: -2
```

Affects every LoRa board whose radio isn't on the VSPI defaults, which
is most of them.

The renderer now emits `sck_pin` / `miso_pin` / `mosi_pin` into the
`lorawan: radio:` block, sourced from `board.default_buses.spi`:

```yaml
lorawan:
  radio:
    chip: sx1276
    cs_pin: GPIO18
    rst_pin: GPIO23
    sck_pin: GPIO5     # NEW
    miso_pin: GPIO19   # NEW
    mosi_pin: GPIO27   # NEW
    dio0_pin: GPIO26
```

## ⚠ Draft until upstream patch lands

The second half requires a matching upstream PR in
`moellere/lorawan-for-esphome` that accepts the three new schema fields
and calls `SPI.begin()` before constructing `Module`. Until that lands
and `_LORAWAN_FOR_ESPHOME_REF` is bumped to its SHA, `esphome config`
on the rendered YAML will reject the new keys.

### Upstream patch (paste-ready)

**`components/lorawan/__init__.py`** — add three optional fields with an
all-three-or-none invariant, plumb to `to_code`:

```python
CONF_SCK_PIN  = "sck_pin"
CONF_MISO_PIN = "miso_pin"
CONF_MOSI_PIN = "mosi_pin"

RADIO_SCHEMA = cv.All(cv.Schema({
    # ... existing ...
    cv.Optional(CONF_SCK_PIN):  pins.internal_gpio_output_pin_number,
    cv.Optional(CONF_MISO_PIN): pins.internal_gpio_input_pin_number,
    cv.Optional(CONF_MOSI_PIN): pins.internal_gpio_output_pin_number,
}), cv.has_at_least_one_key(CONF_SCK_PIN, CONF_MISO_PIN, CONF_MOSI_PIN))

async def to_code(config):
    # ... existing ...
    radio = config[CONF_RADIO]
    if CONF_SCK_PIN in radio:
        cg.add(var.set_sck_pin(radio[CONF_SCK_PIN]))
        cg.add(var.set_miso_pin(radio[CONF_MISO_PIN]))
        cg.add(var.set_mosi_pin(radio[CONF_MOSI_PIN]))
```

**`components/lorawan/lorawan.h`** — three `int8_t` members + setters,
default `-1`:

```cpp
void set_sck_pin(int8_t pin)  { this->sck_pin_  = pin; }
void set_miso_pin(int8_t pin) { this->miso_pin_ = pin; }
void set_mosi_pin(int8_t pin) { this->mosi_pin_ = pin; }
// ...
int8_t sck_pin_  = -1;
int8_t miso_pin_ = -1;
int8_t mosi_pin_ = -1;
```

**`components/lorawan/lorawan.cpp`** — `SPI.begin()` before constructing
`Module`:

```cpp
void LoRaWANComponent::setup() {
  ESP_LOGCONFIG(TAG, "setting up LoRaWAN...");
  if (this->sck_pin_ >= 0) {
    SPI.begin(this->sck_pin_, this->miso_pin_, this->mosi_pin_, this->cs_pin_);
  }
  Module *mod = new Module(this->cs_pin_, this->irq_pin_,
                           this->rst_pin_, this->busy_pin_);
  // ... existing ...
}
```

## Changes in this PR

- `wirestudio/generate/yaml_gen.py` — headless gate + SPI emission.
- `tests/golden/lorawan-battery-uplink.yaml` — regenerated for both
  effects (wifi/api/ota removed; sck/miso/mosi added).
- `tests/test_lorawan.py` — three new tests
  (`test_lorawan_external_path_is_headless_no_wifi_api_ota`,
  `test_lorawan_external_path_drops_esphome_extras_wifi_api_ota`,
  `test_lorawan_emission_passes_spi_pins_from_board_default_bus`).
- `CHANGELOG.md` — entries for both fixes.

## Test plan

- [x] `pytest tests/test_lorawan.py tests/test_fleet.py` — 77 passed.
- [x] Full `pytest` — 832 passed, 10 skipped.
- [x] `ruff check` clean.
- [ ] Open upstream PR against `moellere/lorawan-for-esphome` with the
      patch above.
- [ ] After upstream merges: bump `_LORAWAN_FOR_ESPHOME_REF` to the new
      SHA, re-run `esphome config` against the regenerated golden, mark
      this PR ready for review.
- [ ] Hardware: re-flash TTGO LoRa32 v1, confirm `radio begin failed`
      gone, `event/join` arrives on ChirpStack's app topic, no
      reboot-loop in the field.

## Scope

- **Standalone Arduino LoRaWAN target unaffected** (`firmware_gen.py`,
  not `yaml_gen.py`).
- **Non-LoRaWAN designs unaffected** (gate is False when
  `design.lorawan.payload` is empty).
- **Doesn't touch the OTA tooling**, only YAML emission. Field
  reflashing for LoRaWAN nodes still goes through WebSerial.

## Supersedes

Replaces #134 (which contained only the SPI half). Closing #134 in
favour of this combined PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82