### PR TITLE
release: 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] — 2026-07-17
+
 ### Added
 
 - **Autoroute surfaces: HTTP, MCP/agent, web UI, and a `-pcb` image.**

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Detailed docs live in [`docs/`](docs/):
 
 ## Status
 
-`v0.18.0` — on PyPI (`pip install wirestudio`). The studio has wide
+`v0.19.0` — on PyPI (`pip install wirestudio`). The studio has wide
 surface area (YAML, schematic, PCB + fab outputs, enclosure, agent,
 MCP server, fleet handoff, web UI, two LoRaWAN flash/provision paths —
 standalone Arduino and an external-component path that emits ESPHome
@@ -92,7 +92,7 @@ that pin moves, this line moves with it.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:0.18.0
+  ghcr.io/moellere/wirestudio:0.19.0
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -70,7 +70,7 @@ spec:
         runAsGroup: 1000
       containers:
         - name: wirestudio
-          image: ghcr.io/moellere/wirestudio:0.18.0
+          image: ghcr.io/moellere/wirestudio:0.19.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,7 +11,7 @@ FastAPI serves the API and the built SPA from one process.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:0.18.0
+  ghcr.io/moellere/wirestudio:0.19.0
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +
@@ -23,10 +23,10 @@ Available tags:
 
 | Tag | What it tracks |
 |---|---|
-| `:0.18.0` / `:0.18` / `:latest` | the v0.18.0 release |
+| `:0.19.0` / `:0.19` / `:latest` | the v0.19.0 release |
 | `:main` | latest commit on `main` (rolling) |
 | `:sha-<short>` | a specific commit |
-| `:<tag>-lorawan` (e.g. `:main-lorawan`, `:0.18.0-lorawan`) | same image **plus** the LoRaWAN compile worker (PlatformIO baked in) — see below |
+| `:<tag>-lorawan` (e.g. `:main-lorawan`, `:0.19.0-lorawan`) | same image **plus** the LoRaWAN compile worker (PlatformIO baked in) — see below |
 | `:<tag>-pcb` (e.g. `:main-pcb`, `:0.19.0-pcb`) | the PCB toolchain variant: KiCad 8 (kicad-cli + pcbnew), the pinned symbol/footprint libraries, a JRE, and Freerouting — everything the board/fab/autoroute endpoints gate on — see below |
 
 All feature-gating env vars are optional — the studio runs without any
@@ -96,7 +96,7 @@ so both run side by side from one source tree with independent PVCs.
 
 | App | Overlay | Image | Upgrades when |
 |---|---|---|---|
-| `wirestudio-prod` | `deploy/overlays/prod` | pinned release, e.g. `:0.18.0` | the tag changes in git (bump by hand or via image-updater) |
+| `wirestudio-prod` | `deploy/overlays/prod` | pinned release, e.g. `:0.19.0` | the tag changes in git (bump by hand or via image-updater) |
 | `wirestudio-dev` | `deploy/overlays/dev` | rolling `:main-lorawan` | image-updater digest-pins a new `main` build |
 
 ```sh

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"


### PR DESCRIPTION
Cut 0.19.0 — the autorouting release. `[Unreleased]` becomes `[0.19.0] — 2026-07-17`: the Freerouting pipeline + pcb-route CI gate (#158) and the HTTP/MCP/web-UI surfaces + `-pcb` image variant (#159). Version bumps in `__init__.py`, README, deployment docs, and the k8s reference manifest.

After merge: tag `v0.19.0` on the merge commit → release.yml publishes to PyPI + GitHub Release, docker.yml publishes `:0.19.0` / `:0.19` / `:latest` plus the `-lorawan` and `-pcb` variants, and argocd-image-updater rolls prod from the new release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)