### PR TITLE
feat(kicad): Freerouting autoroute pipeline + pcb-route CI gate

### DIFF
--- a/.github/workflows/pcb-route.yml
+++ b/.github/workflows/pcb-route.yml
@@ -1,0 +1,102 @@
+name: pcb-route
+
+# The routed tier above pcb-drc: run the full Freerouting roundtrip
+# (board -> Specctra DSN via pcbnew -> freerouting.jar -> SES import) on
+# representative examples and hold the result to the routed bar -- zero
+# unconnected items, copper present, no non-waived error-severity DRC
+# violations. Proves the autoroute pipeline itself, not the whole catalog.
+#
+# Heavier than pcb-drc (KiCad + a JRE + the jar), so same cadence: PRs that
+# touch the pipeline, weekly, and on demand.
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'wirestudio/kicad/**'
+      - 'wirestudio/library/**'
+      - 'scripts/check_pcb_route.py'
+      - '.github/workflows/pcb-route.yml'
+  schedule:
+    - cron: '0 12 * * 1'   # 12:00 UTC every Monday, after pcb-drc
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pcb-route-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  KICAD_FOOTPRINTS_REF: "8.0.0"
+  KICAD_SYMBOLS_REF: "8.0.0"
+  FREEROUTING_VERSION: "2.2.4"
+  FREEROUTING_SHA256: "f5ed374182900ccc78e473518bbb9f6b869f4a07159495f663a76f52bb10523b"
+
+jobs:
+  pcb-route:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Cache KiCad footprint libraries
+        id: cache-footprints
+        uses: actions/cache@v4
+        with:
+          path: kicad-footprints
+          key: kicad-footprints-${{ env.KICAD_FOOTPRINTS_REF }}
+      - name: Fetch KiCad footprint libraries
+        if: steps.cache-footprints.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch "$KICAD_FOOTPRINTS_REF" \
+            https://gitlab.com/kicad/libraries/kicad-footprints.git kicad-footprints
+
+      - name: Cache KiCad symbol libraries
+        id: cache-symbols
+        uses: actions/cache@v4
+        with:
+          path: kicad-symbols
+          key: kicad-symbols-${{ env.KICAD_SYMBOLS_REF }}
+      - name: Fetch KiCad symbol libraries
+        if: steps.cache-symbols.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch "$KICAD_SYMBOLS_REF" \
+            https://gitlab.com/kicad/libraries/kicad-symbols.git kicad-symbols
+
+      # KiCad 8 for kicad-cli AND the system-python pcbnew bindings the
+      # DSN/SES bridge runs under (KiCad >= 8: headless ImportSpecctraSES).
+      - name: Install KiCad 8 (kicad-cli + pcbnew)
+        run: |
+          sudo add-apt-repository --yes ppa:kicad/kicad-8.0-releases
+          sudo apt-get update
+          sudo apt-get install --yes kicad
+          kicad-cli version
+          /usr/bin/python3 -c "import pcbnew; print(pcbnew.GetBuildVersion())"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Fetch Freerouting ${{ env.FREEROUTING_VERSION }}
+        run: |
+          curl -sSL -o freerouting.jar \
+            "https://github.com/freerouting/freerouting/releases/download/v${FREEROUTING_VERSION}/freerouting-${FREEROUTING_VERSION}.jar"
+          echo "${FREEROUTING_SHA256}  freerouting.jar" | sha256sum --check
+
+      - name: Install studio
+        run: pip install -e .
+
+      - name: Route representative boards + routed DRC
+        env:
+          KICAD8_FOOTPRINT_DIR: ${{ github.workspace }}/kicad-footprints
+          KICAD8_SYMBOL_DIR: ${{ github.workspace }}/kicad-symbols
+          WIRESTUDIO_PCBNEW_PYTHON: /usr/bin/python3
+          WIRESTUDIO_FREEROUTING_JAR: ${{ github.workspace }}/freerouting.jar
+        run: python scripts/check_pcb_route.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **PCB autorouting (Freerouting).** `wirestudio/kicad/route.py` routes a
+  generated `.kicad_pcb`: Specctra DSN export via pcbnew (a dependency-free
+  `pcbnew_bridge.py` run under the system python — kicad-cli has no Specctra
+  support, and KiCad >= 8 is required for the headless SES import),
+  `freerouting.jar` in batch mode (`-mt 1`; multithreaded routing is a known
+  source of KiCad-DRC clearance violations), then SES import back into the
+  board. Subprocess-based throughout, watchdog-killed on stagnation, results
+  content-addressed like the firmware cache. Gated by `route_status()`
+  (pcbnew bridge + java + `WIRESTUDIO_FREEROUTING_JAR`); CLI at
+  `python -m wirestudio.kicad.route`. A new `pcb-route` CI gate routes
+  representative examples and holds them to the routed bar: copper present,
+  zero unconnected items, no non-waived error-severity DRC violations —
+  verified end-to-end against KiCad 8 + Freerouting 2.2.4 (four boards
+  route clean). HTTP/MCP/web-UI surfaces and a toolchain image are the
+  follow-up; this lands the pipeline and its gate.
+
 ### Documentation
 
 - **Deployment docs reconciled with the actual GitOps flow.** `docs/deployment.md`

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Tiers, in priority order:
 | **Works (lighter checks)** | MCP server | drive the design tools from Claude Code / Desktop over the Model Context Protocol | tool / auth / resource tests in `tests/test_mcp_*.py`; not exercised against a live MCP client in CI |
 | **Experimental** | Thingiverse search relay | rank community models for a board | smoke-tested; depends on a third-party search API that ranks unevenly |
 | **Experimental** | Agent (Claude tool-using) | natural-language design driving | works in practice; tool surface is small; no auto-eval against task list yet |
