### PR TITLE
feat(lorawan): flash fleet-built firmware via WebSerial in the provision dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **LoRaWAN: flash fleet-built firmware via WebSerial from the provision
+  dialog.** Closes the workflow gap where the external-component LoRaWAN
+  path built firmware on the fleet but had no way to land it on a headless
+  device (no network OTA, no fleet flasher). New
+  `FleetClient.get_firmware(run_id, *, factory=)` + `GET
+  /fleet/jobs/{run_id}/firmware[?factory=true]` route ferry the addon's
+  build artifact through the studio (browser never holds `FLEET_TOKEN`),
+  mirroring the standalone path's `/lorawan/firmware/{cache_key}` so the
+  existing `lib/flash.ts` consumes both paths identically. The provision
+  dialog gains a **Flash via WebSerial →** step after a successful Push to
+  fleet: polls the run-status endpoint until the verdict is `passed`,
+  pulls the factory image, then writes it to a blank board at 0x0 with
+  `eraseAll: true` (NVS is empty, `/lorawan/provision-esphome` re-flushed
+  DevNonces, so the wipe is safe per §2.1). Scoped in
+  `docs/lorawan/fleet-firmware-flash.md`. The upstream addon endpoint is
+  still being implemented; until it ships, the button stays available but
+  the call resolves to 404 with a clear "firmware artifact not available"
+  message rather than a silent hang.
+
 ## [0.17.2] — 2026-06-20
 
 ### Fixed

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -43,6 +43,11 @@ class FakeFleetAddon:
         # ({"id", "run_id", "state", "target", "finished_at"}) to drive the
         # run-status verdict tests.
         self.queue_jobs: list[dict] = []
+        # run_id -> {"app": bytes | None, "factory": bytes | None}; tests
+        # populate this to drive the firmware-artifact passthrough tests.
+        # None means "not built" -> the addon 404s (matches the fleet-side
+        # contract that 404 = not ready or unavailable).
+        self.firmware: dict[str, dict[str, bytes | None]] = {}
 
     def transport(self) -> httpx.MockTransport:
         def handler(req: httpx.Request) -> httpx.Response:
@@ -109,6 +114,26 @@ class FakeFleetAddon:
                     "offset": len(full),
                     "finished": bool(self.job_logs[run_id]["finished"]),
                 })
+
+            # GET /ui/api/jobs/{run_id}/firmware            -> app image
+            # GET /ui/api/jobs/{run_id}/firmware/factory    -> factory image
+            if method == "GET" and path.startswith("/ui/api/jobs/") and (
+                path.endswith("/firmware") or path.endswith("/firmware/factory")
+            ):
+                kind = "factory" if path.endswith("/factory") else "app"
+                trim = "/firmware/factory" if kind == "factory" else "/firmware"
+                run_id = path[len("/ui/api/jobs/"):-len(trim)]
+                slot = self.firmware.get(run_id)
+                if slot is None:
+                    return httpx.Response(404, json={"error": "unknown run_id"})
+                data = slot.get(kind)
+                if data is None:
+                    return httpx.Response(404, json={"error": f"no {kind} image"})
+                return httpx.Response(
+                    200,
+                    content=data,
+                    headers={"content-type": "application/octet-stream"},
+                )
 
             return httpx.Response(404, json={"error": "not found"})
 
@@ -485,6 +510,115 @@ async def test_fleet_job_log_unknown_run_id_returns_502(monkeypatch, tmp_path):
     addon = FakeFleetAddon()
     client = _make_client(monkeypatch, tmp_path, addon=addon)
     r = client.get("/fleet/jobs/nope/log")
