### PR TITLE
⚡ Bolt: fix O(N^2) parts lookup in InventoryDialog

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 ## 2025-02-18 - O(N²) array allocations inside render loops
 **Learning:** Computing derived state, like filtering a list of compatibility warnings for every item in a list using `.filter()` inside the `.map()` loop (e.g., `warnings={compatibilityWarnings.filter((w) => w.component_id === b.id)}` in `BusList.tsx`), creates O(N²) intermediate arrays on every render. This forces unnecessary garbage collection and degrades render performance, especially as lists grow. A similar anti-pattern is creating a new filtered `Set` for every item in a loop.
 **Action:** Lift the grouping of data out of the render loop into a `useMemo` map (e.g., computing a `Map<string, CompatibilityWarning[]>` where keys are component IDs). When checking for collisions, pass the entire Set to the child component and perform an `allBusIds.has(draftId)` check instead of pre-filtering the Set for each item.
+
+## 2025-02-18 - Avoid O(N*M) lookups inside closures used in render loops
+**Learning:** In `web/src/components/InventoryDialog.tsx`, `nameOf` helper function performed a `.find` operation over the entire `parts` array for every iteration inside a `.map` loop causing an O(N*M) iteration count rendering list items.
+**Action:** Replace `.find` inside render helper functions with a `Map` populated outside of render loops using `useMemo` for an O(1) performance lookup inside the closure.

--- a/web/src/components/InventoryDialog.tsx
+++ b/web/src/components/InventoryDialog.tsx
@@ -43,7 +43,14 @@ export function InventoryDialog({ design, onClose }: { design?: Design | null; o
   }, []);
 
   const inInventory = useMemo(() => new Set(entries.map((e) => e.library_id)), [entries]);
-  const nameOf = (id: string) => parts.find((p) => p.id === id)?.name ?? id;
+
+  // ⚡ Bolt: memoize parts lookup map to avoid O(N²) array traversals inside the render loop
+  const partsMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of parts) map.set(p.id, p.name);
+    return map;
+  }, [parts]);
+  const nameOf = (id: string) => partsMap.get(id) ?? id;
 
   const matches = useMemo(() => {
     const q = search.trim().toLowerCase();


### PR DESCRIPTION
⚡ Bolt: fix O(N^2) parts lookup in InventoryDialog

What: Replaced the O(N) `parts.find` array traversal inside the `nameOf` render helper with a memoized O(1) `Map` lookup.
Why: The `nameOf` function is called repeatedly inside a `.map` loop to render inventory rows. Calling `.find` on the full `parts` array for every row creates an O(N*M) performance bottleneck, causing slow renders as the inventory grows.
Impact: Reduces render iteration counts inside `InventoryDialog` from O(N*M) to O(1) per row.
Measurement: Verify the change with `cd web && npm test`.

---
*PR created automatically by Jules for task [14254732945025670341](https://jules.google.com/task/14254732945025670341) started by @moellere*