### PR TITLE
fix(deploy): persist component inventory on the data PVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Component inventory now persists across redeploys.** `INVENTORY_PATH` was
+  never set, so `inventory.json` fell back to a package-relative path on the
+  container's ephemeral root filesystem and was lost on every pod restart. The
+  Dockerfile now sets `INVENTORY_PATH=/data/inventory.json`, putting it on the
+  `wirestudio-data` PVC alongside designs and sessions.
+
 ### Documentation
 
 - **MCP token UI documented.** The MCP guide's "Copy the token" step and the

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,7 @@ ENV PYTHONUNBUFFERED=1 \
     WIRESTUDIO_STATIC_DIR=/app/web-dist \
     SESSIONS_DIR=/data/sessions \
     DESIGNS_DIR=/data/designs \
+    INVENTORY_PATH=/data/inventory.json \
     WIRESTUDIO_FW_CACHE=/data/firmware-cache
 
 EXPOSE 8765


### PR DESCRIPTION
## What

Sets `INVENTORY_PATH=/data/inventory.json` in the Dockerfile so the component inventory persists across pod restarts and redeploys.

## Why

`INVENTORY_PATH` was never set in the Dockerfile or any deploy manifest, so `inventory.json` fell back to a package-relative default (`INVENTORY_PATH_DEFAULT` in `wirestudio/inventory/store.py`) that resolves into site-packages on the container's **ephemeral root filesystem** — not the `/data` PVC. Every inventory edit was lost on the next redeploy.

Designs (`DESIGNS_DIR`) and chat sessions (`SESSIONS_DIR`) were already correctly mapped to `/data`; inventory was the lone gap. This puts it on the `wirestudio-data` PVC alongside them.

## Notes

- No manifest change: all `/data` directory env vars live in the Dockerfile `ENV` (the k8s manifest only carries secrets and ChirpStack config), so this stays consistent with `DESIGNS_DIR`/`SESSIONS_DIR`.
- **Operational:** existing inventory on running pods lives on the ephemeral fs and will be lost on the redeploy that picks up this change. Export first if there's anything worth keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)