### PR TITLE
⚡ Bolt: Replace `.filter().map()` with single-pass loop in ConnectionForm

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-07-06 - Avoid sorting and O(N) grouping in unmemoized component closures
 **Learning:** In interactive components like `AddComponentControl`, placing array `.push()` groupings into dictionaries and `.sort()` operations directly in the render body creates new objects and arrays on every keystroke or local state change (e.g. `setPicked`), severely impacting performance in lists.
 **Action:** Always wrap grouping (e.g., `byCategory` dictionaries) and sorting (e.g., `categories.sort()`) of mostly-static library data inside a `useMemo` hook to avoid O(N) allocation and re-sorting during local state interactions.
+
+## 2025-07-23 - Single-pass loops over chained array methods
+**Learning:** Chaining `.filter().map()` or similar methods on large arrays (like `libraryComponents`) allocates multiple intermediate arrays. Even when wrapped in `useMemo`, this creates unnecessary garbage collection pressure when the dependencies change.
+**Action:** When deriving Collections (like `Set`, `Map`, or simply returning a flattened/filtered Array) from large data structures, prefer a single-pass `for...of` loop instead of chained array methods to avoid intermediate allocations.

--- a/web/src/components/ConnectionForm.tsx
+++ b/web/src/components/ConnectionForm.tsx
@@ -53,9 +53,16 @@ export function ConnectionForm({
     return map;
   }, [buses]);
 
+  // ⚡ Bolt: Use single-pass for...of loop instead of .filter().map() to avoid intermediate array allocations
   const expanderLibIds = useMemo(() => {
-    if (!libraryComponents) return new Set<string>();
-    return new Set(libraryComponents.filter((c) => c.category === "io_expander").map((c) => c.id));
+    const ids = new Set<string>();
+    if (!libraryComponents) return ids;
+    for (const c of libraryComponents) {
+      if (c.category === "io_expander") {
+        ids.add(c.id);
+      }
+    }
+    return ids;
   }, [libraryComponents]);
 
   const expanders = useMemo(() => {


### PR DESCRIPTION
💡 What: Replaced a `.filter().map()` chain with a single-pass `for...of` loop when deriving `expanderLibIds` in `web/src/components/ConnectionForm.tsx`.
🎯 Why: Chaining array methods allocates an intermediate array for each step. For potentially large data structures like `libraryComponents`, this creates unnecessary garbage collection pressure and CPU overhead on component updates.
📊 Impact: Reduces intermediate array allocations from two to zero during this `useMemo` computation, reducing memory churn.
🔬 Measurement: Verify by examining the memory profile and GC activity during component mounts or updates when `libraryComponents` is large.

---
*PR created automatically by Jules for task [526298367986878028](https://jules.google.com/task/526298367986878028) started by @moellere*