+    assert r.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# Build-artifact passthrough (fleet -> studio -> browser WebSerial)
+# ---------------------------------------------------------------------------
+
+async def test_get_firmware_returns_app_image_bytes():
+    addon = FakeFleetAddon()
+    addon.firmware["run-1"] = {"app": b"FAKE-APP-IMAGE", "factory": None}
+    fc = addon.make_client()
+    data = await fc.get_firmware("run-1")
+    assert data == b"FAKE-APP-IMAGE"
+
+
+async def test_get_firmware_factory_uses_factory_subpath():
+    addon = FakeFleetAddon()
+    addon.firmware["run-1"] = {
+        "app": b"APP",
+        "factory": b"BOOT+PART+APP",
+    }
+    fc = addon.make_client()
+    data = await fc.get_firmware("run-1", factory=True)
+    assert data == b"BOOT+PART+APP"
+
+
+async def test_get_firmware_unknown_run_id_raises():
+    addon = FakeFleetAddon()
+    fc = addon.make_client()
+    with pytest.raises(FleetUnavailable, match="not available"):
+        await fc.get_firmware("nope")
+
+
+async def test_get_firmware_factory_missing_raises():
+    # The build produced an app image but the older ESPHome on the fleet
+    # didn't emit firmware-factory.bin -- the addon 404s factory while the
+    # app image is fine. The dialog falls back / surfaces the message.
+    addon = FakeFleetAddon()
+    addon.firmware["run-1"] = {"app": b"APP", "factory": None}
+    fc = addon.make_client()
+    with pytest.raises(FleetUnavailable, match="not available"):
+        await fc.get_firmware("run-1", factory=True)
+
+
+async def test_get_firmware_unconfigured_raises():
+    fc = FleetClient(base_url=None, token=None)
+    with pytest.raises(FleetUnavailable, match="missing"):
+        await fc.get_firmware("run-1")
+
+
+async def test_fleet_firmware_endpoint_unconfigured_returns_503(monkeypatch, tmp_path):
+    client = _make_client(monkeypatch, tmp_path, addon=None)
+    r = client.get("/fleet/jobs/run-1/firmware")
+    assert r.status_code == 503
+
+
+async def test_fleet_firmware_endpoint_round_trips_app_image(monkeypatch, tmp_path):
+    addon = FakeFleetAddon()
+    addon.firmware["run-7"] = {"app": b"\x01\x02APP", "factory": None}
+    client = _make_client(monkeypatch, tmp_path, addon=addon)
+    r = client.get("/fleet/jobs/run-7/firmware")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/octet-stream"
+    assert r.headers["content-disposition"] == 'attachment; filename="run-7.bin"'
+    assert r.content == b"\x01\x02APP"
+
+
+async def test_fleet_firmware_endpoint_round_trips_factory_image(monkeypatch, tmp_path):
+    addon = FakeFleetAddon()
+    addon.firmware["run-7"] = {"app": b"app", "factory": b"\xe9\x00\x00FACTORY"}
+    client = _make_client(monkeypatch, tmp_path, addon=addon)
+    r = client.get("/fleet/jobs/run-7/firmware?factory=true")
+    assert r.status_code == 200
+    assert r.headers["content-disposition"] == 'attachment; filename="run-7-factory.bin"'
+    assert r.content == b"\xe9\x00\x00FACTORY"
+
+
+async def test_fleet_firmware_endpoint_unknown_run_id_returns_404(monkeypatch, tmp_path):
+    # 404 means "not ready yet / not built" -- the dialog uses this to keep
+    # waiting on the compile rather than treating it as a fleet outage (which
+    # would be 502).
+    addon = FakeFleetAddon()
+    client = _make_client(monkeypatch, tmp_path, addon=addon)
+    r = client.get("/fleet/jobs/ghost/firmware")
+    assert r.status_code == 404
+
+
+async def test_fleet_firmware_endpoint_addon_unreachable_returns_502(monkeypatch, tmp_path):
+    # Addon returns a 5xx (here, simulated via missing handler -> 404 then
+    # mapped to "not available"). For a transport-level failure we'd return
+    # 502; cover that explicitly by pointing the client at a transport that
+    # always 500s.
+    def boom_handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.startswith("/ui/api/jobs/") and req.url.path.endswith(
+            "/firmware"
+        ):
+            return httpx.Response(500, json={"error": "internal"})
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(boom_handler)
+    fc = FleetClient(
+        base_url="http://broken-fleet.local", token="tok-123", transport=transport,
+    )
+
+    class _BrokenAddon:
+        def make_client(self): return fc
+
+    client = _make_client(monkeypatch, tmp_path, addon=_BrokenAddon())
+    r = client.get("/fleet/jobs/run-1/firmware")
     assert r.status_code == 502
 
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -237,6 +237,27 @@ export const api = {
     ),
   fleetRunStatus: (runId: string) =>
     request<FleetRunStatus>(`/fleet/jobs/${encodeURIComponent(runId)}`),
