### PR TITLE
release: 0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.3] — 2026-06-28
+
 ### Fixed
 
 - **Component inventory now persists across redeploys.** `INVENTORY_PATH` was

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"


### PR DESCRIPTION
Release commit for **0.17.3** (patch). Bumps `wirestudio/__init__.py` and rolls `[Unreleased]` into a dated `[0.17.3]` section.

## Contents (from `[Unreleased]`)
- **Fixed:** component inventory now persists across redeploys (`INVENTORY_PATH=/data/inventory.json`, #145)
- **Added:** MCP bearer token view/rotate in the web UI; LoRaWAN flash fleet-built firmware via WebSerial
- **Documentation:** MCP token UI documented

## After merge
Tag the merge commit `v0.17.3` and push it. That triggers: PyPI publish + GitHub Release (`release.yml`), GHCR images `:0.17.3`/`:0.17`/`:latest` + `:0.17.3-lorawan` (`docker.yml`), and an auto-opened `deploy(prod): roll to 0.17.3` PR. Merging that prod PR is what makes ArgoCD sync prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)