### PR TITLE
release: 0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] — 2026-06-20
+
 ### Fixed
 
 - **LoRaWAN external-component path now renders headless.** The renderer

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.17.1"
+__version__ = "0.17.2"


### PR DESCRIPTION
## Summary

Release 0.17.2. The headline is **the LoRaWAN external-component path is now hardware-ready**: this is the release that gets the headless YAML + inline SPI pin fixes onto the prod cluster so the TTGO LoRa32 v1 join test actually has a chance.

### What lands with this tag

- **#133** — Render headless YAML on the external-component path (no `wifi:`/`api:`/network `ota:`/`captive_portal:`) **and** emit `sck_pin`/`miso_pin`/`mosi_pin` in the `lorawan: radio:` block, pinned to `moellere/lorawan-for-esphome@1f7ee9a` (upstream PR #2 merged).
- **#132** — Cross-application `dev_eui` collisions surface as actionable 502s naming the conflicting application.
- **#131** — ChirpStack gRPC errors are wrapped as `ChirpStackUnavailable` → 502 with the gRPC status string. Provision dialog probes `/lorawan/chirpstack/status` on mount and disables the Provision button when the server is unreachable.
- **#130** — Docs freshness: deployment.md / README.md image tags synced; ArgoCD section rewritten to reflect the bump-prod / bump-dev-on-tag / github-release automation.
- **#129** — k8s manifest wires `CHIRPSTACK_API_URL` + `CHIRPSTACK_API_TOKEN`; scrubbed local-environment specifics from `docs/lorawan/`; in-code `CHIRPSTACK_API_URL` default is now `chirpstack:8080` (typical in-cluster Service name).
- **#128** — Release-tag automation fixes (`bump-prod` opens a PR instead of pushing direct; `bump-dev-on-tag` skips cleanly when no `dev` branch exists).

### What happens on tag

1. `build` + `lorawan-image` push `:0.17.2`, `:0.17`, `:latest`, `:0.17.2-lorawan`, `:0.17-lorawan` to ghcr.io.
2. `bump-prod` opens a PR against `main` to roll `deploy/overlays/prod/kustomization.yaml` from `0.17.1` → `0.17.2`. Merge that to roll prod via ArgoCD.
3. `github-release` cuts the GitHub Release from the `[0.17.2]` CHANGELOG section.

## Files

- `wirestudio/__init__.py`: `__version__ = "0.17.2"`
- `CHANGELOG.md`: `[Unreleased]` → `[0.17.2] — 2026-06-20`

## Test plan

- [x] `pytest -q` — 832 passed, 10 skipped.
- [ ] Merge this PR.
- [ ] `git tag v0.17.2 && git push origin v0.17.2`.
- [ ] Merge the auto-opened `deploy/prod-0.17.2` PR once required checks pass.
- [ ] Re-render the LoRaWAN design through the studio: confirm rendered YAML has no `wifi:` / `api:` / `ota:`, and the `radio:` block carries `sck_pin: GPIO5` / `miso_pin: GPIO19` / `mosi_pin: GPIO27`.
- [ ] Re-flash TTGO LoRa32 v1 with the new YAML. Expect `radio begin failed: -2` gone, OTAA join completes, `event/join` arrives on ChirpStack's app topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_