### PR TITLE
fix(lorawan): emit sck/miso/mosi pins into radio block (gated on upstream PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **LoRaWAN: render passes SCK / MISO / MOSI to lorawan-for-esphome.**
+  v0 of the upstream component constructed RadioLib's `Module` without
+  calling `SPI.begin(sck, miso, mosi, cs)`, so it used arduino-esp32's
+  VSPI defaults (18/19/23/5). TTGO LoRa32 v1 (and most LoRa boards)
+  wire the radio to non-VSPI pins (5/19/27/18) -- the SX1276
+  chip-version readback returned garbage and the join failed with
+  `ERR_CHIP_NOT_FOUND (-2)`. Renderer now emits `sck_pin` / `miso_pin`
+  / `mosi_pin` in the radio block, sourced from the board library's
+  `default_buses.spi`. Requires the matching upstream lorawan-for-esphome
+  patch that accepts the three fields and calls `SPI.begin()` before
+  constructing the RadioLib Module -- the ref pin will be bumped to the
+  SHA carrying that change before this PR merges. User-reported during
+  the first hardware join attempt on a freshly flashed TTGO LoRa32 v1.
+
 - **LoRaWAN: `create_device` is actually idempotent now.** ChirpStack v4
   scopes `dev_eui` uniquely per tenant (not per application) and leaks
   the SQLite UNIQUE constraint as `INTERNAL` rather than `ALREADY_EXISTS`

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -39,4 +39,7 @@ lorawan:
     chip: sx1276
     cs_pin: GPIO18
     rst_pin: GPIO23
+    sck_pin: GPIO5
+    miso_pin: GPIO19
+    mosi_pin: GPIO27
     dio0_pin: GPIO26

--- a/tests/test_lorawan.py
+++ b/tests/test_lorawan.py
@@ -244,6 +244,24 @@ def test_lorawan_secrets_partial_override_keeps_secret_refs_for_missing_keys():
     assert "app_key: !secret app_key" not in yaml
 
 
+def test_lorawan_emission_passes_spi_pins_from_board_default_bus():
+    """`lorawan-for-esphome` v0 constructed RadioLib's Module without calling
+    SPI.begin(sck, miso, mosi, cs), so it used arduino-esp32's VSPI defaults
+    (18/19/23/5). TTGO LoRa32 v1 wires its SX1276 to 5/19/27/18 -- the
+    chip-version readback returned garbage and join failed with
+    ERR_CHIP_NOT_FOUND (-2). The renderer now emits sck_pin / miso_pin /
+    mosi_pin into the radio: block, sourced from the board library's
+    default SPI bus, so the component can call SPI.begin() with the right
+    pins before constructing the RadioLib Module. Paired with the upstream
+    schema addition in lorawan-for-esphome that accepts these fields."""
+    d = Design.model_validate(json.loads(LORAWAN_EXAMPLE.read_text()))
+    yaml = render_yaml(d, default_library())
+    # TTGO LoRa32 v1 SPI pinout (matches ttgo-lora32-v1.yaml:17).
+    assert "sck_pin: GPIO5" in yaml
+    assert "miso_pin: GPIO19" in yaml
+    assert "mosi_pin: GPIO27" in yaml
+
+
 def test_lorawan_emission_reads_radio_config_from_board_library():
     """The radio block (chip, pins, optional tcxo/dio2-rf-switch) comes from
     the board library's `radio:` metadata -- not duplicated in design.json.

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -417,6 +417,23 @@ def _emit_lorawan_blocks(
         "cs_pin":  radio.pins.cs,
         "rst_pin": radio.pins.rst,
     }
+    # lorawan-for-esphome v0 constructed RadioLib's Module without calling
+    # SPI.begin(sck, miso, mosi, cs), so it relied on Arduino's default SPI
+    # bus -- which on arduino-esp32 is VSPI (18/19/23/5). TTGO LoRa32 v1 and
+    # most LoRa boards wire the radio to non-VSPI pins (e.g. 5/19/27/18), so
+    # the component returned ERR_CHIP_NOT_FOUND on real hardware. Once
+    # upstream merges the patch that takes sck_pin/miso_pin/mosi_pin in the
+    # radio schema and calls SPI.begin() before constructing the Module, we
+    # emit them from the board library's `default_buses.spi` so the YAML
+    # works on any board the studio supports.
+    spi_default = board.default_buses.get("spi") if board.default_buses else None
+    if spi_default:
+        if spi_default.get("clk"):
+            radio_block["sck_pin"] = spi_default["clk"]
+        if spi_default.get("miso"):
+            radio_block["miso_pin"] = spi_default["miso"]
+        if spi_default.get("mosi"):
+            radio_block["mosi_pin"] = spi_default["mosi"]
     if radio.pins.dio0:
         radio_block["dio0_pin"] = radio.pins.dio0
     if radio.pins.dio1:


### PR DESCRIPTION
## Summary

**Studio-side half of a coordinated two-repo fix.** Draft until the
[upstream `lorawan-for-esphome` PR](#upstream-patch-below) merges and
`_LORAWAN_FOR_ESPHOME_REF` is bumped to its SHA.

User hit `ERR_CHIP_NOT_FOUND (-2)` on the first hardware join on a TTGO
LoRa32 v1, freshly flashed via ESPHome web flasher. Boot logs confirm
the firmware runs and only the `lorawan` component fails:
```
[E][lorawan:050]: radio begin failed: -2
```

Root cause: `lorawan-for-esphome` v0 constructs RadioLib's `Module`
without calling `SPI.begin(sck, miso, mosi, cs)`, so it falls back to
arduino-esp32's VSPI defaults (18/19/23/5). TTGO LoRa32 v1 wires its
SX1276 to **5/19/27/18** — the chip-version readback returns garbage
and join fails. Affects every LoRa board whose radio isn't on the VSPI
defaults, which is most of them.

## Studio-side change (this PR)

The board library already carries the SPI bus pinout
(`ttgo-lora32-v1.yaml:17` and friends). The renderer now emits
`sck_pin` / `miso_pin` / `mosi_pin` into the `lorawan: radio:` block,
sourced from `board.default_buses.spi`:

```yaml
lorawan:
  ...
  radio:
    chip: sx1276
    cs_pin: GPIO18
    rst_pin: GPIO23
    sck_pin: GPIO5     # NEW
    miso_pin: GPIO19   # NEW
    mosi_pin: GPIO27   # NEW
    dio0_pin: GPIO26
```

Regenerates the `lorawan-battery-uplink` golden and pins the emission
in a new test (`test_lorawan_emission_passes_spi_pins_from_board_default_bus`).

## Upstream patch (separate repo — apply before bumping the ref pin here)

`moellere/lorawan-for-esphome`. Two files. **Schema** (`components/lorawan/__init__.py`)
add the three optional fields:

```python
CONF_SCK_PIN  = "sck_pin"
CONF_MISO_PIN = "miso_pin"
CONF_MOSI_PIN = "mosi_pin"

RADIO_SCHEMA = cv.Schema({
    # ... existing ...
    cv.Optional(CONF_SCK_PIN):  pins.internal_gpio_output_pin_number,
    cv.Optional(CONF_MISO_PIN): pins.internal_gpio_input_pin_number,
    cv.Optional(CONF_MOSI_PIN): pins.internal_gpio_output_pin_number,
})

async def to_code(config):
    # ... existing ...
    radio = config[CONF_RADIO]
    if CONF_SCK_PIN in radio:
        cg.add(var.set_sck_pin(radio[CONF_SCK_PIN]))
        cg.add(var.set_miso_pin(radio[CONF_MISO_PIN]))
        cg.add(var.set_mosi_pin(radio[CONF_MOSI_PIN]))
```

(Use `cv.All(cv.Schema({...}), cv.has_all_keys(CONF_SCK_PIN, CONF_MISO_PIN, CONF_MOSI_PIN))` or a `cv.has_at_least_one_key` invariant so it's all-three-or-none — `SPI.begin()` needs all three.)

**Component** (`components/lorawan/lorawan.h`):
```cpp
class LoRaWANComponent : public Component {
 public:
  // ... existing ...
  void set_sck_pin(int8_t pin)  { this->sck_pin_  = pin; }
  void set_miso_pin(int8_t pin) { this->miso_pin_ = pin; }
  void set_mosi_pin(int8_t pin) { this->mosi_pin_ = pin; }

 protected:
  int8_t sck_pin_  = -1;
  int8_t miso_pin_ = -1;
  int8_t mosi_pin_ = -1;
};
```

`components/lorawan/lorawan.cpp` setup:
```cpp
void LoRaWANComponent::setup() {
  ESP_LOGCONFIG(TAG, "setting up LoRaWAN...");

  // If sck/miso/mosi were supplied, bind the Arduino SPI bus to them
  // before RadioLib constructs the Module. Defaulting RadioLib to
  // arduino-esp32's VSPI pins (18/19/23/5) silently breaks every LoRa
  // board whose radio sits on different SPI pins.
  if (this->sck_pin_ >= 0) {
    SPI.begin(this->sck_pin_, this->miso_pin_, this->mosi_pin_, this->cs_pin_);
  }

  Module *mod = new Module(this->cs_pin_, this->irq_pin_,
                           this->rst_pin_, this->busy_pin_);
  // ... existing ...
}
```

## Test plan

- [x] `pytest tests/test_lorawan.py tests/test_fleet.py` — 75 passed.
- [x] Full `pytest` — 830 passed, 10 skipped.
- [ ] Upstream PR opened against `moellere/lorawan-for-esphome` with the
      schema + setup change.
- [ ] After upstream merges: bump `_LORAWAN_FOR_ESPHOME_REF` to the new
      SHA in this PR, re-run `esphome config` against the regenerated
      golden, and mark the draft ready for review.
- [ ] Hardware: re-flash TTGO LoRa32 v1, confirm `radio begin failed`
      gone and an `event/join` arrives on the ChirpStack app topic.

## Why draft

Until the upstream schema accepts `sck_pin` / `miso_pin` / `mosi_pin`,
the rendered YAML will fail `esphome config` because the upstream
validator rejects unknown keys under `radio:`. Holding this as a draft
prevents accidentally landing YAML changes the upstream `main` can't
parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_