### PR TITLE
docs(index): mark PCB layout Verified (unrouted) in the roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `:X.Y.Z-lorawan` release tag), plus the manual `newTag` option. Also fixed a
   broken image tag in `deploy/k8s.yaml` (`:v0.17.1`, which never existed in the
   registry) — now `:0.18.0`.
+- **Docs roadmap: PCB layout marked Verified (unrouted).** `docs/index.md`
+  Priority 4 no longer claims the layout is "not yet in flight" — it now
+  records the shipped `.kicad_pcb` emit (0.14.0) and fab outputs (0.15.0)
+  with their CI gates, leaving Freerouting autorouting as the open step.
 - **README leads with the hardware design angle.** The intro now frames the
   studio around what stock ESPHome's Device Builder doesn't do — electrical
   metadata, CSP pin solving, electrical validation, and the physical artifacts

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,10 +113,19 @@ e.g. [YAPP_Box](https://github.com/mrWheel/YAPP_Box) and integrate
 instead of reimplementing? Next: more boards' `enclosure:` metadata
 (only 5 carry it today); a lid + snap-fit; slicer-side print validation.
 
-**Priority 4 — PCB layout.** *Deferred to 1.0+.* The footprint-coverage
-gate (every component + board names a real KiCad footprint that resolves
-in the pinned libraries) landed as step 1 — the foundation a `.kicad_pcb`
-emit builds on — but the layout itself is not yet in flight.
+**Priority 4 — PCB layout.** *Verified (unrouted).* Shipped in three
+steps: the footprint-coverage gate (every component + board names a
+real KiCad footprint that resolves in the pinned libraries, 0.13), the
+`.kicad_pcb` emit (footprints placed, pads bound to nets, `Edge.Cuts`
+outline, 0.14), and the fab outputs (BOM / CPL / Gerber + drill via
+`/design/fab/*`, packaged for JLCPCB upload, 0.15). The
+[`pcb-layout`](../.github/workflows/pcb-layout.yml) gate proves every
+bundled example emits a structurally sound board, and
+[`pcb-drc`](../.github/workflows/pcb-drc.yml) opens each board in real
+KiCad and runs DRC (unrouted airwires expected). Boards are unrouted —
+Gerbers carry pads but no traces, flagged via `is_routed`. Next:
+Freerouting autorouting, closing the gap to a genuinely fab-ready
+routed board.
 
 **LoRaWAN target (0.13 standalone, 0.16+ external-component).** *Works —
 hardware-validated on the standalone path; external-component path


### PR DESCRIPTION
Follow-up to #156: docs/index.md Priority 4 had the same staleness the README status table did — it claimed PCB layout was deferred and "not yet in flight," while the `.kicad_pcb` emit (0.14.0) and fab outputs (0.15.0) shipped with the `pcb-layout` and `pcb-drc` gates. Now records the shipped state and leaves Freerouting autorouting as the open step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)