### PR TITLE
feat(kicad): surface autorouting via HTTP, MCP/agent, web UI + -pcb image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -130,6 +130,47 @@ jobs:
           cache-from: type=gha,scope=lorawan
           cache-to: type=gha,mode=max,scope=lorawan
 
+  # The PCB-toolchain variant: Dockerfile.pcb on the official KiCad 8 image,
+  # with pcbnew, kicad-cli, the pinned gitlab libraries, a Temurin JRE, and
+  # the Freerouting jar -- the image that can autoroute and emit routed fab
+  # packages. amd64-only and push-only like the lorawan variant. Published as
+  # the `-pcb` tag suffix (e.g. :main-pcb).
+  pcb-image:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/wirestudio
+          flavor: suffix=-pcb,latest=false
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.pcb
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=pcb
+          cache-to: type=gha,mode=max,scope=pcb
+
   # Deployment is NOT handled here. The k8s cluster is driven by the
   # moellere/argocd GitOps repo, where argocd-image-updater watches this
   # registry and rolls each environment automatically:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Autoroute surfaces: HTTP, MCP/agent, web UI, and a `-pcb` image.**
+  `POST /design/kicad/route` streams the Freerouting log as SSE and the
+  routed board downloads from `GET /design/kicad/route/{cache_key}`;
+  `GET /design/kicad/route/status` gates the feature. The fab Gerber/package
+  endpoints accept `?route=true` (503 toolchain missing, 409 routing failed),
+  and `fab_status` reports `route`/`route_reason`. New `route_pcb` MCP/agent
+  tool returns a routed summary (segments, vias, cache_key). The KiCad export
+  dialog gains an **Autoroute** section (route button, live log, routed-board
+  download) and a **Routed** checkbox on the fab package. A new
+  `Dockerfile.pcb` variant (published as the `-pcb` tag suffix) bakes in
+  KiCad 8 + pcbnew, the pinned libraries, a Temurin JRE, and the pinned
+  Freerouting jar so a deployment can route out of the box; route results
+  cache under `/data/route-cache`.
+
 - **PCB autorouting (Freerouting).** `wirestudio/kicad/route.py` routes a
   generated `.kicad_pcb`: Specctra DSN export via pcbnew (a dependency-free
   `pcbnew_bridge.py` run under the system python — kicad-cli has no Specctra

--- a/Dockerfile.pcb
+++ b/Dockerfile.pcb
@@ -1,0 +1,92 @@
+# syntax=docker/dockerfile:1.7
+#
+# PCB-toolchain variant: the default image plus everything the autoroute and
+# fab pipeline needs baked in. Published as the `-pcb` tag suffix.
+#
+# Based on the official KiCad 8 image because the route step needs pcbnew's
+# python bindings (kicad-cli has no Specctra support) and they only exist
+# inside a full KiCad install. KiCad 8/9 only: KiCad 10 removes the SWIG
+# bindings the DSN/SES bridge depends on. On top of that:
+#   - the pinned KiCad symbol/footprint libraries from gitlab (the image's
+#     bundled libs differ from the pin -- e.g. no Module:WEMOS_D1_mini_light)
+#   - a Temurin 25 JRE + the pinned Freerouting jar (GPL-3, fetched from the
+#     upstream release and invoked as a subprocess at arm's length)
+#
+# Run it exactly like the default image; /data persists designs, sessions,
+# and the route cache.
+
+# ---------------------------------------------------------------------------
+# Stage 1: build the SPA bundle (same as the default Dockerfile).
+# ---------------------------------------------------------------------------
+FROM node:20-alpine AS web-builder
+WORKDIR /web
+
+COPY web/package.json web/package-lock.json* ./
+RUN npm ci --no-audit --no-fund
+
+COPY web/ ./
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime on the official KiCad 8 image.
+# ---------------------------------------------------------------------------
+FROM kicad/kicad:8.0 AS runtime
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git python3-pip python3-venv tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pinned KiCad libraries -- the same refs the CI gates emit against.
+ARG KICAD_LIBS_REF=8.0.0
+RUN git clone --depth 1 --branch "$KICAD_LIBS_REF" \
+        https://gitlab.com/kicad/libraries/kicad-footprints.git /opt/kicad-libs/footprints \
+    && git clone --depth 1 --branch "$KICAD_LIBS_REF" \
+        https://gitlab.com/kicad/libraries/kicad-symbols.git /opt/kicad-libs/symbols \
+    && rm -rf /opt/kicad-libs/footprints/.git /opt/kicad-libs/symbols/.git
+
+COPY --from=eclipse-temurin:25-jre /opt/java/openjdk /opt/java/openjdk
+
+ARG FREEROUTING_VERSION=2.2.4
+ARG FREEROUTING_SHA256=f5ed374182900ccc78e473518bbb9f6b869f4a07159495f663a76f52bb10523b
+RUN curl -sSL -o /opt/freerouting.jar \
+        "https://github.com/freerouting/freerouting/releases/download/v${FREEROUTING_VERSION}/freerouting-${FREEROUTING_VERSION}.jar" \
+    && echo "${FREEROUTING_SHA256}  /opt/freerouting.jar" | sha256sum --check
+
+WORKDIR /app
+
+# The app lives in a venv; the pcbnew bridge runs under the system python
+# (WIRESTUDIO_PCBNEW_PYTHON), which is where KiCad's bindings are.
+COPY pyproject.toml ./
+COPY wirestudio/ ./wirestudio/
+COPY README.md ./
+
+RUN python3 -m venv /opt/venv && /opt/venv/bin/pip install --no-cache-dir .
+
+COPY --from=web-builder /web/dist /app/web-dist
+
+RUN mkdir -p /data/sessions /data/designs && \
+    useradd -m -s /bin/bash appuser && \
+    chown -R appuser:appuser /app /data
+
+ENV PYTHONUNBUFFERED=1 \
+    PATH=/opt/venv/bin:$PATH \
+    WIRESTUDIO_STATIC_DIR=/app/web-dist \
+    SESSIONS_DIR=/data/sessions \
+    DESIGNS_DIR=/data/designs \
+    INVENTORY_PATH=/data/inventory.json \
+    WIRESTUDIO_FW_CACHE=/data/firmware-cache \
+    WIRESTUDIO_ROUTE_CACHE=/data/route-cache \
+    WIRESTUDIO_PCBNEW_PYTHON=/usr/bin/python3 \
+    WIRESTUDIO_JAVA=/opt/java/openjdk/bin/java \
+    WIRESTUDIO_FREEROUTING_JAR=/opt/freerouting.jar \
+    KICAD8_FOOTPRINT_DIR=/opt/kicad-libs/footprints \
+    KICAD8_SYMBOL_DIR=/opt/kicad-libs/symbols
+
+EXPOSE 8765
+VOLUME ["/data"]
+
+USER appuser
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["python", "-m", "wirestudio.api", "--host", "0.0.0.0", "--port", "8765", "--static-dir", "/app/web-dist"]

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Tiers, in priority order:
 | **Works (lighter checks)** | MCP server | drive the design tools from Claude Code / Desktop over the Model Context Protocol | tool / auth / resource tests in `tests/test_mcp_*.py`; not exercised against a live MCP client in CI |
 | **Experimental** | Thingiverse search relay | rank community models for a board | smoke-tested; depends on a third-party search API that ranks unevenly |
 | **Experimental** | Agent (Claude tool-using) | natural-language design driving | works in practice; tool surface is small; no auto-eval against task list yet |
-| **Verified** | PCB autorouting | Freerouting roundtrip — board → Specctra DSN → routed → SES import (`python -m wirestudio.kicad.route`) | representative examples route with zero unconnected items and pass routed DRC ([gate](.github/workflows/pcb-route.yml)); HTTP/MCP/UI surfaces and a toolchain image are follow-ups |
+| **Verified** | PCB autorouting | Freerouting roundtrip — board → Specctra DSN → routed → SES import; SSE route endpoint, `route_pcb` MCP/agent tool, web-UI Route button, `?route=true` fab exports, `-pcb` image variant | representative examples route with zero unconnected items and pass routed DRC ([gate](.github/workflows/pcb-route.yml)) |
 
 The **Verified** tier is the bar the project is asking to be judged
 on. Everything else is offered with the caveat that's spelled out in

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -27,6 +27,7 @@ Available tags:
 | `:main` | latest commit on `main` (rolling) |
 | `:sha-<short>` | a specific commit |
 | `:<tag>-lorawan` (e.g. `:main-lorawan`, `:0.18.0-lorawan`) | same image **plus** the LoRaWAN compile worker (PlatformIO baked in) — see below |
+| `:<tag>-pcb` (e.g. `:main-pcb`, `:0.19.0-pcb`) | the PCB toolchain variant: KiCad 8 (kicad-cli + pcbnew), the pinned symbol/footprint libraries, a JRE, and Freerouting — everything the board/fab/autoroute endpoints gate on — see below |
 
 All feature-gating env vars are optional — the studio runs without any
 of them, just with the corresponding feature turned off. See
@@ -39,6 +40,17 @@ of them, just with the corresponding feature turned off. See
 | `THINGIVERSE_API_KEY` | enclosure search (`/enclosure/search`) |
 | `WIRESTUDIO_MCP_TOKEN` | bearer token for the `/mcp` endpoint (auto-generated if unset) |
 | `CHIRPSTACK_API_URL` + `CHIRPSTACK_API_TOKEN` | LoRaWAN device provisioning against ChirpStack (`/lorawan/provision`, `/lorawan/provision-esphome`) |
+
+### PCB toolchain (`-pcb` variant)
+
+The default image can't emit boards, Gerbers, or routed boards — those
+endpoints gate on KiCad tooling and report `available: false`. The
+**`-pcb` variant** (`Dockerfile.pcb`, based on the official
+`kicad/kicad:8.0` image) bakes in kicad-cli, pcbnew, the pinned KiCad
+libraries, a Temurin JRE, and the pinned Freerouting jar, with all the
+`WIRESTUDIO_*` toolchain env vars preset. Autoroute results cache under
+`/data/route-cache`, so they survive restarts with the volume. amd64
+only, like `-lorawan`.
 
 ### LoRaWAN compile worker
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,9 +128,12 @@ autoroute step now closes the routing gap:
 bridge) → `freerouting.jar` → SES import, and the
 [`pcb-route`](../.github/workflows/pcb-route.yml) gate holds
 representative examples to the routed bar (copper present, zero
-unconnected items, routed DRC clean). Next: wire routing into the fab
-endpoints/MCP/web UI and ship a toolchain image so the default deploy
-can route.
+unconnected items, routed DRC clean). Routing is surfaced everywhere the
+board is: `POST /design/kicad/route` (SSE), the `route_pcb` MCP/agent
+tool, the web UI's Autoroute section, `?route=true` on the fab exports,
+and the `-pcb` image variant that carries the toolchain. Next: routed
+DRC feedback in the UI, via-cost/keepout tuning, and copper pours for
+power nets.
 
 **LoRaWAN target (0.13 standalone, 0.16+ external-component).** *Works —
 hardware-validated on the standalone path; external-component path

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -70,8 +70,18 @@ emits a SKiDL Python script the user runs locally to produce a
 `.kicad_sch` — no LLM in the wire-routing path, fully diffable in git.
 `python -m wirestudio.kicad.import --symbol Lib:Symbol` drafts the
 `kicad:` block for a library component from a KiCad `.kicad_sym`
