### PR TITLE
fix: generated SKiDL script pins KICAD8 tool and symbol path; release 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1] — 2026-07-25
+
+### Fixed
+
+- **Schematic render 500 in deployments.** The generated SKiDL script now
+  pins `skidl.set_default_tool(KICAD8)` and sets the symbol search path
+  from the `KICAD*_SYMBOL_DIR` env vars itself. Previously only the CI
+  runner did this, so running the script raw -- which is exactly what
+  `/design/kicad/render` and the download-and-run flow do -- left SKiDL
+  on its legacy default tool and failed with `Can't open file: RF_Module`.
+  Verified end-to-end: raw script -> .kicad_sch on skidl 2.2.3 against
+  pinned kicad-symbols 8.0.0.
+
 ## [0.20.0] — 2026-07-25
 
 ### Added

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.20.0"
+__version__ = "0.20.1"

--- a/wirestudio/kicad/generator.py
+++ b/wirestudio/kicad/generator.py
@@ -110,7 +110,21 @@ The script writes <design_id>.kicad_sch + .net + .xml into the current
 directory. Edit pin assignments + component overrides above the
 generate_*() calls if you want to tweak before re-running.
 """
+import os
+
+import skidl
 from skidl import Part, Net, generate_netlist, generate_schematic, TEMPLATE
+
+# Pin the tool and symbol search path so the script resolves symbols the
+# same way everywhere it runs. SKiDL's default tool predates .kicad_sym
+# libraries, and its default search path includes '.', which lets a stray
+# <Lib>.kicad_sym in the tree shadow the real library.
+skidl.set_default_tool(skidl.KICAD8)
+_sym = next((os.environ[v] for v in (
+    "KICAD8_SYMBOL_DIR", "KICAD9_SYMBOL_DIR", "KICAD7_SYMBOL_DIR",
+    "KICAD6_SYMBOL_DIR", "KICAD_SYMBOL_DIR") if os.environ.get(v)), None)
+if _sym:
+    skidl.lib_search_paths[skidl.KICAD8] = [_sym]
 
 
 def build():


### PR DESCRIPTION
Fixes the consistent 500 on the schematic tab in the 0.20.0 deployment.

Root cause: `/design/kicad/render` (and the download-and-run flow) execute the generated SKiDL script raw. Only `scripts/check_schematics.py`'s runner ever pinned `skidl.set_default_tool(KICAD8)` and the symbol search path, so the raw script left SKiDL on its legacy default tool, which cannot resolve `.kicad_sym` libraries from `KICAD8_SYMBOL_DIR` — failing with `Can't open file: RF_Module`. The experimental `generate_schematic()` step itself works fine on skidl 2.2.3 once the tool is pinned.

Fix: the script preamble now pins the tool and sets `lib_search_paths` from the `KICAD*_SYMBOL_DIR` env vars itself (same fallback order and same '.'-shadowing rationale as the CI runner).

Verified locally by reproducing prod's exact failure, then re-running the raw script for garage-motion, analog-node, and t-beam against pinned kicad-symbols 8.0.0 — each emits a clean `.kicad_sch`. `tests/test_kicad.py` + `tests/test_kicad_render.py` pass (38). Includes the 0.20.1 version bump and changelog section; push `v0.20.1` after merge to publish and roll the deployment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLucY2SKuBDPFaDAJnnYs1)_