### PR TITLE
docs(mcp): point token setup at the Settings dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **MCP token UI documented.** The MCP guide's "Copy the token" step and the
+  user guide's Web UI section now point at the header **Settings** (gear)
+  dialog for viewing, copying, and regenerating the MCP bearer token.
+
 ### Added
 
 - **MCP bearer token: view and rotate from the web UI.** The token was only

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -32,6 +32,12 @@ INFO  Generated MCP token; copy it from /home/<user>/.config/wirestudio/mcp-toke
 
 ### 2. Copy the token
 
+Easiest from the web UI: open the **Settings** (gear) icon in the header,
+reveal the token, and copy it. You can also regenerate it there — see
+[Viewing and rotating the token](#viewing-and-rotating-the-token).
+
+From the shell instead:
+
 ```bash
 cat ~/.config/wirestudio/mcp-token
 ```

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -65,7 +65,11 @@ Header buttons: **New design**, **Reset**, **Save**, **Download JSON**,
 **Solve pins**, **strict** (toggle), **Connect device** (USB
 bootstrap), **Add by function** (capability picker), **Schematic**
 (KiCad export), **Enclosure** (parametric `.scad` + Thingiverse
-search), **Push to fleet**.
+search), **Push to fleet**, **Settings** (gear).
+
+The **Settings** dialog surfaces the MCP bearer token: reveal, copy, or
+regenerate it without leaving the browser (read-only when the token is
+pinned via `WIRESTUDIO_MCP_TOKEN`). See [the MCP guide](mcp.md#auth).
 
 ## HTTP API endpoints
 


### PR DESCRIPTION
## Summary

Follow-up docs for the MCP token Settings UI (shipped in #143). The feature merged but the prose docs still told users to `cat ~/.config/wirestudio/mcp-token` as the only way to get the token.

- **`docs/mcp.md`** — the first-connect "Copy the token" step now leads with the header **Settings** (gear) dialog (reveal + copy), keeping the shell/env methods as alternatives.
- **`docs/user_guide.md`** — adds **Settings** (gear) to the header-buttons list and a one-line note that it surfaces the MCP token (reveal/copy/regenerate; read-only when pinned via `WIRESTUDIO_MCP_TOKEN`).

The endpoint/rotation reference (`GET /mcp/token`, `POST /mcp/token/rotate`) was already added to `docs/mcp.md` in #143.

Docs-only; no code under `wirestudio/` changes. CHANGELOG gets a short Documentation entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)