### PR TITLE
docs(readme): lead with the hardware design angle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `:X.Y.Z-lorawan` release tag), plus the manual `newTag` option. Also fixed a
   broken image tag in `deploy/k8s.yaml` (`:v0.17.1`, which never existed in the
   registry) — now `:0.18.0`.
+- **README leads with the hardware design angle.** The intro now frames the
+  studio around what stock ESPHome's Device Builder doesn't do — electrical
+  metadata, CSP pin solving, electrical validation, and the physical artifacts
+  (wiring, schematic, PCB, fab bundle, enclosure) — instead of board/component
+  selection. Also reconciled the status table with reality: KiCad PCB layout
+  (0.14.0) and fab outputs (0.15.0) move from Deferred to Verified with their
+  CI gates linked, only Freerouting autorouting stays deferred; version
+  references and the Docker quickstart tag move to `0.18.0` (the `v0.17.1`
+  tag never existed in the registry).
 
 ## [0.18.0] — 2026-07-11
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # wirestudio
 
-Agent-driven IoT device design tool. Describe a goal (or pick parts);
-get ESPHome YAML, an ASCII wiring diagram, and a BOM that compile
-under upstream ESPHome.
+Hardware design tool for ESPHome devices. A single `design.json`
+(board + components + connections) drives every artifact: solved pin
+assignments, electrical validation, compile-clean ESPHome YAML, an
+ASCII wiring diagram, a KiCad schematic and placed PCB, a JLCPCB fab
+bundle (BOM / CPL / Gerber / drill), and a parametric OpenSCAD
+enclosure. Drive it from the web UI, the built-in agent, or any MCP
+client.
+
+Stock ESPHome's Device Builder covers picking a board and adding
+components. wirestudio works below the YAML: the component library
+carries electrical metadata ESPHome doesn't model (voltage rails,
+current draw, pull-ups, per-pin capabilities), a CSP solver assigns
+legal pins from it, a validator catches boot-strap / ADC2-WiFi /
+voltage conflicts, and the same design fans out to the physical
+artifacts — wiring, schematic, PCB, enclosure.
 
 Two LoRaWAN paths share the studio. The standalone target builds and
 flashes RadioLib + LoRaWAN_ESP32 firmware over WebSerial. The newer
@@ -14,8 +26,8 @@ join-status polling all from the web UI. Both paths target US915 radio
 boards (TTGO T-Beam / LoRa32, Heltec WiFi LoRa 32 V2 / V3) and
 provision against ChirpStack.
 
