### PR TITLE
release: 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] — 2026-07-11
+
 ### Added
 
 - **Strict mode.** A design-level `strict: true` toggle flips the permissive

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.17.3"
+__version__ = "0.18.0"


### PR DESCRIPTION
Roll `[Unreleased]` into `[0.18.0]` and bump `wirestudio.__version__` to 0.18.0.

Contents of this release:
- Potentiometer + 12V PWM fan components (`solder-fan` example)
- Pin-solver PWM/interrupt tightening + validate-time `function_unsupported` check
- Module batch (1 → 5): `fan-controller`, `relay-4ch`, `motion-light`, `env-display`
- Strict mode: persistent `design.strict` toggle enforced across render/validate/push/CLI, with `set_strict` MCP tool + UI persistence

After merge: push the `v0.18.0` tag to trigger the image build and the automated prod-roll PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)