-library. PCB layout (Freerouting + Gerber export) is on the 1.0+
-roadmap.
+library.
+
+PCB layout and routing are server-side: `POST /design/kicad/pcb` emits
+the placed board, `POST /design/kicad/route` autoroutes it with
+Freerouting (SSE log stream; fetch the routed board from
+`GET /design/kicad/route/{cache_key}`), and the fab endpoints accept
+`?route=true` to route before exporting Gerbers. The route step needs
+pcbnew, a JRE, and the Freerouting jar on the server — set
+`WIRESTUDIO_PCBNEW_PYTHON`, `WIRESTUDIO_JAVA`, and
+`WIRESTUDIO_FREEROUTING_JAR`, or run the `-pcb` image variant which
+bakes all three in. `GET /design/kicad/route/status` reports what's
+missing.
 
 The output is gate-verified: the [`kicad-schematic`](../.github/workflows/kicad-schematic.yml)
 workflow runs every bundled example's SKiDL script against the pinned

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -181,7 +181,7 @@ bind flag.
 
 ## Tools
 
-The same 12 tools the embedded `/agent/turn` flow uses, plus the two
+The same tools the embedded `/agent/turn` flow uses, plus the two
 active-design tools. Mutating tools load the design, apply the change,
 and persist back to `designs/<id>.json`.
 
@@ -189,6 +189,7 @@ and persist back to `designs/<id>.json`.
 |------|---------|-------|
 | `search_components` | no | fuzzy library lookup by name/category/use_case/alias |
 | `list_boards` | no | every board with mcu / framework / platformio_board |
+| `library_detail` | no | full component/board card on demand |
 | `recommend` | no | ranked capability search with rationale + constraints |
 | `render` | no | YAML + ASCII for a stored design |
 | `validate` | no | schema + library check |
@@ -197,8 +198,15 @@ and persist back to `designs/<id>.json`.
 | `remove_component` | yes | drop component + its originating connections |
 | `set_param` | yes | per-instance param set (`value: null` deletes) |
 | `set_connection` | yes | retarget a single connection |
+| `set_strict` | yes | toggle `design.strict` (violations block generation) |
 | `add_bus` | yes | append an i2c / spi / uart / 1wire / i2s bus |
 | `solve_pins` | yes | auto-assign unbound connections |