+  /** Download the fleet-built firmware artifact for a finished compile run.
+   *  Mirrors `lorawanFirmware` (standalone path) so the existing WebSerial
+   *  flasher in `lib/flash.ts` consumes both paths identically. `factory=true`
+   *  fetches the merged bootloader+partitions+app image for flashing a blank
+   *  board at 0x0. 404 means the run hasn't finished yet (or the build didn't
+   *  produce the requested image); 502 means the fleet itself is unreachable. */
+  fleetFirmware: async (
+    runId: string,
+    opts: { factory?: boolean } = {},
+  ): Promise<Uint8Array> => {
+    const path = `/fleet/jobs/${encodeURIComponent(runId)}/firmware${
+      opts.factory ? "?factory=true" : ""
+    }`;
+    const res = await fetch(`${API_BASE}${path}`);
+    if (!res.ok) {
+      let body: unknown = undefined;
+      try { body = await res.json(); } catch { /* not json */ }
+      throw new ApiError(res.status, `GET ${path} -> ${res.status}`, body);
+    }
+    return new Uint8Array(await res.arrayBuffer());
+  },
 
   lorawanCompileStatus: () => request<LorawanCompileStatus>("/lorawan/compile/status"),
   /** Probe ChirpStack: reachability + token auth. The provision dialog calls

--- a/web/src/components/LorawanProvisionEsphomeDialog.test.tsx
+++ b/web/src/components/LorawanProvisionEsphomeDialog.test.tsx
@@ -29,6 +29,8 @@ vi.mock("../api/client", async () => {
       lorawanProvisionEsphome: vi.fn(),
       lorawanActivation: vi.fn(),
       fleetPush: vi.fn(),
+      fleetRunStatus: vi.fn(),
+      fleetFirmware: vi.fn(),
     },
   };
 });
@@ -40,15 +42,27 @@ vi.mock("../lib/usb-detect", () => ({
   isWebSerialSupported: vi.fn(() => "yes"),
 }));
 
+// flash.ts is also browser-only (esptool-js for the actual write); the dialog
+// dynamic-imports it from the Flash button. Mock at the module boundary so
+// jsdom doesn't try to load esptool-js, and the flash flow can be unit-tested
+// without a real WebSerial port. lib/flash.ts has its own unit tests.
+vi.mock("../lib/flash", () => ({
+  flashFirmware: vi.fn(),
+}));
+
 import { detectChip, isWebSerialSupported } from "../lib/usb-detect";
+import { flashFirmware } from "../lib/flash";
 const mockDetectChip = detectChip as unknown as ReturnType<typeof vi.fn>;
 const mockSupported = isWebSerialSupported as unknown as ReturnType<typeof vi.fn>;
+const mockFlash = flashFirmware as unknown as ReturnType<typeof vi.fn>;
 
 const mockApi = api as unknown as {
   lorawanChirpstackStatus: ReturnType<typeof vi.fn>;
   lorawanProvisionEsphome: ReturnType<typeof vi.fn>;
   lorawanActivation: ReturnType<typeof vi.fn>;
   fleetPush: ReturnType<typeof vi.fn>;
+  fleetRunStatus: ReturnType<typeof vi.fn>;
+  fleetFirmware: ReturnType<typeof vi.fn>;
 };
 
 function design(overrides: Partial<Design> = {}): Design {
@@ -83,8 +97,11 @@ beforeEach(() => {
   mockApi.lorawanProvisionEsphome.mockReset();
   mockApi.lorawanActivation.mockReset();
   mockApi.fleetPush.mockReset();
+  mockApi.fleetRunStatus.mockReset();
+  mockApi.fleetFirmware.mockReset();
   mockDetectChip.mockReset();
   mockSupported.mockReturnValue("yes");
+  mockFlash.mockReset();
 });
 
 afterEach(() => {
@@ -414,5 +431,93 @@ describe("push to fleet", () => {
     expect(await screen.findByText(/push failed: 503: fleet not configured/i)).toBeTruthy();
     // Pre-failed state — Push to fleet stays available for a retry.
     expect(screen.getByRole("button", { name: /Push to fleet →/i })).toBeEnabled();
+  });
+});
+
+describe("flash via WebSerial (fleet-built artifact)", () => {
+  async function pushFirst(user: ReturnType<typeof userEvent.setup>) {
+    mockApi.lorawanProvisionEsphome.mockResolvedValue({
+      secrets: {
+        dev_eui: "70b3d57ed0001234",
+        join_eui: "0000000000000000",
+        app_key: "00112233445566778899aabbccddeeff",
+      },
+      chirpstack: { application_id: "app-1", device_profile_id: "dp-1" },
+      band: "US915",
+      sub_band: 2,
+    });
+    mockApi.lorawanActivation.mockResolvedValue({ dev_eui: "70b3d57ed0001234", joined: false });
+    mockApi.fleetPush.mockResolvedValue({
+      filename: "lw-spike.yaml",
+      created: true,
+      run_id: "run-1",
+      enqueued: 1,
+    });
+
+    await user.type(screen.getByPlaceholderText(/70b3d57ed0001234/i), "70b3d57ed0001234");
+    await user.click(screen.getByRole("button", { name: /Provision →/i }));
+    await waitFor(() => expect(screen.getByRole("button", { name: /Push to fleet →/i })).toBeTruthy());
+    await user.click(screen.getByRole("button", { name: /Push to fleet →/i }));
+    // Wait for the flash button to render once push succeeded.
+    await waitFor(() => expect(screen.getByRole("button", { name: /Flash via WebSerial →/i })).toBeTruthy());
+  }
+
+  it("waits for compile, fetches the factory image, and writes it with eraseAll", async () => {
+    const user = userEvent.setup();
+    mockApi.fleetRunStatus.mockResolvedValue({
+      run_id: "run-1", verdict: "passed", jobs: [],
+    });
+    const bin = new Uint8Array([0xe9, 0x00, 0x00, 0x42]);
+    mockApi.fleetFirmware.mockResolvedValue(bin);
+    mockFlash.mockResolvedValue({
+      chipName: "ESP32", mac: undefined,
+      write: vi.fn(), close: vi.fn(),
+    });
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await pushFirst(user);
+    await user.click(screen.getByRole("button", { name: /Flash via WebSerial →/i }));
+
+    await waitFor(() => expect(mockFlash).toHaveBeenCalled());
+    expect(mockApi.fleetRunStatus).toHaveBeenCalledWith("run-1");
+    expect(mockApi.fleetFirmware).toHaveBeenCalledWith("run-1", { factory: true });
+    const args = mockFlash.mock.calls[0][0];
+    expect(args.images).toEqual([{ data: bin, address: 0x0 }]);
+    expect(args.eraseAll).toBe(true);
+    await waitFor(() => expect(screen.getByRole("button", { name: /^Flashed$/i })).toBeDisabled());
+  });
+
+  it("surfaces a compile-failed verdict and refuses to fetch the firmware", async () => {
+    const user = userEvent.setup();
+    mockApi.fleetRunStatus.mockResolvedValue({
+      run_id: "run-1", verdict: "failed", jobs: [],
+    });
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await pushFirst(user);
+    await user.click(screen.getByRole("button", { name: /Flash via WebSerial →/i }));
+
+    expect(await screen.findByText(/flash failed: compile failed/i)).toBeTruthy();
+    expect(mockApi.fleetFirmware).not.toHaveBeenCalled();
+    expect(mockFlash).not.toHaveBeenCalled();
+  });
+
+  it("surfaces 404 from /fleet/jobs/.../firmware as the flash error (artifact not ready)", async () => {
+    const user = userEvent.setup();
+    mockApi.fleetRunStatus.mockResolvedValue({
+      run_id: "run-1", verdict: "passed", jobs: [],
+    });
+    mockApi.fleetFirmware.mockRejectedValue(
+      new ApiError(404, "GET /fleet/jobs/run-1/firmware?factory=true -> 404", {
+        detail: "firmware artifact not available for run_id 'run-1'",
+      }),
+    );
+
+    render(<LorawanProvisionEsphomeDialog design={design()} onClose={() => {}} />);
+    await pushFirst(user);
+    await user.click(screen.getByRole("button", { name: /Flash via WebSerial →/i }));
+
+    expect(await screen.findByText(/flash failed: 404: firmware artifact not available/i)).toBeTruthy();
+    expect(mockFlash).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/LorawanProvisionEsphomeDialog.tsx
+++ b/web/src/components/LorawanProvisionEsphomeDialog.tsx
@@ -255,6 +255,78 @@ export function LorawanProvisionEsphomeDialog({ design, onClose }: Props) {
     }
   }
 
+  // "Flash via WebSerial" picks up the fleet-built factory image (via the
+  // studio's /fleet/jobs/{run_id}/firmware passthrough -- browser never sees
+  // FLEET_TOKEN) and writes it to a blank board via lib/flash.ts. Gated on a
+  // successful fleet compile because the artifact doesn't exist before then.
+  // State machine: idle -> waiting (poll fleet status) -> flashing -> flashed
+  // | error. See docs/lorawan/fleet-firmware-flash.md for the contract.
+  type FlashState =
+    | { kind: "idle" }
+    | { kind: "waiting"; verdict: string }
+    | { kind: "fetching" }
+    | { kind: "flashing"; written: number; total: number }
+    | { kind: "flashed"; bytes: number }
+    | { kind: "error"; message: string };
+  const [flashState, setFlashState] = useState<FlashState>({ kind: "idle" });
+  const [serialLog, setSerialLog] = useState<string>("");
+  const flashSessionRef = useRef<{ close: () => Promise<void> } | null>(null);
+
+  // Release the WebSerial port when the dialog unmounts so a left-open monitor
+  // doesn't hold the OS handle for the next provisioning attempt.
+  useEffect(() => () => {
+    void flashSessionRef.current?.close();
+  }, []);
+
+  async function handleFlash() {
+    if (pushState.kind !== "pushed" || !pushState.run_id) return;
+    const runId = pushState.run_id;
+    setFlashState({ kind: "waiting", verdict: "running" });
+    setSerialLog("");
+    try {
+      // 1. Wait for the compile to land. The fleet artifact endpoint 404s
+      //    until the run finishes; polling the run-status endpoint is the
+      //    canonical "is it ready" signal (reused from the push flow).
+      while (true) {
+        const status = await api.fleetRunStatus(runId);
+        if (status.verdict === "passed") break;
+        if (status.verdict === "failed" || status.verdict === "cancelled") {
+          throw new Error(`compile ${status.verdict}`);
+        }
+        setFlashState({ kind: "waiting", verdict: status.verdict });
+        await new Promise((r) => setTimeout(r, 2000));
+      }
+      // 2. Fetch the factory image -- blank-board flash at 0x0 + full erase.
+      //    The provision step re-flushed DevNonces, so wiping NVS is safe
+      //    (the §2.1 reasoning baked into flash.ts's docstring).
+      setFlashState({ kind: "fetching" });
+      const data = await api.fleetFirmware(runId, { factory: true });
+      // 3. Dynamic-import the flasher so esptool-js stays out of the bundle
+      //    until the user clicks (matches usb-detect's pattern).
+      const { flashFirmware } = await import("../lib/flash");
+      setFlashState({ kind: "flashing", written: 0, total: data.byteLength });
+      const session = await flashFirmware({
+        images: [{ data, address: 0x0 }],
+        eraseAll: true,
+        onProgress: (written, total) =>
+          setFlashState({ kind: "flashing", written, total }),
+        onSerial: (text) =>
+          setSerialLog((s) => (s + text).slice(-8000)),
+      });
+      flashSessionRef.current = session;
+      setFlashState({ kind: "flashed", bytes: data.byteLength });
+    } catch (e) {
+      let msg: string;
+      if (e instanceof ApiError) {
+        const detail = (e.body as { detail?: unknown } | undefined)?.detail;
+        msg = `${e.status}: ${typeof detail === "string" ? detail : e.message}`;
+      } else {
+        msg = e instanceof Error ? e.message : String(e);
+      }
+      setFlashState({ kind: "error", message: msg });
+    }
+  }
+
   const devEuiValid = DEV_EUI_RE.test(devEui);
   // ChirpStack-not-available gates the Provision button. Status is null while
   // the initial probe is in flight; treat that as "not yet". When the probe
@@ -480,6 +552,67 @@ export function LorawanProvisionEsphomeDialog({ design, onClose }: Props) {
                 <div className="mt-2 text-xs text-rose-400">
                   push failed: {pushState.message}
                 </div>
+              )}
+            </div>
+          )}
+
+          {/* Flash via WebSerial -- pulls the fleet-built factory image
+              through the studio (browser never holds FLEET_TOKEN) and
+              writes it to a blank board. Appears only after a successful
+              fleet push, since the artifact doesn't exist before then. */}
+          {result && pushState.kind === "pushed" && pushState.run_id && (
+            <div className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-[11px] uppercase tracking-wide text-zinc-500">
+                    flash via WebSerial
+                  </div>
+                  <div className="mt-1 text-xs text-zinc-400">
+                    Pull the fleet-built factory image and flash a blank board.
+                    Waits for the compile to finish, then erase + write at 0x0.
+                  </div>
+                </div>
+                <button
+                  onClick={handleFlash}
+                  disabled={
+                    flashState.kind === "waiting" ||
+                    flashState.kind === "fetching" ||
+                    flashState.kind === "flashing" ||
+                    flashState.kind === "flashed"
+                  }
+                  title={
+                    flashState.kind === "flashed"
+                      ? "Already flashed in this session"
+                      : undefined
+                  }
+                  className="rounded-md bg-blue-500/20 px-3 py-1.5 text-sm text-blue-100 ring-1 ring-blue-400/40 enabled:hover:bg-blue-500/30 disabled:opacity-40"
+                >
+                  {flashState.kind === "waiting"
+                    ? `Waiting (${flashState.verdict})…`
+                    : flashState.kind === "fetching"
+                      ? "Fetching image…"
+                      : flashState.kind === "flashing"
+                        ? `Flashing ${Math.round((flashState.written / Math.max(flashState.total, 1)) * 100)}%`
+                        : flashState.kind === "flashed"
+                          ? "Flashed"
+                          : "Flash via WebSerial →"}
+                </button>
+              </div>
+              {flashState.kind === "flashed" && (
+                <div className="mt-2 text-xs text-emerald-300">
+                  Wrote {flashState.bytes.toLocaleString()} bytes. Watch the
+                  serial log below for the LoRaWAN join.
+                </div>
+              )}
+              {flashState.kind === "error" && (
+                <div className="mt-2 text-xs text-rose-400">
+                  flash failed: {flashState.message}
+                </div>
+              )}
+              {serialLog && (
+                <pre className="mt-2 max-h-40 overflow-auto rounded-md border border-zinc-800 bg-black/60 p-2 font-mono text-[11px] leading-relaxed text-zinc-300">
+                  {serialLog}
+                </pre>
               )}
             </div>
           )}

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -1212,6 +1212,53 @@ def create_app(
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
 
+    @app.get("/fleet/jobs/{run_id}/firmware", tags=["fleet"])
+    async def fleet_job_firmware(run_id: str, factory: bool = False) -> Response:
+        """Passthrough for the fleet's compiled-firmware artifact -- the
+        studio fetches it server-side with FLEET_TOKEN and streams the
+        bytes to the browser's WebSerial flasher (no token in the browser).
+
+        ``?factory=true`` returns the merged bootloader+partitions+app
+        image for flashing a blank board at offset 0x0 (paired with
+        ``eraseAll: true`` on the browser side); default is the app image
+        for an NVS-preserving re-flash. Mirrors the standalone path's
+        ``/lorawan/firmware/{cache_key}[/factory]`` so the WebSerial flow
+        on the external-component path can reuse ``lib/flash.ts`` unchanged.
+
+        Returns 404 when the run hasn't finished, has aged out of the
+        addon's tracking, or the build didn't produce the requested image
+        type; 503 when fleet credentials are missing; 502 when the addon
+        is reachable but the call failed (e.g. the upstream artifact
+        endpoint isn't implemented yet -- see
+        ``docs/lorawan/fleet-firmware-flash.md``).
+        """
+        fc = make_fleet()
+        if not fc.is_configured():
+            raise HTTPException(
+                status_code=503,
+                detail="fleet not configured (set FLEET_URL and FLEET_TOKEN)",
+            )
+        try:
+            data = await fc.get_firmware(run_id, factory=factory)
+        except FleetUnavailable as e:
+            # The client raises FleetUnavailable on both 404 (firmware not
+            # available -> the dialog stops the flash flow with a clear
+            # message) and transport failures (the addon being down).
+            # Preserve the 404 vs 502 distinction the addon emitted so the
+            # browser can tell "not ready yet" from "fleet is down".
+            msg = str(e)
+            if "not available" in msg:
+                raise HTTPException(status_code=404, detail=msg) from e
+            raise HTTPException(status_code=502, detail=msg) from e
+        suffix = "-factory" if factory else ""
+        return Response(
+            content=data,
+            media_type="application/octet-stream",
+            headers={
+                "Content-Disposition": f'attachment; filename="{run_id}{suffix}.bin"',
+            },
+        )
+
     @app.get("/agent/status", tags=["agent"])
     def agent_status() -> dict:
         ok, reason = agent_available()

--- a/wirestudio/fleet/client.py
+++ b/wirestudio/fleet/client.py
@@ -283,6 +283,50 @@ class FleetClient:
         return RunStatus(run_id=run_id, verdict=_verdict(jobs), jobs=jobs)
 
     # ------------------------------------------------------------------
+    # Build-artifact fetch
+    # ------------------------------------------------------------------
+
+    async def get_firmware(
+        self, run_id: str, *, factory: bool = False
+    ) -> bytes:
+        """Fetch the compiled firmware bytes for a finished build.
+
+        Mirrors the addon's artifact endpoint at
+        ``GET /ui/api/jobs/{run_id}/firmware[/factory]`` (the upstream
+        half of the headless-device flash story -- see
+        ``docs/lorawan/fleet-firmware-flash.md``). The browser never holds
+        ``FLEET_TOKEN``; this is the studio-side passthrough that fetches
+        with the server token and re-streams the bytes to the WebSerial
+        flasher via the matching studio route.
+
+        ``factory=False`` (default) fetches the app image (re-flash that
+        preserves NVS); ``factory=True`` fetches the merged factory image
+        for blank-board flashing at offset 0x0. 404 -> ``FleetUnavailable``
+        the same way ``get_job_log`` handles unknown run_ids, so the UI
+        can stop polling.
+
+        The upstream endpoint does not exist yet at the time of writing
+        (it's the scoped fleet half); calls will 502 via the matching
+        studio route until the addon ships it. That gates the dialog's
+        "Flash via WebSerial" button on the upstream rollout without
+        changing this client surface later.
+        """
+        if not self.is_configured():
+            raise FleetUnavailable("FLEET_URL or FLEET_TOKEN missing")
+        suffix = "/factory" if factory else ""
+        async with self._client() as c:
+            resp = await c.get(f"/ui/api/jobs/{run_id}/firmware{suffix}")
+        if resp.status_code == 404:
+            raise FleetUnavailable(
+                f"firmware artifact not available for run_id {run_id!r}"
+            )
+        if resp.status_code >= 400:
+            raise FleetUnavailable(
+                f"firmware fetch failed: http {resp.status_code} {resp.text}"
+            )
+        return resp.content
+
+    # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements steps 2 + 3 of the scoping doc in #139
(`docs/lorawan/fleet-firmware-flash.md`): the in-scope studio halves of
**fleet-built firmware → WebSerial flash**. Closes the workflow gap
where the external-component LoRaWAN path built firmware on the fleet
but had no way to land it on a headless device (no network OTA, no fleet
flasher), so operators were hand-running `esphome run` locally.

The browser side reuses `lib/flash.ts` **unchanged** — it was already
image-agnostic. The new code is a server passthrough, a client method, and
dialog wiring.

## What lands

### 1. `FleetClient.get_firmware(run_id, *, factory=False) -> bytes`

Mirrors `get_job_log`'s shape and `FleetUnavailable` handling. Hits the
addon's `GET /ui/api/jobs/{run_id}/firmware[/factory]` — the upstream
half. Until the addon endpoint ships, calls 502 cleanly via the matching
studio route below; no client-side guesses about availability.

### 2. `GET /fleet/jobs/{run_id}/firmware[?factory=true]` passthrough

Streams the bytes as `application/octet-stream` after fetching with
`FLEET_TOKEN` server-side. The browser never holds the token. Preserves
404 (not ready / unavailable) vs 502 (transport / addon down) so the
browser can tell "still building" from "fleet outage". Mirrors the
standalone path's `/lorawan/firmware/{cache_key}[/factory]` route.

### 3. `api.fleetFirmware` + Flash via WebSerial step

New `LorawanProvisionEsphomeDialog` step appearing only after a successful
**Push to fleet →**:

1. Poll `fleetRunStatus` until verdict is `passed` (reusing existing run-
   status infra; no new polling). Surfaces `failed` / `cancelled` as a
   flash error and refuses to fetch.
2. Pull the factory image via the new `fleetFirmware(runId, { factory: true })`.
3. Dynamic-import `lib/flash`, write at `0x0` with `eraseAll: true`.
   Blank-board flash; NVS is empty and `/lorawan/provision-esphome`
   re-flushed DevNonces, so the wipe is safe (§2.1 reasoning already
   encoded in `flash.ts`).
4. Stream the post-flash serial log into the dialog so the LoRaWAN join
   line lands visibly next to the existing activation poll.

## Test plan

- [x] `pytest tests/test_fleet.py` — 50 passed (+10 new: client method
      variants, route variants, 404 / 502 / 503 paths).
- [x] `pytest -q` — 842 passed, 10 skipped.
- [x] `vitest run` full suite — 184 passed (+3 new dialog tests covering
      happy path with verify-args, compile-failed verdict refuses fetch,
      404 surfaced as flash error).
- [x] `tsc --noEmit`, `ruff check`, `eslint` clean.
- [ ] After upstream addon endpoint ships, flash a TTGO LoRa32 v1
      end-to-end through the dialog and confirm a clean OTAA join in the
      streamed serial log.

## Scope discipline

- **`lib/flash.ts` untouched.** The image-agnostic primitive from the
  standalone path was already the right shape.
- **No new polling infra.** The flash step reuses `fleetRunStatus` so the
  gate is consistent with existing fleet UX.
- **No new bundles in the main chunk.** `flash.ts` is dynamic-imported
  on click, matching the `usb-detect.ts` pattern.
- **Factory image only, for the dialog button.** App-region re-flash
  (preserve NVS) is the update case; deferred to a follow-up button per
  the scoping doc.
- **No fleet endpoint included.** That's the upstream half scoped in
  #139; this PR is the studio half and ships behind the unimplemented
  endpoint (button surfaces a clear 404 message until the addon ships).

## Files

- `wirestudio/fleet/client.py` — `get_firmware`
- `wirestudio/api/app.py` — `/fleet/jobs/{run_id}/firmware` route
- `web/src/api/client.ts` — `fleetFirmware`
- `web/src/components/LorawanProvisionEsphomeDialog.tsx` — Flash step
- `tests/test_fleet.py` — 10 new tests
- `web/src/components/LorawanProvisionEsphomeDialog.test.tsx` — 3 new tests
- `CHANGELOG.md` — `[Unreleased]` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFyMtkmq8tJEXNC5PmYp82)_