### PR TITLE
fix: schematic render with unassigned pins; release 0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1] — 2026-07-25
+
+### Fixed
+
+- **Schematic render failed on designs with unassigned pins.** Unbound
+  connection targets (empty gpio pin / bus id) emitted stub
+  `GPIO_UNBOUND` nets that SKiDL's schematic router cannot route on
+  larger designs (`GlobalRoutingFailure`). Unassigned pins now stay
+  unconnected in the generated script (annotated `run Solve Pins`), and
+  `generate_schematic(allow_routing_failure=True)` degrades any other
+  routing failure to a stubbed-net render instead of a 500.
+
 ## [0.21.0] — 2026-07-25
 
 ### Added

--- a/tests/test_kicad.py
+++ b/tests/test_kicad.py
@@ -53,7 +53,7 @@ def test_skidl_imports_appear(lib):
     script = generate_skidl(_design("garage-motion"), lib)
     assert "from skidl import" in script
     assert "Part" in script and "Net" in script
-    assert "generate_schematic()" in script
+    assert "generate_schematic(allow_routing_failure=True)" in script
 
 
 def test_design_id_appears_in_docstring(lib):

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"

--- a/wirestudio/kicad/generator.py
+++ b/wirestudio/kicad/generator.py
@@ -147,7 +147,9 @@ if __name__ == "__main__":
     # Default: emit a netlist (.net) + a schematic (.kicad_sch).
     # Comment out either if you only want one.
     generate_netlist()
-    generate_schematic()
+    # allow_routing_failure: SKiDL's schematic router is best-effort; a
+    # degraded render with stubbed nets beats no render at all.
+    generate_schematic(allow_routing_failure=True)
 '''
 
 
@@ -259,6 +261,15 @@ def _render_connections(
             except FileNotFoundError:
                 pass
         pin_name = _resolve_pin_role(conn.pin_role, lib_comp)
+        # Unbound targets (empty gpio pin / bus id -- the design hasn't been
+        # pin-solved yet) stay unconnected. Emitting a stub net for them
+        # gives SKiDL's schematic router a wire with nowhere to go, which
+        # fails routing on larger designs.
+        if (conn.target.kind == "gpio" and not conn.target.pin) or (
+            conn.target.kind == "bus" and not conn.target.bus_id
+        ):
+            lines.append(f'# {conn.component_id}.{conn.pin_role}: unassigned (run Solve Pins)')
+            continue
         net_expr = _net_handle_for(conn.target, design, ref_index)
         lines.append(f'{comp_var}[{_quote(pin_name)}] += {net_expr}')
     return "\n".join(lines)


### PR DESCRIPTION
Fixes the remaining schematic-tab 500 (the error surfacing from #172 exposed the real cause).

Root cause: connections with unassigned pins (empty `gpio` pin / `bus` id — a design that hasn't been pin-solved) emitted stub `GPIO_UNBOUND` nets in the SKiDL script. Each is a wire from a net label to nowhere; SKiDL's experimental schematic router fails on them once the design is large enough (`GlobalRoutingFailure: GPIO_UNBOUND3 ...`, as reported). The netlist itself generated cleanly, which is why the CI gate (netlist-only) never caught it.

Fix, two layers:
- The generator leaves unassigned pins unconnected, annotated `# <comp>.<role>: unassigned (run Solve Pins)` — the semantically correct schematic for an unsolved design.
- The script's `generate_schematic(allow_routing_failure=True)` degrades any residual routing failure to a stubbed-net render instead of an exception, so the preview endpoint can't be killed by router geometry again.

Verified: a design seeded with unbound pins now generates a script with zero `UNBOUND` nets and renders to `.kicad_sch` locally against pinned kicad-symbols; kicad test suites pass (one assertion updated for the new call signature). Includes the 0.21.1 bump + changelog — tag `v0.21.1` after merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLucY2SKuBDPFaDAJnnYs1)_