-| **Deferred** | PCB autorouting | Freerouting traces → routed Gerbers | 1.0+, not started |
+| **Verified** | PCB autorouting | Freerouting roundtrip — board → Specctra DSN → routed → SES import (`python -m wirestudio.kicad.route`) | representative examples route with zero unconnected items and pass routed DRC ([gate](.github/workflows/pcb-route.yml)); HTTP/MCP/UI surfaces and a toolchain image are follow-ups |
 
 The **Verified** tier is the bar the project is asking to be judged
 on. Everything else is offered with the caveat that's spelled out in

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,10 +122,15 @@ outline, 0.14), and the fab outputs (BOM / CPL / Gerber + drill via
 [`pcb-layout`](../.github/workflows/pcb-layout.yml) gate proves every
 bundled example emits a structurally sound board, and
 [`pcb-drc`](../.github/workflows/pcb-drc.yml) opens each board in real
-KiCad and runs DRC (unrouted airwires expected). Boards are unrouted —
-Gerbers carry pads but no traces, flagged via `is_routed`. Next:
-Freerouting autorouting, closing the gap to a genuinely fab-ready
-routed board.
+KiCad and runs DRC (unrouted airwires expected). The Freerouting
+autoroute step now closes the routing gap:
+`python -m wirestudio.kicad.route` runs board → Specctra DSN (pcbnew
+bridge) → `freerouting.jar` → SES import, and the
+[`pcb-route`](../.github/workflows/pcb-route.yml) gate holds
+representative examples to the routed bar (copper present, zero
+unconnected items, routed DRC clean). Next: wire routing into the fab
+endpoints/MCP/web UI and ship a toolchain image so the default deploy
+can route.
 
 **LoRaWAN target (0.13 standalone, 0.16+ external-component).** *Works —
 hardware-validated on the standalone path; external-component path

--- a/scripts/check_pcb_route.py
+++ b/scripts/check_pcb_route.py
@@ -1,0 +1,132 @@
+"""Autoroute representative example boards and hold them to the routed bar.
+
+Where check_pcb_drc.py proves KiCad accepts every placed-but-unrouted board
+(waiving unconnected airwires), this gate runs the full Freerouting roundtrip
+on a representative spread of examples and asserts the *routed* standard:
+zero unconnected items, copper present, and no error-severity violations
+beyond the footprint-inherent set the DRC tier already waives.
+
+A representative subset, not every example: routing cost scales with board
+density and the point is proving the pipeline, not re-routing the catalog
+weekly.
+
+Needs kicad-cli, a pcbnew-capable python (WIRESTUDIO_PCBNEW_PYTHON), java,
+and WIRESTUDIO_FREEROUTING_JAR. Skips with exit 0 when the route toolchain
+is absent so it's a no-op elsewhere.
+
+Exit 0 = every representative board routes and passes routed DRC, 1 = at
+least one failed, 2 = KiCad libraries not found.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from wirestudio.kicad.fab import is_routed
+from wirestudio.kicad.pcb import generate_kicad_pcb, pcb_status
+from wirestudio.kicad.route import RouteError, route_board, route_status
+from wirestudio.library import default_library
+from wirestudio.model import Design
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "wirestudio" / "examples"
+
+# Small, PWM-dense, I2C multi-sensor, many-connection: a spread of routing
+# difficulty, not an exhaustive sweep.
+REPRESENTATIVE = ["garage-motion", "solder-fan", "weather-station", "securitypanel"]
+
+# The footprint-inherent waivers from check_pcb_drc.py — but NOT
+# unconnected_items: a routed board with airwires is a routing failure.
+_IGNORED_VIOLATIONS = {
+    "drill_out_of_range",
+    "solder_mask_bridge",
+    "copper_edge_clearance",
+    "courtyards_overlap",
+    "silk_over_copper",
+    "silk_overlap",
+    "silk_edge_clearance",
+}
+
+
+def _routed_problems(report: Path) -> list[str]:
+    data = json.loads(report.read_text())
+    out = [
+        f"{v.get('type')}: {v.get('description')}"
+        for v in data.get("violations", [])
+        if v.get("severity") == "error" and v.get("type") not in _IGNORED_VIOLATIONS
+    ]
+    unconnected = data.get("unconnected_items", [])
+    if unconnected:
+        out.append(f"{len(unconnected)} unconnected item(s) after routing")
+    return out
+
+
+def main() -> int:
+    status = route_status()
+    if not status["available"]:
+        print(f"route toolchain unavailable; skipping (no-op): {status['reason']}",
+              file=sys.stderr)
+        return 0
+    if shutil.which("kicad-cli") is None:
+        print("kicad-cli not on PATH; skipping (no-op).", file=sys.stderr)
+        return 0
+    if not pcb_status()["available"]:
+        print(f"error: {pcb_status()['reason']}", file=sys.stderr)
+        return 2
+
+    lib = default_library()
+    failures: dict[str, list[str]] = {}
+    with tempfile.TemporaryDirectory(prefix="wirestudio-route-") as td:
+        tmp = Path(td)
+        for name in REPRESENTATIVE:
+            design = Design.model_validate(
+                json.loads((EXAMPLES_DIR / f"{name}.json").read_text())
+            )
+            try:
+                unrouted = generate_kicad_pcb(design, lib)
+            except Exception as exc:  # noqa: BLE001
+                failures[name] = [f"emit raised {type(exc).__name__}: {exc}"]
+                continue
+            try:
+                routed = route_board(unrouted, use_cache=False)
+            except RouteError as exc:
+                failures[name] = [f"routing failed: {str(exc)[-800:]}"]
+                continue
+            if not is_routed(routed):
+                failures[name] = ["routed board carries no copper"]
+                continue
+            board = tmp / f"{name}.kicad_pcb"
+            board.write_text(routed)
+            report = tmp / f"{name}.drc.json"
+            proc = subprocess.run(
+                ["kicad-cli", "pcb", "drc", "--format", "json",
+                 "--output", str(report), str(board)],
+                capture_output=True, text=True, timeout=180,
+            )
+            if not report.is_file():
+                failures[name] = [f"kicad-cli produced no report (rc={proc.returncode}): "
+                                  f"{(proc.stderr or proc.stdout or '')[-500:]}"]
+                continue
+            problems = _routed_problems(report)
+            if problems:
+                failures[name] = problems
+            else:
+                print(f"{name}: routed clean", file=sys.stderr)
+
+    if failures:
+        print(f"{len(failures)} board(s) failed the routed gate:", file=sys.stderr)
+        for name, problems in failures.items():
+            for p in problems:
+                print(f"  {name}: {p}", file=sys.stderr)
+        return 1
+    print(f"all {len(REPRESENTATIVE)} representative boards route and pass routed DRC.",
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kicad_route.py
+++ b/tests/test_kicad_route.py
@@ -1,0 +1,144 @@
+"""Tests for the Freerouting autoroute step.
+
+The real toolchain (pcbnew + Java + the Freerouting jar) is exercised in CI's
+pcb-route workflow; here the bridge interpreter and java are stubbed with
+small shell scripts so the event flow, caching, verification, and failure
+paths run anywhere.
+"""
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from wirestudio.kicad.route import (
+    RouteError,
+    RouteUnavailable,
+    route_board,
+    route_cache_key,
+    route_events,
+    route_status,
+)
+
+UNROUTED = '(kicad_pcb (version 20240108) (net 0 "") (net 1 "VCC"))\n'
+ROUTED = UNROUTED.replace("))\n", ') (segment (net 1)))\n')
+
+
+def _script(path: Path, body: str) -> str:
+    path.write_text("#!/bin/sh\n" + body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+    return str(path)
+
+
+@pytest.fixture
+def toolchain(tmp_path, monkeypatch):
+    """Fake bridge interpreter + java that mimic a successful roundtrip."""
+    bridge = _script(
+        tmp_path / "fake-python",
+        'case "$2" in\n'
+        "probe) echo 8.0.9 ;;\n"
+        'dsn) echo dsn > "$4" ;;\n'
+        'ses) printf \'%s\' \'' + ROUTED.replace("\n", "") + '\' > "$3" ;;\n'
+        "esac\n",
+    )
+    java = _script(
+        tmp_path / "fake-java",
+        'echo "pass 1: 12 of 12 routed"\necho session > "$6"\n',
+    )
+    jar = tmp_path / "freerouting.jar"
+    jar.write_bytes(b"jar")
+    monkeypatch.setenv("WIRESTUDIO_PCBNEW_PYTHON", bridge)
+    monkeypatch.setenv("WIRESTUDIO_JAVA", java)
+    monkeypatch.setenv("WIRESTUDIO_FREEROUTING_JAR", str(jar))
+    return tmp_path
+
+
+def test_status_shape_and_unavailable_reasons(monkeypatch):
+    monkeypatch.setenv("WIRESTUDIO_PCBNEW_PYTHON", "/bin/false")
+    monkeypatch.delenv("WIRESTUDIO_FREEROUTING_JAR", raising=False)
+    status = route_status()
+    assert set(status) == {"available", "pcbnew", "java", "freerouting_jar", "reason"}
+    assert status["available"] is False
+    assert "pcbnew" in status["reason"]
+    assert "Freerouting jar" in status["reason"]
+
+
+def test_status_available_with_toolchain(toolchain):
+    status = route_status()
+    assert status["available"] is True
+    assert status["pcbnew"] == "8.0.9"
+    assert status["reason"] is None
+
+
+def test_cache_key_folds_in_board_and_passes():
+    a = route_cache_key(UNROUTED)
+    assert a == route_cache_key(UNROUTED)
+    assert a != route_cache_key(ROUTED)
+    assert a != route_cache_key(UNROUTED, max_passes=5)
+
+
+def test_route_events_roundtrip(toolchain, tmp_path):
+    events = list(route_events(UNROUTED, cache_dir=tmp_path / "cache"))
+    done = events[-1]
+    assert done["type"] == "done"
+    assert done["ok"] is True and done["routed"] is True
+    assert "(segment" in done["board"]
+    assert any(e["type"] == "log" and "12 of 12" in e["data"] for e in events)
+
+
+def test_route_events_cache_hit_replays_log(toolchain, tmp_path):
+    cache = tmp_path / "cache"
+    first = list(route_events(UNROUTED, cache_dir=cache))[-1]
+    # Break the toolchain: a cache hit must not touch it.
+    os.environ["WIRESTUDIO_PCBNEW_PYTHON"] = "/bin/false"
+    events = list(route_events(UNROUTED, cache_dir=cache))
+    done = events[-1]
+    assert done["cache_hit"] is True
+    assert done["board"] == first["board"]
+    assert any(e["type"] == "log" and "12 of 12" in e["data"] for e in events)
+
+
+def test_cache_miss_without_toolchain_raises(monkeypatch, tmp_path):
+    monkeypatch.setenv("WIRESTUDIO_PCBNEW_PYTHON", "/bin/false")
+    monkeypatch.delenv("WIRESTUDIO_FREEROUTING_JAR", raising=False)
+    with pytest.raises(RouteUnavailable):
+        list(route_events(UNROUTED, cache_dir=tmp_path / "cache"))
+
+
+def test_no_session_file_is_a_failed_done(toolchain, tmp_path):
+    _script(tmp_path / "fake-java", 'echo "could not route"\n')
+    events = list(route_events(UNROUTED, cache_dir=tmp_path / "cache"))
+    done = events[-1]
+    assert done["ok"] is False and done["board"] is None
+    assert any("no session file" in e["data"] for e in events if e["type"] == "log")
+
+
+def test_unrouted_result_is_a_failed_done(toolchain, tmp_path):
+    # Bridge whose SES import leaves the board without copper.
+    _script(
+        tmp_path / "fake-python",
+        'case "$2" in\n'
+        "probe) echo 8.0.9 ;;\n"
+        'dsn) echo dsn > "$4" ;;\n'
+        'ses) : ;;\n'
+        "esac\n",
+    )
+    done = list(route_events(UNROUTED, cache_dir=tmp_path / "cache"))[-1]
+    assert done["ok"] is False and done["board"] is None
+
+
+def test_watchdog_kills_a_hung_router(toolchain, tmp_path):
+    _script(tmp_path / "fake-java", "exec sleep 30\n")
+    events = list(route_events(UNROUTED, cache_dir=tmp_path / "cache", timeout=1))
+    done = events[-1]
+    assert done["ok"] is False
+    assert any("TIMED OUT" in e["data"] for e in events if e["type"] == "log")
+
+
+def test_route_board_returns_text_or_raises(toolchain, tmp_path):
+    assert "(segment" in route_board(UNROUTED, cache_dir=tmp_path / "c1")
+    _script(tmp_path / "fake-java", 'echo "could not route"\n')
+    with pytest.raises(RouteError, match="could not route"):
+        route_board(ROUTED, cache_dir=tmp_path / "c2")

--- a/wirestudio/kicad/pcbnew_bridge.py
+++ b/wirestudio/kicad/pcbnew_bridge.py
@@ -1,0 +1,49 @@
+"""Specctra DSN/SES bridge, run under the *system* python that has pcbnew.
+
+kicad-cli has no Specctra support; the headless path is the pcbnew SWIG
+module, which lives in KiCad's own python environment, not the app's. This
+script is therefore dependency-free (stdlib + pcbnew only) so route.py can
+invoke it as ``<pcbnew-python> pcbnew_bridge.py <cmd> ...`` regardless of
+which interpreter carries the bindings.
+
+Commands:
+    probe                       print the pcbnew build version
+    dsn <board> <out.dsn>       export a Specctra DSN
+    ses <board> <in.ses>        import a routed session into <board> in place
+
+Requires KiCad >= 8: the standalone ImportSpecctraSES(BOARD, path) overload
+does not exist in KiCad 7.
+"""
+import sys
+
+
+def main() -> int:
+    import pcbnew
+
+    cmd = sys.argv[1]
+    if cmd == "probe":
+        if not hasattr(pcbnew, "ImportSpecctraSES"):
+            print("pcbnew lacks ImportSpecctraSES (KiCad >= 8 required)", file=sys.stderr)
+            return 1
+        print(pcbnew.GetBuildVersion())
+        return 0
+    if cmd == "dsn":
+        board = pcbnew.LoadBoard(sys.argv[2])
+        if not pcbnew.ExportSpecctraDSN(board, sys.argv[3]):
+            print("ExportSpecctraDSN failed", file=sys.stderr)
+            return 1
+        return 0
+    if cmd == "ses":
+        board_path, ses_path = sys.argv[2], sys.argv[3]
+        board = pcbnew.LoadBoard(board_path)
+        if not pcbnew.ImportSpecctraSES(board, ses_path):
+            print("ImportSpecctraSES failed", file=sys.stderr)
+            return 1
+        pcbnew.SaveBoard(board_path, board)
+        return 0
+    print(f"unknown command: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wirestudio/kicad/route.py
+++ b/wirestudio/kicad/route.py
@@ -1,0 +1,292 @@
+"""Autoroute a generated ``.kicad_pcb`` with Freerouting.
+
+Pipeline: board text -> Specctra DSN (pcbnew, via pcbnew_bridge.py under the
+system python) -> ``java -jar freerouting.jar`` batch mode -> SES import back
+into the board (bridge again). Everything is subprocess-based: pcbnew's SWIG
+bindings live in KiCad's python, and Freerouting is GPL-3 Java invoked at
+arm's length.
+
+Gated like the other server-side-tool features: ``route_status()`` reports
+``available`` and the POST raises ``RouteUnavailable`` -> 503. Results are
+content-addressed on the unrouted board text + routing params, mirroring the
+firmware cache, so re-routing an unchanged board replays the stored log and
+returns instantly.
+
+Freerouting runs with ``-mt 1``: multithreaded routing is a known source of
+KiCad-DRC clearance violations (freerouting#191).
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+from typing import Iterator, Optional
+
+from wirestudio.kicad.fab import is_routed
+
+_CACHE_VERSION = "1"
+_TIMEOUT = int(os.environ.get("WIRESTUDIO_ROUTE_TIMEOUT", "600"))
+_BRIDGE_TIMEOUT = 120  # seconds per pcbnew bridge call
+_DEFAULT_PASSES = 20
+_BRIDGE = Path(__file__).with_name("pcbnew_bridge.py")
+
+
+class RouteUnavailable(RuntimeError):
+    """The pcbnew bridge, Java, or the Freerouting jar isn't available."""
+
+
+class RouteError(RuntimeError):
+    """A routing step ran and failed; ``str()`` carries the tool output."""
+
+
+def _default_cache_dir() -> Path:
+    return Path(
+        os.environ.get("WIRESTUDIO_ROUTE_CACHE")
+        or Path(tempfile.gettempdir()) / "wirestudio-route-cache"
+    )
+
+
+def _pcbnew_python() -> Optional[str]:
+    """Interpreter that can import pcbnew. The app's venv usually can't, so
+    default to the system python3 and let WIRESTUDIO_PCBNEW_PYTHON override."""
+    return (
+        os.environ.get("WIRESTUDIO_PCBNEW_PYTHON")
+        or shutil.which("python3")
+        or shutil.which("python")
+    )
+
+
+def _java() -> Optional[str]:
+    return os.environ.get("WIRESTUDIO_JAVA") or shutil.which("java")
+
+
+def _freerouting_jar() -> Optional[Path]:
+    jar = os.environ.get("WIRESTUDIO_FREEROUTING_JAR")
+    if jar and Path(jar).is_file():
+        return Path(jar)
+    return None
+
+
+def _probe_bridge(python: str) -> tuple[bool, str]:
+    try:
+        proc = subprocess.run(
+            [python, str(_BRIDGE), "probe"],
+            capture_output=True, text=True, timeout=_BRIDGE_TIMEOUT,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, str(exc)
+    out = (proc.stdout or proc.stderr).strip()
+    return proc.returncode == 0, out
+
+
+def route_status() -> dict:
+    """What the autoroute step needs and whether it's all here. `available`
+    is the headline the UI keys off."""
+    python = _pcbnew_python()
+    java = _java()
+    jar = _freerouting_jar()
+    missing = []
+    pcbnew_version = None
+    if python is None:
+        missing.append("no python interpreter found for the pcbnew bridge")
+    else:
+        ok, out = _probe_bridge(python)
+        if ok:
+            pcbnew_version = out
+        else:
+            missing.append(
+                f"pcbnew not importable by {python} (install KiCad >= 8 or set "
+                f"WIRESTUDIO_PCBNEW_PYTHON): {out.splitlines()[-1] if out else 'no output'}"
+            )
+    if java is None:
+        missing.append("java not on PATH (Freerouting needs a JRE; set WIRESTUDIO_JAVA)")
+    if jar is None:
+        missing.append("Freerouting jar not found (set WIRESTUDIO_FREEROUTING_JAR)")
+    return {
+        "available": not missing,
+        "pcbnew": pcbnew_version,
+        "java": java,
+        "freerouting_jar": str(jar) if jar else None,
+        "reason": "; ".join(missing) or None,
+    }
+
+
+def route_cache_key(board_text: str, *, max_passes: int = _DEFAULT_PASSES) -> str:
+    h = hashlib.sha256()
+    h.update(_CACHE_VERSION.encode())
+    h.update(str(max_passes).encode())
+    h.update(b"\0")
+    h.update(board_text.encode())
+    return h.hexdigest()[:16]
+
+
+def _bridge(python: str, *args: str) -> None:
+    proc = subprocess.run(
+        [python, str(_BRIDGE), *args],
+        capture_output=True, text=True, timeout=_BRIDGE_TIMEOUT,
+    )
+    if proc.returncode != 0:
+        raise RouteError((proc.stderr or proc.stdout).strip() or f"bridge {args[0]} failed")
+
+
+def route_events(
+    board_text: str,
+    *,
+    max_passes: int = _DEFAULT_PASSES,
+    timeout: int = _TIMEOUT,
+    cache_dir: Optional[Path] = None,
+    use_cache: bool = True,
+) -> Iterator[dict]:
+    """Route the board, yielding events as Freerouting works.
+
+    Yields ``{"type": "log", "data": <line>}`` per output line and a final
+    ``{"type": "done", "ok", "routed", "cache_key", "cache_hit", "board"}``
+    where ``board`` is the routed board text (None on failure). A warm cache
+    replays the stored log, touching no toolchain. Raises RouteUnavailable on
+    a cache miss with the toolchain missing; a routing run that completes
+    without producing copper is a normal ``done`` event (ok=False).
+    """
+    key = route_cache_key(board_text, max_passes=max_passes)
+    slot = Path(cache_dir or _default_cache_dir()) / key
+    cached_board = slot / "routed.kicad_pcb"
+    cached_log = slot / "route.log"
+
+    if use_cache and cached_board.exists():
+        if cached_log.exists():
+            yield {"type": "log", "data": cached_log.read_text()}
+        routed = cached_board.read_text()
+        yield {"type": "done", "ok": True, "routed": is_routed(routed),
+               "cache_key": key, "cache_hit": True, "board": routed}
+        return
+
+    status = route_status()
+    if not status["available"]:
+        raise RouteUnavailable(status["reason"])
+    python = _pcbnew_python()
+    parts: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="wirestudio-route-") as tmp:
+        work = Path(tmp)
+        board_path = work / "board.kicad_pcb"
+        dsn_path = work / "board.dsn"
+        ses_path = work / "board.ses"
+        board_path.write_text(board_text)
+
+        try:
+            _bridge(python, "dsn", str(board_path), str(dsn_path))
+        except RouteError as exc:
+            yield {"type": "log", "data": f"DSN export failed: {exc}\n"}
+            yield {"type": "done", "ok": False, "routed": False,
+                   "cache_key": key, "cache_hit": False, "board": None}
+            return
+
+        proc = subprocess.Popen(
+            [_java(), "-jar", str(_freerouting_jar()),
+             "-de", str(dsn_path), "-do", str(ses_path),
+             "-mp", str(max_passes), "-mt", "1", "--gui.enabled=false"],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1, cwd=tmp,
+        )
+        # Watchdog: a stagnated router (no output, never exits) still gets killed.
+        killed = threading.Event()
+
+        def _kill_on_timeout() -> None:
+            killed.set()
+            proc.kill()
+
+        timer = threading.Timer(timeout, _kill_on_timeout)
+        timer.start()
+        try:
+            for line in proc.stdout:  # type: ignore[union-attr]
+                parts.append(line)
+                yield {"type": "log", "data": line}
+        finally:
+            timer.cancel()
+            proc.wait()
+        if killed.is_set():
+            parts.append(f"\nTIMED OUT after {timeout}s\n")
+            yield {"type": "log", "data": parts[-1]}
+
+        routed_text = None
+        if ses_path.exists():
+            try:
+                _bridge(python, "ses", str(board_path), str(ses_path))
+                routed_text = board_path.read_text()
+            except RouteError as exc:
+                parts.append(f"SES import failed: {exc}\n")
+                yield {"type": "log", "data": parts[-1]}
+        elif not killed.is_set():
+            parts.append("Freerouting produced no session file\n")
+            yield {"type": "log", "data": parts[-1]}
+
+        ok = routed_text is not None and is_routed(routed_text)
+        slot.mkdir(parents=True, exist_ok=True)
+        cached_log.write_text("".join(parts))
+        if ok:
+            cached_board.write_text(routed_text)
+        yield {"type": "done", "ok": ok, "routed": ok,
+               "cache_key": key, "cache_hit": False,
+               "board": routed_text if ok else None}
+
+
+def route_board(
+    board_text: str,
+    *,
+    max_passes: int = _DEFAULT_PASSES,
+    timeout: int = _TIMEOUT,
+    cache_dir: Optional[Path] = None,
+    use_cache: bool = True,
+) -> str:
+    """Route and return the routed board text. Raises RouteError (with the
+    Freerouting log) if routing completed without producing copper."""
+    log: list[str] = []
+    for event in route_events(
+        board_text, max_passes=max_passes, timeout=timeout,
+        cache_dir=cache_dir, use_cache=use_cache,
+    ):
+        if event["type"] == "log":
+            log.append(event["data"])
+        elif event["type"] == "done":
+            if event["ok"]:
+                return event["board"]
+            raise RouteError("routing failed:\n" + "".join(log))
+    raise RouteError("routing produced no result")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    import argparse
+    import json
+    import sys
+
+    parser = argparse.ArgumentParser(description="Autoroute a .kicad_pcb with Freerouting")
+    parser.add_argument("board", nargs="?", help="path to a .kicad_pcb")
+    parser.add_argument("--status", action="store_true", help="print availability and exit")
+    parser.add_argument("--passes", type=int, default=_DEFAULT_PASSES)
+    parser.add_argument("--out", help="write the routed board here (default: stdout)")
+    args = parser.parse_args(argv)
+
+    if args.status:
+        print(json.dumps(route_status(), indent=2))
+        return 0
+    if not args.board:
+        parser.error("board path required unless --status")
+    try:
+        routed = route_board(Path(args.board).read_text(), max_passes=args.passes)
+    except (RouteUnavailable, RouteError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    if args.out:
+        Path(args.out).write_text(routed)
+    else:
+        print(routed)
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())


### PR DESCRIPTION
Lands the autoroute step the fab outputs have been flagging via `is_routed`: `wirestudio/kicad/route.py` runs board → Specctra DSN → Freerouting → SES import, all subprocess-based.

Key mechanics, from the integration research:
- `kicad-cli` has no Specctra support in KiCad 8 or 9; the headless path is `pcbnew.ExportSpecctraDSN` / `ImportSpecctraSES` (standalone overloads; the import one is new in KiCad 8). Those live in KiCad's system python, so a dependency-free `pcbnew_bridge.py` runs under `WIRESTUDIO_PCBNEW_PYTHON`.
- Freerouting 2.2.4 pinned (sha256-checked in CI), batch mode with `-mp 20 -mt 1` — multithreaded routing is a known source of KiCad-DRC clearance violations (freerouting#191) — plus the watchdog-kill pattern from the LoRaWAN compile worker for stagnated runs.
- Results content-addressed on board text + params, mirroring the firmware cache.
- KiCad 10 removes the SWIG bindings, so the pipeline pins to KiCad 8/9 images.

New `pcb-route` workflow (path-filtered + weekly, like pcb-drc) routes four representative examples — garage-motion, solder-fan, weather-station, securitypanel — and holds them to the routed bar: copper present, **zero unconnected items** (the waiver pcb-drc grants unrouted boards is revoked here), no error-severity violations beyond the footprint-inherent set.

Verified end-to-end locally in the kicad/kicad:8.0 + freerouting containers: all four boards route clean in seconds each. 10 new unit tests cover the event flow, caching, verification, and failure paths with a stubbed toolchain; full suite 864 passed.

Follow-ups (next PR): HTTP/MCP/web-UI surfaces, `route=true` on the fab package, and a toolchain image variant so the default deploy can route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)