### PR TITLE
release: 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] — 2026-07-18
+
 ### Added
 
 - **`-full` image variant: PCB toolchain + LoRaWAN worker in one image.**

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Detailed docs live in [`docs/`](docs/):
 
 ## Status
 
-`v0.19.0` — on PyPI (`pip install wirestudio`). The studio has wide
+`v0.19.1` — on PyPI (`pip install wirestudio`). The studio has wide
 surface area (YAML, schematic, PCB + fab outputs, enclosure, agent,
 MCP server, fleet handoff, web UI, two LoRaWAN flash/provision paths —
 standalone Arduino and an external-component path that emits ESPHome
@@ -92,7 +92,7 @@ that pin moves, this line moves with it.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:0.19.0
+  ghcr.io/moellere/wirestudio:0.19.1
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -70,7 +70,7 @@ spec:
         runAsGroup: 1000
       containers:
         - name: wirestudio
-          image: ghcr.io/moellere/wirestudio:0.19.0
+          image: ghcr.io/moellere/wirestudio:0.19.1
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,7 +11,7 @@ FastAPI serves the API and the built SPA from one process.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:0.19.0
+  ghcr.io/moellere/wirestudio:0.19.1
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +
@@ -23,12 +23,12 @@ Available tags:
 
 | Tag | What it tracks |
 |---|---|
-| `:0.19.0` / `:0.19` / `:latest` | the v0.19.0 release |
+| `:0.19.1` / `:0.19` / `:latest` | the v0.19.0 release |
 | `:main` | latest commit on `main` (rolling) |
 | `:sha-<short>` | a specific commit |
-| `:<tag>-lorawan` (e.g. `:main-lorawan`, `:0.19.0-lorawan`) | same image **plus** the LoRaWAN compile worker (PlatformIO baked in) — see below |
-| `:<tag>-pcb` (e.g. `:main-pcb`, `:0.19.0-pcb`) | the PCB toolchain variant: KiCad 8 (kicad-cli + pcbnew), the pinned symbol/footprint libraries, a JRE, and Freerouting — everything the board/fab/autoroute endpoints gate on — see below |
-| `:<tag>-full` (e.g. `:main-full`, `:0.19.0-full`) | the every-feature image prod runs: `-pcb` **plus** the LoRaWAN compile worker (PlatformIO + prewarmed espressif32) |
+| `:<tag>-lorawan` (e.g. `:main-lorawan`, `:0.19.1-lorawan`) | same image **plus** the LoRaWAN compile worker (PlatformIO baked in) — see below |
+| `:<tag>-pcb` (e.g. `:main-pcb`, `:0.19.1-pcb`) | the PCB toolchain variant: KiCad 8 (kicad-cli + pcbnew), the pinned symbol/footprint libraries, a JRE, and Freerouting — everything the board/fab/autoroute endpoints gate on — see below |
+| `:<tag>-full` (e.g. `:main-full`, `:0.19.1-full`) | the every-feature image prod runs: `-pcb` **plus** the LoRaWAN compile worker (PlatformIO + prewarmed espressif32) |
 
 All feature-gating env vars are optional — the studio runs without any
 of them, just with the corresponding feature turned off. See
@@ -97,7 +97,7 @@ so both run side by side from one source tree with independent PVCs.
 
 | App | Overlay | Image | Upgrades when |
 |---|---|---|---|
-| `wirestudio-prod` | `deploy/overlays/prod` | pinned release, e.g. `:0.19.0` | the tag changes in git (bump by hand or via image-updater) |
+| `wirestudio-prod` | `deploy/overlays/prod` | pinned release, e.g. `:0.19.1` | the tag changes in git (bump by hand or via image-updater) |
 | `wirestudio-dev` | `deploy/overlays/dev` | rolling `:main-lorawan` | image-updater digest-pins a new `main` build |
 
 ```sh

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"


### PR DESCRIPTION
Cut 0.19.1 — the `-full` image variant (#161) as a patch release so the tag pipeline publishes `:0.19.1-full` for prod to track (the argocd repo's ImageUpdater CRs move to the `-full` pattern in a companion change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)