### PR TITLE
build(docker): -full image variant (PCB toolchain + LoRaWAN worker)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -171,6 +171,47 @@ jobs:
           cache-from: type=gha,scope=pcb
           cache-to: type=gha,mode=max,scope=pcb
 
+  # The every-feature variant prod runs: Dockerfile.pcb + WITH_LORAWAN=true,
+  # so one image carries the PCB toolchain (KiCad + pcbnew + Freerouting) AND
+  # the LoRaWAN compile worker (PlatformIO + prewarmed espressif32). Published
+  # as the `-full` tag suffix.
+  full-image:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/wirestudio
+          flavor: suffix=-full,latest=false
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.pcb
+          platforms: linux/amd64
+          build-args: WITH_LORAWAN=true
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=full
+          cache-to: type=gha,mode=max,scope=full
+
   # Deployment is NOT handled here. The k8s cluster is driven by the
   # moellere/argocd GitOps repo, where argocd-image-updater watches this
   # registry and rolls each environment automatically:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`-full` image variant: PCB toolchain + LoRaWAN worker in one image.**
+  `Dockerfile.pcb` gains the same `WITH_LORAWAN` build-arg as the default
+  Dockerfile (PlatformIO + the `[lorawan]` extra + espressif32 prewarm,
+  installed into the app venv); a new `full-image` CI job publishes it as
+  the `-full` tag suffix. This is the every-feature image prod runs —
+  autoroute/fab AND LoRaWAN compile/flash from one deployment — replacing
+  `-lorawan` as the prod-tracked variant.
+
 ## [0.19.0] — 2026-07-17
 
 ### Added

--- a/Dockerfile.pcb
+++ b/Dockerfile.pcb
@@ -1,7 +1,10 @@
 # syntax=docker/dockerfile:1.7
 #
 # PCB-toolchain variant: the default image plus everything the autoroute and
-# fab pipeline needs baked in. Published as the `-pcb` tag suffix.
+# fab pipeline needs baked in. Published as the `-pcb` tag suffix; with
+# WITH_LORAWAN=true it also carries the LoRaWAN compile worker (PlatformIO +
+# prewarmed espressif32 toolchain) and is published as `-full` -- the
+# every-feature image prod runs.
 #
 # Based on the official KiCad 8 image because the route step needs pcbnew's
 # python bindings (kicad-cli has no Specctra support) and they only exist
@@ -68,6 +71,20 @@ COPY --from=web-builder /web/dist /app/web-dist
 RUN mkdir -p /data/sessions /data/designs && \
     useradd -m -s /bin/bash appuser && \
     chown -R appuser:appuser /app /data
+
+# Optional LoRaWAN compile worker, same shape as the default Dockerfile's
+# WITH_LORAWAN block but against the /opt/venv interpreter.
+ARG WITH_LORAWAN=false
+ENV PLATFORMIO_CORE_DIR=/opt/pio
+RUN <<'EOF'
+set -eu
+if [ "$WITH_LORAWAN" = "true" ]; then
+    /opt/venv/bin/pip install --no-cache-dir platformio ".[lorawan]"
+    mkdir -p "$PLATFORMIO_CORE_DIR"
+    /opt/venv/bin/python -c "from wirestudio.library import default_library; from wirestudio.model import Design; from wirestudio.targets import get_target; from wirestudio.targets.lorawan.compile import compile_firmware; lib=default_library(); [compile_firmware(Design(schema_version='0.1', id='prewarm-'+b, name=b, target='lorawan', lorawan={}, board={'library_id': b, 'mcu': 'esp32'}, power={'supply':'usb','rail_voltage_v':3.3}), lib, use_cache=False) for b in get_target('lorawan').board_ids(lib)]"
+    chown -R appuser:appuser "$PLATFORMIO_CORE_DIR"
+fi
+EOF
 
 ENV PYTHONUNBUFFERED=1 \
     PATH=/opt/venv/bin:$PATH \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,6 +28,7 @@ Available tags:
 | `:sha-<short>` | a specific commit |
 | `:<tag>-lorawan` (e.g. `:main-lorawan`, `:0.19.0-lorawan`) | same image **plus** the LoRaWAN compile worker (PlatformIO baked in) — see below |
 | `:<tag>-pcb` (e.g. `:main-pcb`, `:0.19.0-pcb`) | the PCB toolchain variant: KiCad 8 (kicad-cli + pcbnew), the pinned symbol/footprint libraries, a JRE, and Freerouting — everything the board/fab/autoroute endpoints gate on — see below |
+| `:<tag>-full` (e.g. `:main-full`, `:0.19.0-full`) | the every-feature image prod runs: `-pcb` **plus** the LoRaWAN compile worker (PlatformIO + prewarmed espressif32) |
 
 All feature-gating env vars are optional — the studio runs without any
 of them, just with the corresponding feature turned off. See
@@ -105,11 +106,13 @@ kubectl apply -f deploy/argocd/wirestudio-dev.yaml
 ```
 
 Both apps run `automated: { prune, selfHeal }`, so ArgoCD applies git
-changes and reverts manual cluster edits on its own. Staging tracks the
-`:main-lorawan` tag (the LoRaWAN worker variant, so the compile/flash
-flow works on staging); prod pins an immutable release tag and stays
-lean. Each overlay sets its own namespace, so the apps never share
-`/data`.
+changes and reverts manual cluster edits on its own. Track the variant
+that carries the features the environment needs — the upstream cluster
+runs `-full` on both (staging `:main-full` by digest, prod the newest
+`:X.Y.Z-full` release tag), so the LoRaWAN compile/flash flow AND the
+PCB autoroute/fab endpoints work everywhere. Prod pins an immutable
+release tag. Each overlay sets its own namespace, so the apps never
+share `/data`.
 
 ### Keeping the image current
 


### PR DESCRIPTION
Combined image for prod: `Dockerfile.pcb` + `WITH_LORAWAN=true`, published as the `-full` tag suffix by a new `full-image` job. One deployment carries KiCad 8/pcbnew/Freerouting (autoroute + fab) and PlatformIO with the prewarmed espressif32 toolchain (LoRaWAN compile/flash).

Verified in the locally built image (5.86GB): route status available, a real route completes over SSE, fab status reports everything true, and a TTGO LoRa32-v2 standalone firmware compile succeeds through `/lorawan/compile`.

Companion change in the argocd repo retargets prod (newest `X.Y.Z-full`) and staging (`main-full` by digest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)