### PR TITLE
feat(mcp): view and rotate the MCP bearer token from the web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP bearer token: view and rotate from the web UI.** The token was only
+  discoverable by reading `~/.config/wirestudio/mcp-token` or grepping server
+  logs. A Settings dialog (header gear icon) now shows it masked with a reveal
+  toggle, a copy button, and a regenerate action. Two routes back it on the
+  unauthenticated API surface (a client must see the token before it can
+  present it): `GET /mcp/token` -> `{ token, managed }` and `POST
+  /mcp/token/rotate`. Rotation takes effect without a restart -- the bearer
+  middleware now reads the live token from a `TokenStore` on each request
+  instead of capturing it at mount time; `resolve_token()` stays as a thin
+  delegate. When the token is set via `WIRESTUDIO_MCP_TOKEN` it is shown
+  read-only and rotation returns 409 (the operator owns the secret).
+
 - **LoRaWAN: flash fleet-built firmware via WebSerial from the provision
   dialog.** Closes the workflow gap where the external-component LoRaWAN
   path built firmware on the fleet but had no way to land it on a headless

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -142,6 +142,20 @@ CORS-gated, rate-limited model — hardening those is a separate effort.
 The header comparison uses `secrets.compare_digest`, so a bad token
 can't be brute-forced by timing.
 
+### Viewing and rotating the token
+
+The web UI surfaces the token under the header **Settings** (gear) icon:
+reveal, copy, and regenerate. Two endpoints back it, both on the
+unauthenticated API surface (a client needs to *see* the token before it
+can present it):
+
+- `GET /mcp/token` → `{ token, managed }`. `managed` is `"file"`
+  (rotatable) or `"env"` (set via `WIRESTUDIO_MCP_TOKEN`, read-only).
+- `POST /mcp/token/rotate` → generates a new token, rewrites the
+  persisted file (mode 0600), and switches the running server over to it
+  with no restart. Returns `409` when the token is env-managed. Rotating
+  immediately 401s any client still holding the old token.
+
 ## Remote deployment
 
 For a homelab deployment behind a real hostname, swap the URL for

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -12,6 +12,9 @@ from starlette.routing import Route
 from wirestudio.mcp.auth import (
     DEFAULT_TOKEN_PATH,
     BearerTokenMiddleware,
+    TokenManagedError,
+    TokenStore,
+    load_token_store,
     resolve_token,
 )
 
@@ -34,7 +37,8 @@ def _build_app(token: str) -> Starlette:
             Route("/public", _ok),
         ]
     )
-    app.add_middleware(BearerTokenMiddleware, token=token)
+    store = TokenStore(token=token, path=Path("/unused"), env_managed=True)
+    app.add_middleware(BearerTokenMiddleware, store=store)
     return app
 
 
@@ -113,6 +117,43 @@ def test_resolve_token_generates_and_persists(monkeypatch, tmp_path: Path):
     assert mode == 0o600
     # Subsequent calls return the same value.
     assert resolve_token(token_path=file_path) == token
