### PR TITLE
schematic render quality: stub power nets, auto_stub, rotate_parts; release 0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.3] — 2026-07-25
+
+### Changed
+
+- **Cleaner schematic renders.** Power/rail nets are marked as stubs
+  (short labeled stubs at each pin instead of routed wires), and
+  generate_schematic runs with auto_stub (high-fanout nets become
+  labeled stubs; routing failures fall back to a stubbed drawing) and
+  rotate_parts. Cuts most of the label/wire overlap in the preview.
+
 ## [0.21.2] — 2026-07-25
 
 ### Added

--- a/tests/test_kicad.py
+++ b/tests/test_kicad.py
@@ -53,7 +53,7 @@ def test_skidl_imports_appear(lib):
     script = generate_skidl(_design("garage-motion"), lib)
     assert "from skidl import" in script
     assert "Part" in script and "Net" in script
-    assert "generate_schematic(allow_routing_failure=True)" in script
+    assert "generate_schematic(allow_routing_failure=True, auto_stub=True, rotate_parts=True)" in script
 
 
 def test_design_id_appears_in_docstring(lib):

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.21.2"
+__version__ = "0.21.3"

--- a/wirestudio/kicad/generator.py
+++ b/wirestudio/kicad/generator.py
@@ -146,7 +146,11 @@ if _sym:
 
 def build():
     # ---- Power rails -----------------------------------------------------
+    # Power nets draw as short labeled stubs at each pin instead of
+    # routed wires -- standard schematic practice, and it keeps SKiDL's
+    # router from webbing the sheet with power wiring.
     GND = Net("GND")
+    GND.stub = True
 {rail_decls}
 
     # ---- Component instances --------------------------------------------
@@ -166,7 +170,10 @@ if __name__ == "__main__":
     generate_netlist()
     # allow_routing_failure: SKiDL's schematic router is best-effort; a
     # degraded render with stubbed nets beats no render at all.
-    generate_schematic(allow_routing_failure=True)
+    # auto_stub: high-fanout nets (buses) become labeled stubs, and
+    # routing failures fall back to a stubbed drawing instead of raising.
+    # rotate_parts: the placer may orient parts to shorten wiring.
+    generate_schematic(allow_routing_failure=True, auto_stub=True, rotate_parts=True)
     _kicad8_compat()
 '''
 
@@ -202,6 +209,7 @@ def _render_rails(design: Design) -> str:
     out: list[str] = []
     for r in sorted(rails):
         out.append(f'NET_PLUS_{_py_var(r)} = Net("+{r}")')
+        out.append(f'NET_PLUS_{_py_var(r)}.stub = True')
     return "\n".join(out)
 
 


### PR DESCRIPTION
Addresses the messy renders (labels and net pointers landing on top of symbols and pins) now that the schematic preview works.

Three layout changes, all standard schematic practice:
- Rail nets (`GND`, `+3V3`, `+5V`) are marked `stub = True` — each pin gets a short labeled stub instead of routed wires webbing the sheet. Power distribution is the bulk of the wire clutter on these designs.
- `generate_schematic(auto_stub=True, ...)` — high-fanout nets (I2C buses on multi-device designs) become labeled stubs too, and routing failures fall back to a stubbed drawing instead of relying solely on `allow_routing_failure`.
- `rotate_parts=True` — the placer may orient parts to shorten wiring.

Verified locally: auto_stub engages, the schematic generates with zero errors, and the KiCad-8 compat rewrite still applies. The kicad-render gate validates loadability end-to-end on this PR and uploads the rendered SVGs as artifacts — eyeball `rendered-schematics` on the gate run for the visual result.

Includes the 0.21.3 bump + changelog; tag `v0.21.3` after merge. SKiDL's placer remains best-effort — if quality still disappoints after this, remaining knobs are `compress_before_place`/`use_push_pull`, or accepting the preview as approximate and leaning on the downloadable script + KiCad for real editing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLucY2SKuBDPFaDAJnnYs1)_