-Produces ESPHome configs but is not affiliated with the ESPHome
-project — see [`weirded/fleet-for-esphome`](https://github.com/weirded/fleet-for-esphome)
+Not affiliated with the ESPHome project — see
+[`weirded/fleet-for-esphome`](https://github.com/weirded/fleet-for-esphome)
 for the OTA-deploy companion this studio's **Push to fleet** flow
 talks to.
 
@@ -33,15 +45,14 @@ Detailed docs live in [`docs/`](docs/):
 
 ## Status
 
-`v0.17.1` — on PyPI (`pip install wirestudio`). The studio has wide
-surface area (YAML, schematic, enclosure, agent, MCP server, fleet
-handoff, web UI, two LoRaWAN flash/provision paths — standalone Arduino
-and an external-component path that emits ESPHome YAML referencing
-`lorawan-for-esphome`) and a set of things actually verified against
-upstream tools. Three of the four priority
-tiers (YAML, wiring schema, enclosure) are now gated in CI, and **every
-library component and board is exercised by a bundled example** that
-passes those gates. This section is honest about which is which, ordered
+`v0.18.0` — on PyPI (`pip install wirestudio`). The studio has wide
+surface area (YAML, schematic, PCB + fab outputs, enclosure, agent,
+MCP server, fleet handoff, web UI, two LoRaWAN flash/provision paths —
+standalone Arduino and an external-component path that emits ESPHome
+YAML referencing `lorawan-for-esphome`) and a set of things actually
+verified against upstream tools. The YAML, schematic, PCB, and
+enclosure paths are gated in CI, and **every library component and
+board is exercised by a bundled example** that passes those gates. This section is honest about which is which, ordered
 by how much it matters that it works.
 
 Tiers, in priority order:
@@ -52,12 +63,14 @@ Tiers, in priority order:
 | **Verified** | CSP pin solver + compat checker | assign legal pins, surface boot-strap / ADC2-WiFi / voltage / locked-pin issues | unit tests + property checks in `tests/test_pin_solver.py` + `tests/test_compatibility.py` |
 | **Verified** | Fleet handoff | push YAML to `fleet-for-esphome` ha-addon, optional compile + log relay | round-trip tests in `tests/test_fleet.py` |
 | **Verified** | KiCad schematic | emit a SKiDL Python script the user runs locally to produce a `.kicad_sch` | every bundled example builds a KiCad netlist against the pinned upstream symbol libraries, every PR ([gate](.github/workflows/kicad-schematic.yml)) — no unresolved symbols or pins. Parts KiCad ships no symbol for (sensor/module breakouts) render as labeled generic headers |
+| **Verified** | KiCad PCB layout | emit a placed, unrouted `.kicad_pcb` — footprints, nets, ratsnest, edge cuts | every bundled example emits a structurally sound board, every PR ([gate](.github/workflows/pcb-layout.yml)); a DRC tier opens each board in real KiCad ([gate](.github/workflows/pcb-drc.yml)) |
+| **Verified** | Fab outputs | JLCPCB upload bundle — BOM, CPL, Gerber + drill (`/design/fab/*`) | CPL positions match the `.kicad_pcb` placement; the DRC tier smoke-tests the Gerber export. Boards are unrouted until the Freerouting step, so Gerbers carry pads but no traces (`is_routed` flags it) |
 | **Verified** | Parametric enclosure | OpenSCAD `.scad` from board mount-hole metadata | every enclosure-capable board renders through real OpenSCAD to a non-empty, manifold (closed, printable) solid, every PR ([gate](.github/workflows/enclosure-render.yml)) |
 | **Works (hardware-validated)** | LoRaWAN target | build RadioLib + LoRaWAN_ESP32 firmware for US915 radio boards, flash over WebSerial, provision against ChirpStack | every radio board's firmware builds in CI ([gate](.github/workflows/lorawan-firmware.yml)); validated end-to-end on a TTGO T-Beam against live ChirpStack 4.17 — no automated live-device gate |
 | **Works (lighter checks)** | MCP server | drive the design tools from Claude Code / Desktop over the Model Context Protocol | tool / auth / resource tests in `tests/test_mcp_*.py`; not exercised against a live MCP client in CI |
 | **Experimental** | Thingiverse search relay | rank community models for a board | smoke-tested; depends on a third-party search API that ranks unevenly |
 | **Experimental** | Agent (Claude tool-using) | natural-language design driving | works in practice; tool surface is small; no auto-eval against task list yet |
-| **Deferred** | KiCad PCB layout | Freerouting + Gerber + JLCPCB CPL/BOM | 1.0+, not started |
+| **Deferred** | PCB autorouting | Freerouting traces → routed Gerbers | 1.0+, not started |
 
 The **Verified** tier is the bar the project is asking to be judged
 on. Everything else is offered with the caveat that's spelled out in
@@ -79,7 +92,7 @@ that pin moves, this line moves with it.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:v0.17.1
+  ghcr.io/moellere/wirestudio:0.18.0
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +


### PR DESCRIPTION
Reframe the README intro around what stock ESPHome's Device Builder doesn't do: electrical metadata, CSP pin solving, electrical validation, and the physical artifacts (wiring, schematic, PCB, fab bundle, enclosure). ESPHome 2026.5/2026.6 made board and component selection table stakes; the lead now sells what's downstream of the electrical model instead.

Also reconciles the status table with reality: KiCad PCB layout (0.14.0) and fab outputs (0.15.0) move from Deferred to Verified with their CI gates linked; only Freerouting autorouting stays deferred. Version references bump to v0.18.0 and the Docker quickstart tag is fixed to `0.18.0` (`v0.17.1` never existed in the registry, so the quickstart was broken as written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)