+
+
+async def test_middleware_reads_rotated_token_without_restart(tmp_path: Path):
+    # Rotation updates the live store; the already-mounted middleware must
+    # validate against the new token, not the one captured at startup.
+    file_path = tmp_path / "mcp-token"
+    file_path.write_text("original")
+    store = TokenStore(token="original", path=file_path, env_managed=False)
+
+    app = Starlette(routes=[Route("/mcp", _ok)])
+    app.add_middleware(BearerTokenMiddleware, store=store)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        new_token = store.rotate()
+        r_old = await c.get("/mcp", headers={"Authorization": "Bearer original"})
+        r_new = await c.get("/mcp", headers={"Authorization": f"Bearer {new_token}"})
+    assert r_old.status_code == 401
+    assert r_new.status_code == 200
+
+
+def test_token_store_rotate_persists_new_token(tmp_path: Path):
+    file_path = tmp_path / "mcp-token"
+    store = load_token_store(token_path=file_path)
+    first = store.token
+    rotated = store.rotate()
+    assert rotated != first
+    assert store.token == rotated
+    assert file_path.read_text() == rotated
+    assert file_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_token_store_rotate_refuses_env_managed(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("WIRESTUDIO_MCP_TOKEN", "from-env")
+    store = load_token_store(token_path=tmp_path / "mcp-token")
+    assert store.env_managed is True
+    with pytest.raises(TokenManagedError):
+        store.rotate()
 
 
 def test_default_token_path_is_under_user_config():

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,6 +25,7 @@ import { SchematicDialog } from "./components/SchematicDialog";
 import { LorawanFlashDialog } from "./components/LorawanFlashDialog";
 import { LorawanProvisionEsphomeDialog } from "./components/LorawanProvisionEsphomeDialog";
 import { InventoryDialog } from "./components/InventoryDialog";
+import { SettingsDialog } from "./components/SettingsDialog";
 import { useDebouncedValue } from "./lib/debounce";
 import { useAdvancedMode } from "./lib/uiMode";
 import {
@@ -40,6 +41,7 @@ import {
   RotateCcw,
   Download,
   ExternalLink,
+  Settings,
   Radio,
   Boxes,
   KeyRound,
@@ -106,6 +108,7 @@ export default function App() {
   const [showFlashDialog, setShowFlashDialog] = useState(false);
   const [showProvisionEsphomeDialog, setShowProvisionEsphomeDialog] = useState(false);
   const [showInventoryDialog, setShowInventoryDialog] = useState(false);
+  const [showSettingsDialog, setShowSettingsDialog] = useState(false);
   const [savingState, setSavingState] = useState<"idle" | "saving" | "saved">("idle");
 
   const dirty = useMemo(() => isDirty(originalDesign, design), [originalDesign, design]);
@@ -676,9 +679,18 @@ export default function App() {
               </label>
             </div>
 
+            <button
+              onClick={() => setShowSettingsDialog(true)}
+              className="ml-1 flex items-center gap-1 rounded-md p-1.5 text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-300"
+              title="Settings"
+              aria-label="Settings"
+            >
+              <Settings className="h-4 w-4" />
+            </button>
+
             <a
               href="/api/docs" target="_blank" rel="noreferrer"
-              className="ml-1 flex items-center gap-1 rounded-md p-1.5 text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-300"
+              className="flex items-center gap-1 rounded-md p-1.5 text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-300"
               title="OpenAPI documentation"
               aria-label="OpenAPI documentation"
             >
@@ -789,6 +801,7 @@ export default function App() {
       {showInventoryDialog && (
         <InventoryDialog design={design} onClose={() => setShowInventoryDialog(false)} />
       )}
+      {showSettingsDialog && <SettingsDialog onClose={() => setShowSettingsDialog(false)} />}
       <AgentSidebar
         open={showAgent}
         design={design}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -320,7 +320,16 @@ export const api = {
       method: "POST",
       body: JSON.stringify(body),
     }),
+
+  /** Current MCP bearer token. `managed: "env"` means it's set via an env var
+   *  and can't be rotated here. 404 if the server was built without MCP. */
+  mcpToken: () => request<McpTokenInfo>("/mcp/token"),
+  /** Generate a new MCP token, persist it, and switch the live server over to
+   *  it. Existing MCP clients must update. 409 if the token is env-managed. */
+  mcpTokenRotate: () => request<McpTokenInfo>("/mcp/token/rotate", { method: "POST" }),
 };
+
+export type McpTokenInfo = { token: string; managed: "file" | "env" };
 
 /**
  * Stream an agent turn over SSE. Yields each event as it arrives. Throws

--- a/web/src/components/SettingsDialog.tsx
+++ b/web/src/components/SettingsDialog.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from "react";
+import { Check, Copy, Eye, EyeOff, KeyRound, RotateCcw } from "lucide-react";
+import { ApiError, api, type McpTokenInfo } from "../api/client";
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "ready"; info: McpTokenInfo }
+  | { kind: "absent" } // server built without MCP
+  | { kind: "error"; message: string };
+
+function errMessage(e: unknown): string {
+  if (e instanceof ApiError) {
+    const detail = (e.body as { detail?: unknown } | undefined)?.detail;
+    return `${e.status}: ${typeof detail === "string" ? detail : e.message}`;
+  }
+  return e instanceof Error ? e.message : String(e);
+}
+
+export function SettingsDialog({ onClose }: { onClose: () => void }) {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [revealed, setRevealed] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [confirmRotate, setConfirmRotate] = useState(false);
+  const [rotating, setRotating] = useState(false);
+  const [rotateError, setRotateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    api
+      .mcpToken()
+      .then((info) => live && setState({ kind: "ready", info }))
+      .catch((e) => {
+        if (!live) return;
+        if (e instanceof ApiError && e.status === 404) setState({ kind: "absent" });
+        else setState({ kind: "error", message: errMessage(e) });
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  const token = state.kind === "ready" ? state.info.token : "";
+  const envManaged = state.kind === "ready" && state.info.managed === "env";
+
+  async function copyToken() {
+    try {
+      await navigator.clipboard.writeText(token);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard blocked; user can reveal + copy manually */
+    }
+  }
+
+  async function rotate() {
+    setRotating(true);
+    setRotateError(null);
+    try {
+      const info = await api.mcpTokenRotate();
+      setState({ kind: "ready", info });
+      setRevealed(true);
+      setConfirmRotate(false);
+    } catch (e) {
+      setRotateError(errMessage(e));
+    } finally {
+      setRotating(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="m-4 max-h-[85vh] w-full max-w-xl overflow-y-auto rounded-lg border border-zinc-800 bg-zinc-950 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
+          <div>
+            <div className="text-sm font-semibold text-zinc-100">Settings</div>
+            <div className="text-xs text-zinc-500">Connection and access for external clients.</div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md border border-zinc-800 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-900"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="space-y-4 p-4 text-sm">
+          <section className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+            <div className="flex items-center gap-2">
+              <KeyRound className="h-4 w-4 text-zinc-400" />
+              <span className="text-[11px] uppercase tracking-wide text-zinc-500">
+                MCP bearer token
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-zinc-400">
+              MCP clients (Claude Desktop, Claude Code) authenticate to the <code className="rounded bg-zinc-800 px-1">/mcp</code>{" "}
+              endpoint with this token via an <code className="rounded bg-zinc-800 px-1">Authorization: Bearer …</code> header.
+            </p>
+
+            {state.kind === "loading" && (
+              <div className="mt-3 text-xs text-zinc-500">Loading…</div>
+            )}
+
+            {state.kind === "absent" && (
+              <div className="mt-3 text-xs text-amber-300">
+                This server was built without the MCP endpoint, so there is no token.
+              </div>
+            )}
+
+            {state.kind === "error" && (
+              <div className="mt-3 text-xs text-rose-400">Couldn't load token — {state.message}</div>
+            )}
+
+            {state.kind === "ready" && (
+              <>
+                <div className="mt-3 flex items-stretch gap-2">
+                  <input
+                    readOnly
+                    value={revealed ? token : "•".repeat(Math.min(token.length, 44))}
+                    className="flex-1 rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 font-mono text-xs text-zinc-200"
+                  />
+                  <button
+                    onClick={() => setRevealed((r) => !r)}
+                    title={revealed ? "Hide" : "Reveal"}
+                    className="rounded-md border border-zinc-800 px-2 text-zinc-300 hover:bg-zinc-900"
+                  >
+                    {revealed ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                  <button
+                    onClick={copyToken}
+                    title="Copy"
+                    className="flex items-center gap-1 rounded-md border border-zinc-800 px-2 text-xs text-zinc-300 hover:bg-zinc-900"
+                  >
+                    {copied ? <Check className="h-4 w-4 text-emerald-400" /> : <Copy className="h-4 w-4" />}
+                  </button>
+                </div>
+
+                {envManaged ? (
+                  <div className="mt-3 text-xs text-zinc-400">
+                    This token is set via the <code className="rounded bg-zinc-800 px-1">WIRESTUDIO_MCP_TOKEN</code>{" "}
+                    environment variable, so it's read-only here. Rotate it by updating that secret and
+                    restarting the server.
+                  </div>
+                ) : (
+                  <div className="mt-3">
+                    {!confirmRotate ? (
+                      <button
+                        onClick={() => {
+                          setConfirmRotate(true);
+                          setRotateError(null);
+                        }}
+                        className="flex items-center gap-1.5 rounded-md border border-zinc-800 px-2.5 py-1.5 text-xs text-zinc-300 hover:bg-zinc-900"
+                      >
+                        <RotateCcw className="h-4 w-4" />
+                        Regenerate token
+                      </button>
+                    ) : (
+                      <div className="rounded-md border border-amber-900/60 bg-amber-950/30 p-3">
+                        <div className="text-xs text-amber-200">
+                          Regenerating immediately invalidates the current token. Any connected MCP
+                          client will get 401s until you update it with the new value.
+                        </div>
+                        <div className="mt-2 flex gap-2">
+                          <button
+                            onClick={rotate}
+                            disabled={rotating}
+                            className="rounded-md border border-amber-700 bg-amber-900/40 px-2.5 py-1 text-xs text-amber-100 hover:bg-amber-900/70 disabled:opacity-50"
+                          >
+                            {rotating ? "Regenerating…" : "Confirm regenerate"}
+                          </button>
+                          <button
+                            onClick={() => setConfirmRotate(false)}
+                            disabled={rotating}
+                            className="rounded-md border border-zinc-800 px-2.5 py-1 text-xs text-zinc-300 hover:bg-zinc-900 disabled:opacity-50"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                    {rotateError && (
+                      <div className="mt-2 text-xs text-rose-400">{rotateError}</div>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://127.0.0.1:8765',
+        target: process.env.WIRESTUDIO_API_TARGET ?? 'http://127.0.0.1:8765',
         changeOrigin: true,
         rewrite: (p) => p.replace(/^\/api/, ''),
       },

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -22,7 +22,12 @@ from slowapi.errors import RateLimitExceeded
 import os
 from pydantic import ValidationError
 
-from wirestudio.mcp import BearerTokenMiddleware, build_mcp_server, resolve_token
+from wirestudio.mcp import (
+    BearerTokenMiddleware,
+    TokenManagedError,
+    build_mcp_server,
+    load_token_store,
+)
 
 from wirestudio import __version__
 from wirestudio.agent.agent import is_available as agent_available, run_turn, stream_turn_events
@@ -42,6 +47,7 @@ from wirestudio.api.schemas import (
     InventoryCheckRequest,
     InventoryCheckResponse,
     InventoryEntryModel,
+    McpTokenResponse,
     ModuleSummary,
     FleetJobLogResponse,
     FleetJobStatus,
@@ -1354,11 +1360,32 @@ def create_app(
                 h.strip() for h in allowed_hosts.split(",") if h.strip()
             ]
         token_path_env = os.environ.get("WIRESTUDIO_MCP_TOKEN_PATH")
-        token = resolve_token(
+        token_store = load_token_store(
             token_path=Path(token_path_env) if token_path_env else None,
         )
+
+        # Token-management endpoints for the web UI. Registered before the
+        # catch-all mount below so FastAPI serves them directly -- they sit on
+        # the unauthenticated API surface (the bearer token only gates /mcp),
+        # which is required so the UI can show the token to a user who doesn't
+        # have it yet.
+        @app.get("/mcp/token", response_model=McpTokenResponse, tags=["mcp"])
+        def get_mcp_token() -> McpTokenResponse:
+            return McpTokenResponse(
+                token=token_store.token,
+                managed="env" if token_store.env_managed else "file",
+            )
+
+        @app.post("/mcp/token/rotate", response_model=McpTokenResponse, tags=["mcp"])
+        def rotate_mcp_token() -> McpTokenResponse:
+            try:
+                new_token = token_store.rotate()
+            except TokenManagedError as e:
+                raise HTTPException(status_code=409, detail=str(e)) from e
+            return McpTokenResponse(token=new_token, managed="file")
+
         mcp_app = mcp_server.streamable_http_app()
-        mcp_app.add_middleware(BearerTokenMiddleware, token=token)
+        mcp_app.add_middleware(BearerTokenMiddleware, store=token_store)
         app.mount("/", mcp_app)
 
     return app

--- a/wirestudio/api/schemas.py
+++ b/wirestudio/api/schemas.py
@@ -3,13 +3,21 @@
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
 
 class _S(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
+
+class McpTokenResponse(_S):
+    token: str = Field(description="Current MCP bearer token.")
+    managed: Literal["file", "env"] = Field(
+        description="Token source: 'file' (rotatable here) or 'env' (set via "
+        "WIRESTUDIO_MCP_TOKEN, read-only)."
+    )
 
 
 class BoardSummary(_S):

--- a/wirestudio/mcp/__init__.py
+++ b/wirestudio/mcp/__init__.py
@@ -8,6 +8,9 @@ into the existing FastAPI app at `/mcp` over the Streamable HTTP transport.
 from wirestudio.mcp.auth import (
     DEFAULT_TOKEN_PATH,
     BearerTokenMiddleware,
+    TokenManagedError,
+    TokenStore,
+    load_token_store,
     resolve_token,
 )
 from wirestudio.mcp.server import build_mcp_server
@@ -15,6 +18,9 @@ from wirestudio.mcp.server import build_mcp_server
 __all__ = [
     "BearerTokenMiddleware",
     "DEFAULT_TOKEN_PATH",
+    "TokenManagedError",
+    "TokenStore",
     "build_mcp_server",
+    "load_token_store",
     "resolve_token",
 ]

--- a/wirestudio/mcp/auth.py
+++ b/wirestudio/mcp/auth.py
@@ -21,32 +21,83 @@ DEFAULT_TOKEN_PATH = Path(os.path.expanduser("~/.config/wirestudio/mcp-token"))
 ENV_VAR = "WIRESTUDIO_MCP_TOKEN"
 
 
-def resolve_token(
+class TokenManagedError(RuntimeError):
+    """Raised when rotation is attempted on an externally-managed token.
+
+    When the token comes from `WIRESTUDIO_MCP_TOKEN` we can't rewrite it -- the
+    operator owns it (k8s Secret / sops). Rotating would only diverge the live
+    value from the secret, so we refuse.
+    """
+
+
+def _generate_and_persist(path: Path) -> str:
+    token = secrets.token_urlsafe(32)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(token)
+    path.chmod(0o600)
+    return token
+
+
+class TokenStore:
+    """Holds the live MCP bearer token so rotation takes effect without a restart.
+
+    `BearerTokenMiddleware` reads `.token` on every request rather than
+    capturing the value at construction time. `env_managed` is True when the
+    token came from the env var, in which case `rotate()` raises.
+    """
+
+    def __init__(self, *, token: str, path: Path, env_managed: bool) -> None:
+        self._token = token
+        self._path = path
+        self.env_managed = env_managed
+
+    @property
+    def token(self) -> str:
+        return self._token
+
+    def rotate(self) -> str:
+        if self.env_managed:
+            raise TokenManagedError(
+                f"token is set via {ENV_VAR}; rotate it by updating that secret, not here"
+            )
+        self._token = _generate_and_persist(self._path)
+        logger.info("Rotated MCP token; persisted to %s", self._path)
+        return self._token
+
+
+def load_token_store(
     *,
     env_var: str = ENV_VAR,
     token_path: Path | None = None,
-) -> str:
-    """Return the MCP bearer token, generating + persisting one on first call.
+) -> TokenStore:
+    """Resolve the MCP bearer token into a mutable store.
 
     The env var wins if set (operators using k8s Secrets / sops set this and
     the token-file path is ignored). Otherwise the persisted file is read.
     Otherwise a fresh token is generated, persisted with mode 0600, and the
     path is logged at INFO so the operator knows where to copy it from.
     """
+    path = token_path or DEFAULT_TOKEN_PATH
+
     env_token = os.environ.get(env_var)
     if env_token:
-        return env_token.strip()
+        return TokenStore(token=env_token.strip(), path=path, env_managed=True)
 
-    path = token_path or DEFAULT_TOKEN_PATH
     if path.exists():
-        return path.read_text().strip()
+        return TokenStore(token=path.read_text().strip(), path=path, env_managed=False)
 
-    token = secrets.token_urlsafe(32)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(token)
-    path.chmod(0o600)
+    token = _generate_and_persist(path)
     logger.info("Generated MCP token; copy it from %s", path)
-    return token
+    return TokenStore(token=token, path=path, env_managed=False)
+
+
+def resolve_token(
+    *,
+    env_var: str = ENV_VAR,
+    token_path: Path | None = None,
+) -> str:
+    """Return the current MCP bearer token. See `load_token_store`."""
+    return load_token_store(env_var=env_var, token_path=token_path).token
 
 
 class BearerTokenMiddleware:
@@ -59,9 +110,9 @@ class BearerTokenMiddleware:
     only gates the MCP endpoint, not the rest of the API.
     """
 
-    def __init__(self, app: ASGIApp, *, token: str, path_prefix: str = "/mcp") -> None:
+    def __init__(self, app: ASGIApp, *, store: TokenStore, path_prefix: str = "/mcp") -> None:
         self.app = app
-        self._token = token
+        self._store = store
         # Regex match: prefix as a path component (preceded by "/" or start,
         # followed by "/" or end). We can't compare scope[path] literally
         # because Starlette's nested Mount('/') doesn't strip path
@@ -88,7 +139,7 @@ class BearerTokenMiddleware:
         auth = headers.get(b"authorization", b"").decode("latin-1", errors="ignore")
         prefix = "Bearer "
         if not auth.startswith(prefix) or not secrets.compare_digest(
-            auth[len(prefix):], self._token
+            auth[len(prefix):], self._store.token
         ):
             await _send_401(send)
             return


### PR DESCRIPTION
## Summary

Surfaces the MCP bearer token in the web UI behind a header **gear icon**, so users no longer need to `cat ~/.config/wirestudio/mcp-token` or grep server logs to find it.

The Settings dialog shows the token masked with a reveal (eye) toggle, a copy button, and a **Regenerate** action (one-step confirm, since rotating immediately 401s any connected MCP client). When the token is set via `WIRESTUDIO_MCP_TOKEN` it's shown read-only with an explanation.

## Endpoints

Both sit on the unauthenticated API surface — by necessity, since a client needs to *see* the token before it can present it (and consistent with the rest of `/api`, which is already CORS-gated + rate-limited, token only gates `/mcp`):

- `GET /mcp/token` → `{ token, managed: "file" | "env" }`
- `POST /mcp/token/rotate` → new token; `409` when env-managed

## Rotation without restart

Previously the bearer middleware captured the token by value at mount time, so a rotated token wouldn't take effect until restart. This adds a `TokenStore` the middleware reads on every request; `rotate()` regenerates, persists `0600`, and updates it in place. `resolve_token()` becomes a thin delegate, so its contract is unchanged.

## Notes

- `web/vite.config.ts` gains a `WIRESTUDIO_API_TARGET` env override (default `http://127.0.0.1:8765` unchanged) so the dev server can point at a local backend on a non-default port.
- Security tradeoff is documented in `docs/mcp.md`: anyone who can reach the API can read/rotate the token. Unavoidable for a "display the token" feature. If the broader API is later locked down, these endpoints should move behind the same gate.

## Tests

- `tests/test_mcp_auth.py`: +3 tests (rotate persists, rotate refuses env-managed, middleware reads rotated token without restart). Full file passes.
- Full backend suite: 820 passed (1 pre-existing unrelated failure: `test_coverage_baseline` can't import the package in a subprocess without an editable install — fails identically on `main`).
- Frontend `tsc --noEmit`: clean.
- Verified end-to-end against a running server: GET → rotate → GET round-trips; UI renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)