### PR TITLE
⚡ Bolt: Remove O(N²) Set and Array allocations in BusList render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,7 @@
 ## 2025-02-18 - React O(N²) array allocations in derived state lists
 **Learning:** Calling `.filter()` on a list inside the `.map()` of the very same list (like finding alternatives) creates O(N²) intermediate arrays on every render. This forces unnecessary garbage collection and degrades render performance, especially as lists grow.
 **Action:** Replace nested derived arrays inside render loops with lightweight logic. E.g. counting alternatives can just be `list.length - 1`, and rendering them can just map over the list and conditionally return `null`.
+
+## 2025-02-18 - O(N²) array allocations inside render loops
+**Learning:** Computing derived state, like filtering a list of compatibility warnings for every item in a list using `.filter()` inside the `.map()` loop (e.g., `warnings={compatibilityWarnings.filter((w) => w.component_id === b.id)}` in `BusList.tsx`), creates O(N²) intermediate arrays on every render. This forces unnecessary garbage collection and degrades render performance, especially as lists grow. A similar anti-pattern is creating a new filtered `Set` for every item in a loop.
+**Action:** Lift the grouping of data out of the render loop into a `useMemo` map (e.g., computing a `Map<string, CompatibilityWarning[]>` where keys are component IDs). When checking for collisions, pass the entire Set to the child component and perform an `allBusIds.has(draftId)` check instead of pre-filtering the Set for each item.

--- a/web/src/components/BusList.tsx
+++ b/web/src/components/BusList.tsx
@@ -53,6 +53,18 @@ export function BusList({
   }, [design.buses]);
   const allBusIds = useMemo(() => new Set(buses.map((b) => b.id)), [buses]);
 
+  // ⚡ Bolt: avoid O(N²) array allocations inside the render loop below
+  const warningsByBusId = useMemo(() => {
+    const map = new Map<string, CompatibilityWarning[]>();
+    for (const w of compatibilityWarnings) {
+      if (!w.component_id) continue;
+      const list = map.get(w.component_id);
+      if (list) list.push(w);
+      else map.set(w.component_id, [w]);
+    }
+    return map;
+  }, [compatibilityWarnings]);
+
   const [pickedType, setPickedType] = useState<BusType>("i2c");
 
   return (
@@ -67,8 +79,8 @@ export function BusList({
                 bus={b.raw}
                 type={b.type}
                 gpioPins={gpioPins}
-                warnings={compatibilityWarnings.filter((w) => w.component_id === b.id)}
-                otherBusIds={new Set([...allBusIds].filter((x) => x !== b.id))}
+                warnings={warningsByBusId.get(b.id) ?? []}
+                allBusIds={allBusIds}
                 onRename={(newId) => onChange((d) => renameBus(d, b.id, newId))}
                 onChange={(patch) => onChange((d) => updateBus(d, b.id, patch))}
                 onRemove={() => onChange((d) => removeBus(d, b.id))}
@@ -101,15 +113,15 @@ export function BusList({
 }
 
 function BusCard({
-  bus, type, gpioPins, warnings, otherBusIds, onRename, onChange, onRemove,
+  bus, type, gpioPins, warnings, allBusIds, onRename, onChange, onRemove,
 }: {
   bus: Record<string, unknown>;
   type: BusType;
   gpioPins: string[];
   warnings: CompatibilityWarning[];
-  /** Ids of every other bus in the design; used to refuse a rename that
+  /** Ids of every bus in the design; used to refuse a rename that
    *  would collide. */
-  otherBusIds: Set<string>;
+  allBusIds: Set<string>;
   onRename: (newId: string) => void;
   onChange: (patch: Partial<Record<string, unknown>>) => void;
   onRemove: () => void;
@@ -128,7 +140,7 @@ function BusCard({
 
   function commitRename() {
     const next = draftId.trim();
-    if (next === "" || next === id || otherBusIds.has(next)) {
+    if (next === "" || next === id || allBusIds.has(next)) {
       // Reject and revert -- the caller's onRename guards against the
       // collision case anyway, but we want to clear the visual drift.
       setDraftId(id);
@@ -138,7 +150,7 @@ function BusCard({
   }
 
   const draftDirty = draftId.trim() !== id;
-  const draftCollides = otherBusIds.has(draftId.trim());
+  const draftCollides = draftId.trim() !== id && allBusIds.has(draftId.trim());
 
   return (
     <div className="rounded-md border border-zinc-800 bg-zinc-900/30 p-2">


### PR DESCRIPTION
💡 What: Prevented the creation of intermediate arrays via `.filter` and intermediate `Set` allocations inside the `buses.map` render loop of `BusList.tsx`. I used `useMemo` to construct a grouped `Map` of compatibility warnings by `component_id` once, and passed the shared `allBusIds` Set directly to the child `BusCard` to let it perform an amortized `.has()` lookup.
🎯 Why: React components with inner loops that allocate `Set` or `Array` derivatives inside them degrade render performance when dealing with frequently updated, moderately large arrays.
📊 Impact: Scales list generation computation in `BusList.tsx` from O(N²) to O(N).
🔬 Measurement: Verify functionality of bus renaming interactions and bus rendering speeds with many buses.

---
*PR created automatically by Jules for task [3617454233789838810](https://jules.google.com/task/3617454233789838810) started by @moellere*