+| `kicad_schematic` | no | SKiDL script summary |
+| `kicad_pcb` | no | board emit summary (size, footprints, nets, routed) |
+| `route_pcb` | no | Freerouting autoroute; returns segments/vias/cache_key, board via `GET /design/kicad/route/{cache_key}` |
+| `fab_status` | no | server fab capabilities (BOM/CPL/Gerbers/route) |
+| `fab_bom` | no | JLCPCB BOM CSV |
+| `fab_cpl` | no | JLCPCB CPL CSV |
 | `set_active_design` | — | set the active-design pointer (validates the id exists) |
 | `get_active_design` | — | read the active-design pointer |
 

--- a/tests/test_api_route.py
+++ b/tests/test_api_route.py
@@ -1,0 +1,101 @@
+"""API tests for the autoroute surfaces (/design/kicad/route*).
+
+The toolchain is stubbed the same way test_kicad_route.py does it, so the
+SSE flow, the cache-key artifact fetch, and the fab route= gating run
+without KiCad or Java.
+"""
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from wirestudio.api.app import create_app
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE = REPO_ROOT / "wirestudio" / "examples" / "garage-motion.json"
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+def _script(path: Path, body: str) -> str:
+    path.write_text("#!/bin/sh\n" + body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+    return str(path)
+
+
+@pytest.fixture
+def toolchain(tmp_path, monkeypatch):
+    bridge = _script(
+        tmp_path / "fake-python",
+        'case "$2" in\n'
+        "probe) echo 8.0.9 ;;\n"
+        'dsn) echo dsn > "$4" ;;\n'
+        'ses) printf \'(kicad_pcb (segment (net 1)))\' > "$3" ;;\n'
+        "esac\n",
+    )
+    java = _script(tmp_path / "fake-java", 'echo "pass 1 done"\necho session > "$6"\n')
+    jar = tmp_path / "freerouting.jar"
+    jar.write_bytes(b"jar")
+    monkeypatch.setenv("WIRESTUDIO_PCBNEW_PYTHON", bridge)
+    monkeypatch.setenv("WIRESTUDIO_JAVA", java)
+    monkeypatch.setenv("WIRESTUDIO_FREEROUTING_JAR", str(jar))
+    monkeypatch.setenv("WIRESTUDIO_ROUTE_CACHE", str(tmp_path / "cache"))
+    return tmp_path
+
+
+def _design() -> dict:
+    return json.loads(EXAMPLE.read_text())
+
+
+def test_route_status_shape(client):
+    body = client.get("/design/kicad/route/status").json()
+    assert set(body) == {"available", "pcbnew", "java", "freerouting_jar", "reason"}
+
+
+def test_routed_board_bad_key_and_missing(client, toolchain):
+    assert client.get("/design/kicad/route/not-a-key").status_code == 422
+    assert client.get("/design/kicad/route/0123456789abcdef").status_code == 404
+
+
+kicad_libs = pytest.mark.skipif(
+    __import__("wirestudio.kicad.pcb", fromlist=["pcb_status"]).pcb_status()["available"]
+    is False,
+    reason="KiCad footprint/symbol libs not configured",
+)
+
+
+@kicad_libs
+def test_route_sse_then_artifact(client, toolchain):
+    with client.stream("POST", "/design/kicad/route", json=_design()) as resp:
+        assert resp.status_code == 200
+        frames = [
+            json.loads(line[len("data: "):])
+            for line in resp.iter_lines()
+            if line.startswith("data: ")
+        ]
+    done = frames[-1]
+    assert done["type"] == "done" and done["ok"] is True
+    assert "board" not in done
+    routed = client.get(f"/design/kicad/route/{done['cache_key']}")
+    assert routed.status_code == 200
+    assert "(segment" in routed.text
+
+
+@kicad_libs
+def test_fab_gerbers_route_unavailable_is_503(client, monkeypatch):
+    monkeypatch.setenv("WIRESTUDIO_PCBNEW_PYTHON", "/bin/false")
+    monkeypatch.delenv("WIRESTUDIO_FREEROUTING_JAR", raising=False)
+    resp = client.post("/design/fab/gerbers?route=true", json=_design())
+    assert resp.status_code == 503
+
+
+def test_fab_status_reports_route(client):
+    body = client.get("/design/fab/status").json()
+    assert "route" in body and "route_reason" in body

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -33,6 +33,7 @@ EXPECTED_TOOLS = {
     "solve_pins",
     "kicad_schematic",
     "kicad_pcb",
+    "route_pcb",
     "fab_status",
     "fab_bom",
     "fab_cpl",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -18,6 +18,8 @@ import type {
   FabStatus,
   KicadPcbStatus,
   KicadRenderStatus,
+  KicadRouteEvent,
+  KicadRouteStatus,
   LorawanCompileEvent,
   LorawanCompileStatus,
   LorawanProvisionResponse,
@@ -170,14 +172,21 @@ export const api = {
     request<KicadPcbStatus>("/design/kicad/pcb/status"),
   kicadPcb: (design: Design) =>
     requestText("/design/kicad/pcb", { method: "POST", body: JSON.stringify(design) }),
+  kicadRouteStatus: () =>
+    request<KicadRouteStatus>("/design/kicad/route/status"),
+  kicadRoutedBoard: (cacheKey: string) =>
+    requestText(`/design/kicad/route/${cacheKey}`),
   fabStatus: () =>
     request<FabStatus>("/design/fab/status"),
   fabBom: (design: Design) =>
     requestText("/design/fab/bom", { method: "POST", body: JSON.stringify(design) }),
   fabCpl: (design: Design) =>
     requestText("/design/fab/cpl", { method: "POST", body: JSON.stringify(design) }),
-  fabPackage: (design: Design) =>
-    requestBlob("/design/fab/package", { method: "POST", body: JSON.stringify(design) }),
+  fabPackage: (design: Design, route = false) =>
+    requestBlob(`/design/fab/package${route ? "?route=true" : ""}`, {
+      method: "POST",
+      body: JSON.stringify(design),
+    }),
   enclosureSearchStatus: () =>
     request<EnclosureSearchStatus>("/enclosure/search/status"),
   enclosureSearch: (params: { library_id: string; query?: string; limit?: number }) => {
@@ -385,8 +394,13 @@ export async function* agentStream(body: {
  * ApiError on non-2xx (422 bad design / non-radio board) and Error on an
  * `event: error` frame (e.g. PlatformIO unavailable mid-build).
  */
-export async function* lorawanCompile(design: Design): AsyncGenerator<LorawanCompileEvent> {
-  const res = await fetch(`${API_BASE}/lorawan/compile`, {
+/**
+ * Stream a Freerouting autoroute over SSE. Yields `{type:"log"}` lines and a
+ * final `{type:"done"}` carrying the cache_key to fetch the routed board
+ * with. Throws ApiError on non-2xx and Error on an `event: error` frame.
+ */
+export async function* kicadRoute(design: Design): AsyncGenerator<KicadRouteEvent> {
+  const res = await fetch(`${API_BASE}/design/kicad/route`, {
     method: "POST",
     headers: { "content-type": "application/json", accept: "text/event-stream" },
     body: JSON.stringify(design),
@@ -394,12 +408,16 @@ export async function* lorawanCompile(design: Design): AsyncGenerator<LorawanCom
   if (!res.ok) {
     let errBody: unknown = undefined;
     try { errBody = await res.json(); } catch { /* not json */ }
-    throw new ApiError(res.status, `POST /lorawan/compile -> ${res.status}`, errBody);
+    throw new ApiError(res.status, `POST /design/kicad/route -> ${res.status}`, errBody);
   }
   if (!res.body) {
-    throw new Error("lorawan/compile: no response body");
+    throw new Error("design/kicad/route: no response body");
   }
-  const reader = res.body.getReader();
+  yield* parseSse<KicadRouteEvent>(res.body);
+}
+
+async function* parseSse<T>(body: ReadableStream<Uint8Array>): AsyncGenerator<T> {
+  const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
   while (true) {
@@ -422,7 +440,7 @@ export async function* lorawanCompile(design: Design): AsyncGenerator<LorawanCom
             throw new Error(message);
           }
           try {
-            yield JSON.parse(json) as LorawanCompileEvent;
+            yield JSON.parse(json) as T;
           } catch {
             // ignore malformed event line
           }
@@ -430,6 +448,23 @@ export async function* lorawanCompile(design: Design): AsyncGenerator<LorawanCom
       }
     }
   }
+}
+
+export async function* lorawanCompile(design: Design): AsyncGenerator<LorawanCompileEvent> {
+  const res = await fetch(`${API_BASE}/lorawan/compile`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "text/event-stream" },
+    body: JSON.stringify(design),
+  });
+  if (!res.ok) {
+    let errBody: unknown = undefined;
+    try { errBody = await res.json(); } catch { /* not json */ }
+    throw new ApiError(res.status, `POST /lorawan/compile -> ${res.status}`, errBody);
+  }
+  if (!res.body) {
+    throw new Error("lorawan/compile: no response body");
+  }
+  yield* parseSse<LorawanCompileEvent>(res.body);
 }
 
 export { ApiError };

--- a/web/src/components/SchematicDialog.test.tsx
+++ b/web/src/components/SchematicDialog.test.tsx
@@ -8,8 +8,15 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { SchematicDialog } from "./SchematicDialog";
-import { api } from "../api/client";
-import type { Design, FabStatus, KicadPcbStatus, KicadRenderStatus } from "../types/api";
+import { api, kicadRoute } from "../api/client";
+import type {
+  Design,
+  FabStatus,
+  KicadPcbStatus,
+  KicadRenderStatus,
+  KicadRouteEvent,
+  KicadRouteStatus,
+} from "../types/api";
 
 vi.mock("../api/client", async () => {
   const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
@@ -26,7 +33,10 @@ vi.mock("../api/client", async () => {
       fabBom: vi.fn(),
       fabCpl: vi.fn(),
       fabPackage: vi.fn(),
+      kicadRouteStatus: vi.fn(),
+      kicadRoutedBoard: vi.fn(),
     },
+    kicadRoute: vi.fn(),
   };
 });
 
@@ -40,7 +50,10 @@ const mockApi = api as unknown as {
   fabBom: ReturnType<typeof vi.fn>;
   fabCpl: ReturnType<typeof vi.fn>;
   fabPackage: ReturnType<typeof vi.fn>;
+  kicadRouteStatus: ReturnType<typeof vi.fn>;
+  kicadRoutedBoard: ReturnType<typeof vi.fn>;
 };
+const mockKicadRoute = kicadRoute as unknown as ReturnType<typeof vi.fn>;
 
 const UNAVAILABLE: KicadRenderStatus = {
   available: false, kicad_cli: false, skidl: false, png: false,
@@ -57,11 +70,22 @@ const PCB_AVAILABLE: KicadPcbStatus = {
   available: true, footprints: true, symbols: true, reason: null,
 };
 const FAB_BOM_ONLY: FabStatus = {
-  bom: true, cpl: false, gerbers: false, kicad_cli: false, footprints: false,
+  bom: true, cpl: false, gerbers: false, route: false, route_reason: null,
+  kicad_cli: false, footprints: false,
   reason: "kicad-cli not on PATH (needed for Gerbers)",
 };
 const FAB_FULL: FabStatus = {
-  bom: true, cpl: true, gerbers: true, kicad_cli: true, footprints: true, reason: null,
+  bom: true, cpl: true, gerbers: true, route: false, route_reason: null,
+  kicad_cli: true, footprints: true, reason: null,
+};
+const FAB_ROUTED: FabStatus = { ...FAB_FULL, route: true };
+const ROUTE_UNAVAILABLE: KicadRouteStatus = {
+  available: false, pcbnew: null, java: null, freerouting_jar: null,
+  reason: "Freerouting jar not found",
+};
+const ROUTE_AVAILABLE: KicadRouteStatus = {
+  available: true, pcbnew: "8.0.9", java: "/usr/bin/java",
+  freerouting_jar: "/opt/freerouting.jar", reason: null,
 };
 
 const design: Design = {
@@ -86,9 +110,13 @@ beforeEach(() => {
   mockApi.fabBom.mockReset();
   mockApi.fabCpl.mockReset();
   mockApi.fabPackage.mockReset();
+  mockApi.kicadRouteStatus.mockReset();
+  mockApi.kicadRoutedBoard.mockReset();
+  mockKicadRoute.mockReset();
   mockApi.kicadRenderStatus.mockResolvedValue(UNAVAILABLE);
   mockApi.kicadPcbStatus.mockResolvedValue(PCB_UNAVAILABLE);
   mockApi.fabStatus.mockResolvedValue(FAB_BOM_ONLY);
+  mockApi.kicadRouteStatus.mockResolvedValue(ROUTE_UNAVAILABLE);
   (URL as unknown as { createObjectURL: () => string }).createObjectURL = vi.fn(() => "blob:fake");
   (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = vi.fn();
 });
@@ -215,6 +243,55 @@ describe("SchematicDialog — fab outputs", () => {
     const pkg = await screen.findByRole("button", { name: /Fab package/ });
     await waitFor(() => expect(pkg).toBeEnabled());
     await userEvent.click(pkg);
-    await waitFor(() => expect(mockApi.fabPackage).toHaveBeenCalledWith(design));
+    await waitFor(() => expect(mockApi.fabPackage).toHaveBeenCalledWith(design, false));
+  });
+
+  it("gates the Routed checkbox on the route toolchain and passes route=true", async () => {
+    mockApi.fabStatus.mockResolvedValue(FAB_ROUTED);
+    mockApi.fabPackage.mockResolvedValue(new Blob(["zip"]));
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    const routed = await screen.findByRole("checkbox", { name: /Routed/ });
+    await waitFor(() => expect(routed).toBeEnabled());
+    await userEvent.click(routed);
+    await userEvent.click(screen.getByRole("button", { name: /Fab package/ }));
+    await waitFor(() => expect(mockApi.fabPackage).toHaveBeenCalledWith(design, true));
+  });
+});
+
+describe("SchematicDialog — autoroute", () => {
+  it("shows the toolchain notice when routing is unavailable", async () => {
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    expect(await screen.findByText(/route toolchain/)).toBeInTheDocument();
+    expect(screen.getByText(/Freerouting jar not found/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Route board/ })).toBeNull();
+  });
+
+  it("routes, streams the log, and offers the routed board download", async () => {
+    mockApi.kicadRouteStatus.mockResolvedValue(ROUTE_AVAILABLE);
+    mockApi.kicadRoutedBoard.mockResolvedValue("(kicad_pcb (segment))");
+    mockKicadRoute.mockImplementation(async function* (): AsyncGenerator<KicadRouteEvent> {
+      yield { type: "log", data: "pass 1: 12 of 12 routed\n" };
+      yield { type: "done", ok: true, routed: true, cache_key: "0123456789abcdef", cache_hit: false };
+    });
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    await userEvent.click(await screen.findByRole("button", { name: /Route board/ }));
+    expect(await screen.findByText(/12 of 12 routed/)).toBeInTheDocument();
+    const download = await screen.findByRole("button", { name: /Download routed/ });
+    await userEvent.click(download);
+    await waitFor(() =>
+      expect(mockApi.kicadRoutedBoard).toHaveBeenCalledWith("0123456789abcdef"),
+    );
+  });
+
+  it("surfaces a failed route as an error banner", async () => {
+    mockApi.kicadRouteStatus.mockResolvedValue(ROUTE_AVAILABLE);
+    mockKicadRoute.mockImplementation(async function* (): AsyncGenerator<KicadRouteEvent> {
+      yield { type: "log", data: "could not route\n" };
+      yield { type: "done", ok: false, routed: false, cache_key: "0123456789abcdef", cache_hit: false };
+    });
+    render(<SchematicDialog design={design} onClose={() => {}} />);
+    await userEvent.click(await screen.findByRole("button", { name: /Route board/ }));
+    expect(await screen.findByText(/without a routed board/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Download routed/ })).toBeNull();
   });
 });

--- a/web/src/components/SchematicDialog.tsx
+++ b/web/src/components/SchematicDialog.tsx
@@ -7,9 +7,15 @@
  *    fleet features are: probe `/design/kicad/render/status` and degrade
  *    to a notice when the tools are missing.
  */
-import { useEffect, useState } from "react";
-import { api, ApiError } from "../api/client";
-import type { Design, FabStatus, KicadPcbStatus, KicadRenderStatus } from "../types/api";
+import { useEffect, useRef, useState } from "react";
+import { api, ApiError, kicadRoute } from "../api/client";
+import type {
+  Design,
+  FabStatus,
+  KicadPcbStatus,
+  KicadRenderStatus,
+  KicadRouteStatus,
+} from "../types/api";
 
 interface Props {
   design: Design;
@@ -53,6 +59,14 @@ export function SchematicDialog({ design, onClose }: Props) {
   const [fabStatus, setFabStatus] = useState<FabStatus | null>(null);
   const [fabBusy, setFabBusy] = useState<string | null>(null);
   const [fabError, setFabError] = useState<string | null>(null);
+  const [fabRouted, setFabRouted] = useState(false);
+
+  const [routeStatus, setRouteStatus] = useState<KicadRouteStatus | null>(null);
+  const [routing, setRouting] = useState(false);
+  const [routeLog, setRouteLog] = useState("");
+  const [routeKey, setRouteKey] = useState<string | null>(null);
+  const [routeError, setRouteError] = useState<string | null>(null);
+  const routeLogRef = useRef<HTMLPreElement | null>(null);
 
   useEffect(() => {
     let live = true;
@@ -74,13 +88,26 @@ export function SchematicDialog({ design, onClose }: Props) {
       .fabStatus()
       .then((s) => live && setFabStatus(s))
       .catch(() => live && setFabStatus({
-        bom: true, cpl: false, gerbers: false, kicad_cli: false,
-        footprints: false, reason: "fab status unavailable",
+        bom: true, cpl: false, gerbers: false, route: false, route_reason: null,
+        kicad_cli: false, footprints: false, reason: "fab status unavailable",
+      }));
+    api
+      .kicadRouteStatus()
+      .then((s) => live && setRouteStatus(s))
+      .catch(() => live && setRouteStatus({
+        available: false, pcbnew: null, java: null, freerouting_jar: null,
+        reason: "route status unavailable",
       }));
     return () => {
       live = false;
     };
   }, []);
+
+  // Keep the route log scrolled to the newest line.
+  useEffect(() => {
+    const el = routeLogRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [routeLog]);
 
   // Revoke the object URL when it's replaced or the dialog unmounts.
   useEffect(() => {
@@ -149,6 +176,44 @@ export function SchematicDialog({ design, onClose }: Props) {
   }
 
   const id = design.id ?? "design";
+
+  async function handleRoute() {
+    setRouting(true);
+    setRouteLog("");
+    setRouteKey(null);
+    setRouteError(null);
+    try {
+      for await (const event of kicadRoute(design)) {
+        if (event.type === "log") {
+          setRouteLog((prev) => prev + event.data);
+        } else if (event.type === "done") {
+          if (event.ok) {
+            setRouteKey(event.cache_key);
+          } else {
+            setRouteError("Routing completed without a routed board — see the log.");
+          }
+        }
+      }
+    } catch (e) {
+      setRouteError(formatError(e));
+    } finally {
+      setRouting(false);
+    }
+  }
+
+  async function handleDownloadRouted() {
+    if (!routeKey) return;
+    setRouteError(null);
+    try {
+      saveBlob(
+        await api.kicadRoutedBoard(routeKey),
+        `${id}-routed.kicad_pcb`,
+        "application/octet-stream",
+      );
+    } catch (e) {
+      setRouteError(formatError(e));
+    }
+  }
 
   async function handleFab(
     kind: string,
@@ -289,8 +354,8 @@ python ${design.id ?? "design"}.skidl.py
             <p className="text-xs leading-relaxed text-zinc-400">
               A <code className="text-zinc-200">.kicad_pcb</code> with every
               part placed on a grid and pads wired to nets — open it in KiCad's
-              PCB editor with a full ratsnest and route it. Autorouting and
-              Gerber/JLCPCB export are on the 1.0 roadmap.
+              PCB editor with a full ratsnest and route it yourself, or
+              autoroute it below.
             </p>
             {pcbStatus === null ? (
               <div className="text-xs text-zinc-500">Checking…</div>
@@ -322,6 +387,63 @@ python ${design.id ?? "design"}.skidl.py
             )}
           </section>
 
+          {/* --- Autoroute (Freerouting) ------------------------------- */}
+          <section className="space-y-2 border-t border-zinc-800 pt-3">
+            <div className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
+              Autoroute
+            </div>
+            <p className="text-xs leading-relaxed text-zinc-400">
+              Route the board with Freerouting on the server and download the
+              routed <code className="text-zinc-200">.kicad_pcb</code>. Results
+              are cached — re-routing an unchanged design is instant.
+            </p>
+            {routeStatus === null ? (
+              <div className="text-xs text-zinc-500">Checking…</div>
+            ) : routeStatus.available ? (
+              <>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    onClick={handleRoute}
+                    disabled={routing}
+                    className="rounded-md bg-blue-500/20 px-3 py-1.5 text-sm text-blue-100 ring-1 ring-blue-400/40 enabled:hover:bg-blue-500/30 disabled:opacity-40"
+                  >
+                    {routing ? "Routing…" : routeKey ? "Route again" : "Route board"}
+                  </button>
+                  {routeKey && (
+                    <button
+                      onClick={handleDownloadRouted}
+                      className="rounded-md bg-emerald-500/20 px-3 py-1.5 text-sm text-emerald-100 ring-1 ring-emerald-400/40 hover:bg-emerald-500/30"
+                    >
+                      Download routed .kicad_pcb →
+                    </button>
+                  )}
+                </div>
+                {(routing || routeLog) && (
+                  <pre
+                    ref={routeLogRef}
+                    className="max-h-40 overflow-y-auto rounded-md border border-zinc-800 bg-black/60 p-2 font-mono text-[11px] leading-relaxed text-zinc-300"
+                  >
+                    {routeLog || "Starting Freerouting…"}
+                  </pre>
+                )}
+              </>
+            ) : (
+              <div className="rounded-md border border-zinc-800 bg-zinc-900/40 px-2 py-1.5 text-xs text-zinc-400">
+                Autorouting needs the route toolchain on the server (pcbnew,
+                Java, and the Freerouting jar) — use the{" "}
+                <code className="text-zinc-200">-pcb</code> image variant.
+                {routeStatus.reason && (
+                  <span className="text-zinc-500"> ({routeStatus.reason})</span>
+                )}
+              </div>
+            )}
+            {routeError && (
+              <div className="rounded-md border border-rose-700/40 bg-rose-900/15 px-2 py-1.5 text-xs text-rose-200">
+                {routeError}
+              </div>
+            )}
+          </section>
+
           {/* --- Fab outputs (BOM / CPL / Gerbers) --------------------- */}
           <section className="space-y-2 border-t border-zinc-800 pt-3">
             <div className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
@@ -329,9 +451,28 @@ python ${design.id ?? "design"}.skidl.py
             </div>
             <p className="text-xs leading-relaxed text-zinc-400">
               BOM + pick-and-place (CPL) for assembly, and a Gerber/drill bundle
-              for a board house. The board isn't routed yet, so the Gerbers have
-              pads but no traces — useful once routing lands (1.0 roadmap).
+              for a board house. Check <em>Routed</em> to autoroute before
+              exporting; unrouted Gerbers carry pads but no traces.
             </p>
+            <label
+              className={`flex w-fit items-center gap-2 text-xs ${
+                fabStatus?.route ? "text-zinc-300" : "text-zinc-600"
+              }`}
+              title={
+                fabStatus && !fabStatus.route
+                  ? fabStatus.route_reason ?? "Needs the route toolchain on the server"
+                  : undefined
+              }
+            >
+              <input
+                type="checkbox"
+                checked={fabRouted}
+                disabled={!fabStatus?.route}
+                onChange={(e) => setFabRouted(e.target.checked)}
+                className="accent-blue-500"
+              />
+              Routed (autoroute before export)
+            </label>
             <div className="flex flex-wrap gap-2">
               <button
                 onClick={() => handleFab("bom", () => api.fabBom(design), `${id}-bom.csv`, "text/csv")}
@@ -349,12 +490,14 @@ python ${design.id ?? "design"}.skidl.py
                 {fabBusy === "cpl" ? "…" : "CPL .csv"}
               </button>
               <button
-                onClick={() => handleFab("package", () => api.fabPackage(design), `${id}-fab.zip`, "application/zip")}
+                onClick={() => handleFab("package", () => api.fabPackage(design, fabRouted), `${id}-fab.zip`, "application/zip")}
                 disabled={fabBusy !== null || !fabStatus?.gerbers}
                 title={fabStatus && !fabStatus.gerbers ? "Needs kicad-cli + the libraries on the server" : undefined}
                 className="rounded-md bg-blue-500/20 px-3 py-1.5 text-sm text-blue-100 ring-1 ring-blue-400/40 enabled:hover:bg-blue-500/30 disabled:opacity-40"
               >
-                {fabBusy === "package" ? "Generating…" : "Fab package .zip →"}
+                {fabBusy === "package"
+                  ? fabRouted ? "Routing + generating…" : "Generating…"
+                  : "Fab package .zip →"}
               </button>
             </div>
             {fabStatus && !fabStatus.gerbers && (

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -289,10 +289,24 @@ export interface KicadPcbStatus {
   reason: string | null;
 }
 
+export interface KicadRouteStatus {
+  available: boolean;
+  pcbnew: string | null;
+  java: string | null;
+  freerouting_jar: string | null;
+  reason: string | null;
+}
+
+export type KicadRouteEvent =
+  | { type: "log"; data: string }
+  | { type: "done"; ok: boolean; routed: boolean; cache_key: string; cache_hit: boolean };
+
 export interface FabStatus {
   bom: boolean;
   cpl: boolean;
   gerbers: boolean;
+  route: boolean;
+  route_reason: string | null;
   kicad_cli: boolean;
   footprints: boolean;
   reason: string | null;

--- a/wirestudio/agent/tools.py
+++ b/wirestudio/agent/tools.py
@@ -282,11 +282,24 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
         "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
     },
     {
+        "name": "route_pcb",
+        "description": (
+            "Autoroute the design's .kicad_pcb with Freerouting and return a "
+            "summary (routed, segments, vias, cache_key); the routed board file "
+            "is downloaded via GET /design/kicad/route/{cache_key}. Results are "
+            "cached, so re-routing an unchanged design is instant. Needs the "
+            "route toolchain on the server (pcbnew + java + the Freerouting "
+            "jar) -- returns ok=false, available=false otherwise. Can take a "
+            "minute or two on a dense board. Read-only."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
         "name": "fab_status",
         "description": (
             "What fab outputs the server can produce: BOM is always available, "
-            "CPL needs the footprint libraries, Gerbers need kicad-cli. "
-            "Read-only."
+            "CPL needs the footprint libraries, Gerbers need kicad-cli, routed "
+            "Gerbers also need the Freerouting toolchain (`route`). Read-only."
         ),
         "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
     },
@@ -632,6 +645,41 @@ def _run_kicad_pcb(design: dict, library: Library) -> dict:
     }
 
 
+def _run_route_pcb(design: dict, library: Library) -> dict:
+    """Route and return a summary, not the board text (that's the artifact
+    endpoint's job). A cache hit makes repeat calls instant."""
+    from wirestudio.kicad.route import (
+        RouteError,
+        RouteUnavailable,
+        route_board,
+        route_cache_key,
+    )
+
+    try:
+        d = Design.model_validate(design)
+    except Exception as e:
+        return {"ok": False, "error": f"design failed validation: {e}"}
+    try:
+        board = generate_kicad_pcb(d, library)
+    except PcbUnavailable as e:
+        return {"ok": False, "available": False, "error": str(e)}
+    except (FileNotFoundError, ValueError) as e:
+        return {"ok": False, "error": str(e)}
+    try:
+        routed = route_board(board)
+    except RouteUnavailable as e:
+        return {"ok": False, "available": False, "error": str(e)}
+    except RouteError as e:
+        return {"ok": False, "error": str(e)[-2000:]}
+    return {
+        "ok": True,
+        "routed": True,
+        "segments": len(re.findall(r"^\t\(segment$", routed, re.M)),
+        "vias": len(re.findall(r"^\t\(via$", routed, re.M)),
+        "cache_key": route_cache_key(board),
+    }
+
+
 def _run_fab_status(_design: dict, _library: Library) -> dict:
     """Server-side capability probe; the design/library are ignored."""
     return fab_status()
@@ -691,6 +739,7 @@ TOOL_HANDLERS: dict[str, Callable[..., Any]] = {
     "solve_pins": _run_solve_pins,
     "kicad_schematic": _run_kicad_schematic,
     "kicad_pcb": _run_kicad_pcb,
+    "route_pcb": _run_route_pcb,
     "fab_status": _run_fab_status,
     "fab_bom": _run_fab_bom,
     "fab_cpl": _run_fab_cpl,

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import asdict
 from pathlib import Path
@@ -100,6 +101,13 @@ from wirestudio.kicad.fab import (
     generate_cpl,
 )
 from wirestudio.kicad.pcb import PcbUnavailable, generate_kicad_pcb, pcb_status
+from wirestudio.kicad.route import (
+    RouteError,
+    RouteUnavailable,
+    cached_routed_board,
+    route_events,
+    route_status,
+)
 from wirestudio.kicad.render import (
     RenderError,
     RenderUnavailable,
@@ -604,10 +612,64 @@ def create_app(
             headers={"Content-Disposition": f'attachment; filename="{filename}"'},
         )
 
+    @app.get("/design/kicad/route/status", tags=["design"])
+    def design_kicad_route_status() -> dict:
+        """Probe the autoroute toolchain (pcbnew bridge + java + the
+        Freerouting jar). The web UI gates the Route action on `available`."""
+        return route_status()
+
+    @app.post("/design/kicad/route", tags=["design"])
+    def design_kicad_route(design: dict) -> StreamingResponse:
+        """Autoroute the design's board, streaming the Freerouting log as SSE.
+
+        Frames are `data: {"type": "log"|"done", ...}`; the done frame carries
+        `ok`, `routed`, and `cache_key` -- fetch the routed board from
+        `GET /design/kicad/route/{cache_key}`. Emits eagerly-validated errors
+        (422/503) before the stream opens; a toolchain that vanishes mid-run
+        surfaces as `event: error`.
+        """
+        d = _validate_design(design)
+        try:
+            board = generate_kicad_pcb(d, lib)
+        except PcbUnavailable as e:
+            raise HTTPException(status_code=503, detail=str(e)) from e
+        except (FileNotFoundError, ValueError) as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+
+        def events():
+            try:
+                for event in route_events(board):
+                    if event["type"] == "done":
+                        # The routed board is fetched via cache_key, not SSE.
+                        event = {k: v for k, v in event.items() if k != "board"}
+                    yield f"data: {json.dumps(event)}\n\n"
+            except RouteUnavailable as e:
+                yield f"event: error\ndata: {json.dumps({'message': str(e)})}\n\n"
+
+        return StreamingResponse(
+            events(), media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    @app.get("/design/kicad/route/{cache_key}", tags=["design"])
+    def design_kicad_routed_board(cache_key: str) -> PlainTextResponse:
+        """The routed .kicad_pcb a prior route run stored under `cache_key`.
+        404 until a route for that board has completed."""
+        if not re.fullmatch(r"[0-9a-f]{16}", cache_key):
+            raise HTTPException(status_code=422, detail="bad cache key")
+        board = cached_routed_board(cache_key)
+        if board is None:
+            raise HTTPException(status_code=404, detail="no routed board under that key")
+        return PlainTextResponse(
+            content=board,
+            headers={"Content-Disposition": 'attachment; filename="routed.kicad_pcb"'},
+        )
+
     @app.get("/design/fab/status", tags=["design"])
     def design_fab_status() -> dict:
         """What fab outputs are available: BOM is always emittable, CPL needs
-        the footprint libraries, Gerbers also need kicad-cli."""
+        the footprint libraries, Gerbers also need kicad-cli, routed Gerbers
+        also need the Freerouting toolchain."""
         return fab_status()
 
     @app.post("/design/fab/bom", tags=["design"])
@@ -636,14 +698,17 @@ def create_app(
         )
 
     @app.post("/design/fab/gerbers", tags=["design"])
-    def design_fab_gerbers(design: dict) -> Response:
-        """Gerber + drill files as a zip. 503 when kicad-cli / the libraries
-        are missing."""
+    def design_fab_gerbers(design: dict, route: bool = False) -> Response:
+        """Gerber + drill files as a zip. `?route=true` autoroutes the board
+        first (cached, so a re-export after a route is instant). 503 when
+        kicad-cli / the libraries / the route toolchain are missing."""
         d = _validate_design(design)
         try:
-            data = export_gerbers(d, lib)
-        except (GerberUnavailable, PcbUnavailable) as e:
+            data = export_gerbers(d, lib, route=route)
+        except (GerberUnavailable, PcbUnavailable, RouteUnavailable) as e:
             raise HTTPException(status_code=503, detail=str(e)) from e
+        except RouteError as e:
+            raise HTTPException(status_code=409, detail=str(e)[-2000:]) from e
         except (FileNotFoundError, ValueError) as e:
             raise HTTPException(status_code=422, detail=str(e)) from e
         return Response(
@@ -652,15 +717,18 @@ def create_app(
         )
 
     @app.post("/design/fab/package", tags=["design"])
-    def design_fab_package(design: dict) -> Response:
+    def design_fab_package(design: dict, route: bool = False) -> Response:
         """The JLCPCB upload bundle: Gerbers + drill + CPL + BOM in one zip.
-        Boards are unrouted until the routing step lands, so the Gerbers carry
-        pads but no traces. 503 when kicad-cli / the libraries are missing."""
+        Without `?route=true` the board is unrouted, so the Gerbers carry pads
+        but no traces. 503 when kicad-cli / the libraries / the route
+        toolchain are missing; 409 when routing ran and failed."""
         d = _validate_design(design)
         try:
-            data = export_fab_package(d, lib)
-        except (GerberUnavailable, PcbUnavailable) as e:
+            data = export_fab_package(d, lib, route=route)
+        except (GerberUnavailable, PcbUnavailable, RouteUnavailable) as e:
             raise HTTPException(status_code=503, detail=str(e)) from e
+        except RouteError as e:
+            raise HTTPException(status_code=409, detail=str(e)[-2000:]) from e
         except (FileNotFoundError, ValueError) as e:
             raise HTTPException(status_code=422, detail=str(e)) from e
         return Response(

--- a/wirestudio/kicad/fab.py
+++ b/wirestudio/kicad/fab.py
@@ -54,9 +54,13 @@ def is_routed(board_text: str) -> bool:
 
 def fab_status(*, footprint_dir: Optional[Path] = None) -> dict:
     """What fab outputs are available here. BOM is always pure; CPL needs the
-    footprint libraries (for placement); Gerbers also need kicad-cli."""
+    footprint libraries (for placement); Gerbers also need kicad-cli; routed
+    Gerbers additionally need the Freerouting toolchain."""
+    from wirestudio.kicad.route import route_status
+
     fp = Path(footprint_dir) if footprint_dir else _resolve_footprint_dir()
     cli = _kicad_cli()
+    route = route_status()
     reason = None
     if fp is None or cli is None:
         missing = []
@@ -69,6 +73,8 @@ def fab_status(*, footprint_dir: Optional[Path] = None) -> dict:
         "bom": True,
         "cpl": fp is not None,
         "gerbers": fp is not None and cli is not None,
+        "route": fp is not None and cli is not None and route["available"],
+        "route_reason": route["reason"],
         "kicad_cli": cli is not None,
         "footprints": fp is not None,
         "reason": reason,
@@ -145,13 +151,23 @@ def _zip(files: dict[str, bytes]) -> bytes:
     return buf.getvalue()
 
 
+def _maybe_route(board: str, route: bool) -> str:
+    if not route:
+        return board
+    from wirestudio.kicad.route import route_board
+
+    return route_board(board)
+
+
 def export_gerbers(design: Design, library: Library, *,
                    footprint_dir: Optional[Path] = None,
-                   symbol_dir: Optional[Path] = None) -> bytes:
-    """Zip of Gerber + drill files. Needs kicad-cli + the libraries."""
-    board = generate_kicad_pcb(
+                   symbol_dir: Optional[Path] = None,
+                   route: bool = False) -> bytes:
+    """Zip of Gerber + drill files. Needs kicad-cli + the libraries; with
+    ``route=True`` the board is autorouted first (Freerouting toolchain)."""
+    board = _maybe_route(generate_kicad_pcb(
         design, library, footprint_dir=footprint_dir, symbol_dir=symbol_dir,
-    )
+    ), route)
     with tempfile.TemporaryDirectory(prefix="wirestudio-fab-") as td:
         out = Path(td)
         _gerbers_into(out, board)
@@ -160,11 +176,12 @@ def export_gerbers(design: Design, library: Library, *,
 
 def export_fab_package(design: Design, library: Library, *,
                        footprint_dir: Optional[Path] = None,
-                       symbol_dir: Optional[Path] = None) -> bytes:
+                       symbol_dir: Optional[Path] = None,
+                       route: bool = False) -> bytes:
     """The JLCPCB upload bundle: Gerbers + drill + CPL + BOM in one zip."""
-    board = generate_kicad_pcb(
+    board = _maybe_route(generate_kicad_pcb(
         design, library, footprint_dir=footprint_dir, symbol_dir=symbol_dir,
-    )
+    ), route)
     with tempfile.TemporaryDirectory(prefix="wirestudio-fab-") as td:
         out = Path(td)
         _gerbers_into(out, board)

--- a/wirestudio/kicad/route.py
+++ b/wirestudio/kicad/route.py
@@ -115,6 +115,12 @@ def route_status() -> dict:
     }
 
 
+def cached_routed_board(key: str, *, cache_dir: Optional[Path] = None) -> Optional[str]:
+    """The routed board a prior run stored under ``key``, or None."""
+    path = Path(cache_dir or _default_cache_dir()) / key / "routed.kicad_pcb"
+    return path.read_text() if path.is_file() else None
+
+
 def route_cache_key(board_text: str, *, max_passes: int = _DEFAULT_PASSES) -> str:
     h = hashlib.sha256()
     h.update(_CACHE_VERSION.encode())

--- a/wirestudio/mcp/server.py
+++ b/wirestudio/mcp/server.py
@@ -33,6 +33,7 @@ from wirestudio.agent.tools import (
     _run_recommend,
     _run_remove_component,
     _run_render,
+    _run_route_pcb,
     _run_search_components,
     _run_set_board,
     _run_set_connection,
@@ -417,10 +418,28 @@ def _register_design_tools(
         return _run_kicad_pcb(design, library)
 
     @mcp.tool(
+        name="route_pcb",
+        description=(
+            "Autoroute the named design's .kicad_pcb with Freerouting and "
+            "return a summary (routed, segments, vias, cache_key). The routed "
+            "board file is downloaded via GET /design/kicad/route/{cache_key}. "
+            "Cached, so re-routing an unchanged design is instant; a fresh "
+            "route can take a minute or two. Needs the route toolchain on the "
+            "server. Read-only." + _DESIGN_ID_HINT
+        ),
+    )
+    def route_pcb(design_id: Optional[str] = None) -> dict:
+        rid, design = _load(design_id)
+        if design is None:
+            return _NO_DESIGN_ERROR
+        return _run_route_pcb(design, library)
+
+    @mcp.tool(
         name="fab_status",
         description=(
             "What fab outputs the server can produce: BOM always; CPL needs "
-            "the footprint libraries; Gerbers need kicad-cli. Read-only."
+            "the footprint libraries; Gerbers need kicad-cli; routed Gerbers "
+            "also need the Freerouting toolchain. Read-only."
         ),
     )
     def fab_status_tool() -> dict:


### PR DESCRIPTION
Follow-up to #158 — routing is now reachable from every surface the board is:

- **HTTP**: `GET /design/kicad/route/status`, `POST /design/kicad/route` (SSE log stream, done frame carries `cache_key`), `GET /design/kicad/route/{cache_key}` for the routed board, and `?route=true` on `/design/fab/gerbers` + `/design/fab/package` (503 when the toolchain is missing, 409 when routing ran and failed). `fab_status` gains `route`/`route_reason`.
- **MCP/agent**: new `route_pcb` tool (summary: segments, vias, cache_key); tool docs and the stale MCP tools table updated (it was missing the 0.15 kicad/fab tools and 0.18's `set_strict`).
- **Web UI**: Autoroute section in the KiCad export dialog — route button, live streamed log, routed-board download — plus a Routed checkbox on the fab package. The SSE parser is shared with the LoRaWAN compile stream instead of duplicated.
- **Image**: `Dockerfile.pcb` → `-pcb` tag suffix (amd64, push-only, like `-lorawan`). Based on `kicad/kicad:8.0` (pcbnew + kicad-cli), plus the pinned gitlab symbol/footprint libraries, a Temurin 25 JRE, and the sha256-pinned Freerouting 2.2.4 jar. 2.44GB built.

Verified against the locally built image end-to-end: route status reports available, the SSE route returns `ok: true, routed: true`, the routed fab package's F.Cu/B.Cu gerbers carry trace draw ops, and the artifact endpoint serves the routed `.kicad_pcb`.

Suites: 867 python + 188 web tests green, tsc + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)