### PR TITLE
⚡ Bolt: Eliminate O(N²) array and Set allocations in BusList render

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,7 @@
 ## 2025-02-18 - React O(N²) array allocations in derived state lists
 **Learning:** Calling `.filter()` on a list inside the `.map()` of the very same list (like finding alternatives) creates O(N²) intermediate arrays on every render. This forces unnecessary garbage collection and degrades render performance, especially as lists grow.
 **Action:** Replace nested derived arrays inside render loops with lightweight logic. E.g. counting alternatives can just be `list.length - 1`, and rendering them can just map over the list and conditionally return `null`.
+
+## 2025-02-18 - React O(N²) array allocations in derived state lists
+**Learning:** Calling `.filter()` on a list inside the `.map()` of the very same list (like creating derived Sets for collisions) creates O(N²) intermediate arrays on every render. This forces unnecessary garbage collection and degrades render performance.
+**Action:** Replace nested derived arrays inside render loops with pre-computed dictionaries or reusing existing sets. E.g. pass an `allIds` Set directly to list items and resolve collisions with `allIds.has(nextId) && nextId !== id` instead of making a new `.filter(id !== x)` subset per item.

--- a/web/src/components/BusList.tsx
+++ b/web/src/components/BusList.tsx
@@ -53,6 +53,15 @@ export function BusList({
   }, [design.buses]);
   const allBusIds = useMemo(() => new Set(buses.map((b) => b.id)), [buses]);
 
+  const warningsByBusId = useMemo(() => {
+    const map: Record<string, CompatibilityWarning[]> = {};
+    for (const w of compatibilityWarnings) {
+      if (!w.component_id) continue;
+      (map[w.component_id] ||= []).push(w);
+    }
+    return map;
+  }, [compatibilityWarnings]);
+
   const [pickedType, setPickedType] = useState<BusType>("i2c");
 
   return (
@@ -67,8 +76,8 @@ export function BusList({
                 bus={b.raw}
                 type={b.type}
                 gpioPins={gpioPins}
-                warnings={compatibilityWarnings.filter((w) => w.component_id === b.id)}
-                otherBusIds={new Set([...allBusIds].filter((x) => x !== b.id))}
+                warnings={warningsByBusId[b.id] ?? []}
+                allBusIds={allBusIds}
                 onRename={(newId) => onChange((d) => renameBus(d, b.id, newId))}
                 onChange={(patch) => onChange((d) => updateBus(d, b.id, patch))}
                 onRemove={() => onChange((d) => removeBus(d, b.id))}
@@ -101,15 +110,15 @@ export function BusList({
 }
 
 function BusCard({
-  bus, type, gpioPins, warnings, otherBusIds, onRename, onChange, onRemove,
+  bus, type, gpioPins, warnings, allBusIds, onRename, onChange, onRemove,
 }: {
   bus: Record<string, unknown>;
   type: BusType;
   gpioPins: string[];
   warnings: CompatibilityWarning[];
-  /** Ids of every other bus in the design; used to refuse a rename that
+  /** Ids of every bus in the design; used to refuse a rename that
    *  would collide. */
-  otherBusIds: Set<string>;
+  allBusIds: Set<string>;
   onRename: (newId: string) => void;
   onChange: (patch: Partial<Record<string, unknown>>) => void;
   onRemove: () => void;
@@ -128,7 +137,7 @@ function BusCard({
 
   function commitRename() {
     const next = draftId.trim();
-    if (next === "" || next === id || otherBusIds.has(next)) {
+    if (next === "" || next === id || (allBusIds.has(next) && next !== id)) {
       // Reject and revert -- the caller's onRename guards against the
       // collision case anyway, but we want to clear the visual drift.
       setDraftId(id);
@@ -138,7 +147,7 @@ function BusCard({
   }
 
   const draftDirty = draftId.trim() !== id;
-  const draftCollides = otherBusIds.has(draftId.trim());
+  const draftCollides = allBusIds.has(draftId.trim()) && draftId.trim() !== id;
 
   return (
     <div className="rounded-md border border-zinc-800 bg-zinc-900/30 p-2">


### PR DESCRIPTION
💡 What: 
- Grouped `compatibilityWarnings` by `component_id` in a `useMemo` hook before mapping over `buses`.
- Reused the existing `allBusIds` Set for each `BusCard` instead of filtering and allocating a new `Set` for every card (`new Set([...allBusIds].filter((x) => x !== b.id))`).

🎯 Why: 
Inside `BusList.tsx`, rendering an array of buses caused `filter()` and `new Set()` to be executed per bus for calculating collisions and warnings. This resulted in O(N²) intermediate array allocations and garbage collection overhead during React renders.

📊 Impact: 
Reduces intermediate allocations during rendering from O(N²) to O(N). Avoids unnecessary Set and Array instantiations.

🔬 Measurement: 
Profile React renders during bus addition/removal or typing. Time spent in `render` function should decrease due to lighter operations inside `.map()`.

---
*PR created automatically by Jules for task [10077617022276718081](https://jules.google.com/task/10077617022276718081) started by @moellere*