### PR TITLE
Heltec V4 GNSS: auto-wire connector pins + power-enable, discoverable GPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Heltec WiFi LoRa 32 V4 GNSS auto-wiring.** The board's SH1.25-8 GNSS
+  connector is now an onboard peripheral (`gps_gnss`), so seeding the board
+  auto-places a GPS wired to the correct UART pins (MCU rx GPIO38, tx GPIO39
+  -- matching Meshtastic's `heltec_v4` `GPS_TX_PIN`/`GPS_RX_PIN`). The
+  onboard-GPS seed handler now matches any `gps_*` peripheral key, not just
+  `gps_neo6m`. The seed also carries a board's GNSS power-enable pin (V4:
+  GPS_EN on GPIO34, active low), and the `uart_gps` LoRaWAN setup fragment
+  drives it so the module powers up instead of staying dark.
+
+### Changed
+
+- **GPS/GNSS component discoverability.** `uart_gps` gains `gnss`, `gps`,
+  `uc6580`, and `ublox` aliases (and a `gnss` use-case) so an inspector
+  search for "GNSS" finds it. Covers the Heltec V4's UC6580-class module.
+
 ## [0.23.0] — 2026-07-26
 
 ### Added

--- a/tests/golden/wemosgps.txt
+++ b/tests/golden/wemosgps.txt
@@ -3,7 +3,7 @@
 +-----------------------------------------------------------------------------------------------------------------------+
 |  Rails: 5V, 3V3, GND                                                                                                  |
 |                                                                                                                       |
-|  gps  [Generic UART GPS module (NEO-6M / NEO-8M)]  -- GPS                                                             |
+|  gps  [Generic UART GPS / GNSS module (NEO-6M / NEO-8M / UC6580)]  -- GPS                                             |
 |    VCC   -> rail 5V                                                                                                   |
 |    GND   -> rail GND                                                                                                  |
 |    TX    -> my_uart (D2)                                                                                              |
@@ -14,7 +14,7 @@
 |                                                                                                                       |
 |  BOM:                                                                                                                 |
 |    - WeMos D1 Mini                                                                                                    |
-|    - Generic UART GPS module (NEO-6M / NEO-8M)  (gps)                                                                 |
+|    - Generic UART GPS / GNSS module (NEO-6M / NEO-8M / UC6580)  (gps)                                                 |
 |    - 1x 10uF capacitor                                                                                                |
 |                                                                                                                       |
 |  Power: ~30mA typical, ~80mA peak (budget 500mA)  OK                                                                  |

--- a/tests/test_firmware_gen.py
+++ b/tests/test_firmware_gen.py
@@ -100,6 +100,29 @@ def test_ttgo_v2_uses_v21_platformio_board(lib):
     assert "SX1276 radio = new Module(18, 26, 23, RADIOLIB_NC);" in out["src/main.cpp"]
 
 
+def test_heltec_v4_seeded_gnss_powers_enable_and_fem(lib):
+    # A seeded V4 LoRaWAN tracker: the GNSS enable pin (GPIO34, active low)
+    # is driven LOW to power the module, the UART lands on 38/39, and the RF
+    # front-end pins stay forced HIGH for the radio.
+    from wirestudio.seed import seed_onboard_components
+
+    frag = seed_onboard_components(lib.board("heltec-wifi-lora32-v4"), lib)
+    design = Design(
+        schema_version="0.1", id="v4t", name="V4 tracker",
+        board={"library_id": "heltec-wifi-lora32-v4", "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        target="lorawan", lorawan={"region": "US915", "sub_band": 2},
+        components=frag["components"], buses=frag["buses"],
+        connections=frag["connections"],
+    )
+    cpp = generate_firmware(design, lib)["src/main.cpp"]
+    assert "pinMode(34, OUTPUT);" in cpp
+    assert "digitalWrite(34, LOW);" in cpp  # active-low enable -> power on
+    assert "GPSSerial.begin(9600, SERIAL_8N1, 38, 39);" in cpp
+    for pin in (7, 2, 5, 46):
+        assert f"digitalWrite({pin}, HIGH);" in cpp  # FEM forced high
+
+
 def test_non_radio_board_raises(lib):
     with pytest.raises(ValueError, match="no radio"):
         generate_firmware(_design("esp32-devkitc-v4"), lib)

--- a/tests/test_seed_onboard.py
+++ b/tests/test_seed_onboard.py
@@ -134,6 +134,16 @@ def test_gps_uart_crosses_over_and_avoids_reserved_id(lib):
     assert bus["tx"] == "GPIO12" and bus["rx"] == "GPIO34"
 
 
+def test_heltec_v4_gnss_connector_seeds_on_correct_pins(lib):
+    # The V4's SH1.25-8 GNSS connector auto-selects its UART pins: the
+    # module's TX (GPIO38, "toward the CPU") is the MCU rx, and the MCU tx
+    # (GPIO39) drives the module's RX -- matching Meshtastic's heltec_v4.
+    frag = seed_onboard_components(lib.board("heltec-wifi-lora32-v4"), lib)
+    assert "uart_gps" in {c["library_id"] for c in frag["components"]}
+    bus = next(b for b in frag["buses"] if b["type"] == "uart")
+    assert bus["tx"] == "GPIO39" and bus["rx"] == "GPIO38"
+
+
 def test_unmapped_peripherals_warn_not_fail(lib):
     # axp192 (PMIC) has no component; it should warn, not break seeding.
     frag = seed_onboard_components(lib.board("ttgo-t-beam"), lib)
@@ -145,6 +155,7 @@ def test_unmapped_peripherals_warn_not_fail(lib):
     "esp32-c3-devkitm-1", "esp32-c3-supermini", "esp32-s3-devkitc-1",
     "m5stack-atom-echo", "m5stack-atom-matrix", "m5stack-atomu",
     "m5stack-atoms3-lite", "ttgo-lora32-v1", "ttgo-t-beam",
+    "heltec-wifi-lora32-v4",
 ])
 def test_every_board_seed_renders(lib, board_id):
     """Every board's seeded design renders without error. The

--- a/wirestudio/library/boards/heltec-wifi-lora32-v4.yaml
+++ b/wirestudio/library/boards/heltec-wifi-lora32-v4.yaml
@@ -45,6 +45,13 @@ onboard_peripherals:
   led:          {pin: GPIO35}
   button:       {pin: GPIO0, inverted: true}
   rf_fem:       {power: GPIO7, enable: GPIO2, ctx: GPIO5, pa_mode: GPIO46}
+  # SH1.25-8 GNSS connector (plug-in module, e.g. Heltec UC6580 / L76K).
+  # tx/rx are the module-side labels; the seed handler crosses them so the
+  # MCU rx (GPIO38, "data toward the CPU") reads the module's TX and the MCU
+  # tx (GPIO39) drives the module's RX -- matching Meshtastic's heltec_v4
+  # GPS_TX_PIN=38 / GPS_RX_PIN=39. The module needs GPS_EN driven LOW to
+  # power up: GPIO34 on the V4, GPIO42 on the V4-R8 (see gnss_en below).
+  gps_gnss:     {tx: GPIO38, rx: GPIO39, baud: 9600, enable: GPIO34, enable_active_low: true}
 
 # SX1262 wiring matches the V3 (RadioLib `new Module(8, 14, 12, 13)`),
 # TCXO 1.8V off DIO3, DIO2 as RF switch. setup_high powers and enables

--- a/wirestudio/library/components/uart_gps.yaml
+++ b/wirestudio/library/components/uart_gps.yaml
@@ -1,8 +1,8 @@
 id: uart_gps
-name: Generic UART GPS module (NEO-6M / NEO-8M)
+name: Generic UART GPS / GNSS module (NEO-6M / NEO-8M / UC6580)
 category: sensor
-use_cases: [gps, location, time_sync, navigation]
-aliases: [neo-6m, neo-8m, beitian-880, gp-02]
+use_cases: [gps, gnss, location, time_sync, navigation]
+aliases: [gnss, gps, neo-6m, neo-8m, beitian-880, gp-02, uc6580, ublox]
 
 electrical:
   vcc_min: 3.0
@@ -26,6 +26,11 @@ lorawan:
     TinyGPSPlus gps;
     HardwareSerial GPSSerial(1);
   setup: |
+    {%- if params.enable_pin is defined and params.enable_pin %}
+      pinMode({{ params.enable_pin | string | replace('GPIO', '') }}, OUTPUT);
+      digitalWrite({{ params.enable_pin | string | replace('GPIO', '') }}, {{ 'LOW' if params.enable_active_low else 'HIGH' }});  // power on GNSS module
+      delay(100);
+    {%- endif %}
     {%- if bus is not none %}
       GPSSerial.begin({{ bus.baud | default(9600) }}, SERIAL_8N1, {{ bus.rx }}, {{ bus.tx }});  // RX, TX
     {%- else %}

--- a/wirestudio/seed.py
+++ b/wirestudio/seed.py
@@ -148,6 +148,12 @@ def _seed_gps(key: str, params: dict, ctx: _SeedContext) -> Optional[tuple[dict,
             "satellites": {"name": "GPS Satellites"},
         }},
     }
+    # Boards that gate GNSS power behind a GPIO (Heltec V4: GPS_EN on GPIO34,
+    # active low) stay dark until the firmware drives that pin. Carry it as a
+    # param so the uart_gps LoRaWAN setup fragment can power the module up.
+    if params.get("enable"):
+        comp["params"]["enable_pin"] = params["enable"]
+        comp["params"]["enable_active_low"] = bool(params.get("enable_active_low", False))
     conns = [_rail("onboard_gps", "VCC", "3V3"), _rail("onboard_gps", "GND", "GND"),
              _bus("onboard_gps", "TX", bus_id), _bus("onboard_gps", "RX", bus_id)]
     return comp, conns
@@ -263,7 +269,7 @@ def _handler_for(key: str) -> Optional[Handler]:
         return _seed_mpu6886
     if key.startswith("lora_sx1276"):
         return _seed_sx127x
-    if key.startswith("gps_neo6m"):
+    if key.startswith("gps_"):
         return _seed_gps
     if key == "battery_adc":
         return _seed_battery_adc


### PR DESCRIPTION
## What

Makes the Heltec WiFi LoRa 32 V4's GNSS connector usable without hand-wiring, and drives its power-enable pin so the module actually powers up under LoRaWAN.

Motivation: on a V4, seeding the board left the SH1.25-8 GNSS connector unmapped (GPS had to be added and wired manually), an inspector search for "GNSS" found nothing, and even a hand-wired GPS stayed dark because GPS_EN was never driven.

## Changes

- **Auto-wire GNSS pins.** New `gps_gnss` onboard peripheral on the V4 board -> seeding auto-places a GPS on the correct UART (MCU rx `GPIO38`, tx `GPIO39`). Pins verified against Meshtastic's `heltec_v4/variant.h` (`GPS_TX_PIN=38` toward CPU, `GPS_RX_PIN=39` toward GPS), not guessed.
- **Generalize the seed handler** to match any `gps_*` peripheral key (t-beam's `gps_neo6m` still matches).
- **Drive GPS power-enable.** The seed carries the board's GNSS enable pin (`GPS_EN`, GPIO34, active low) into `uart_gps`'s LoRaWAN setup fragment, which now emits `pinMode(34, OUTPUT); digitalWrite(34, LOW)` so the module powers on.
- **Discoverability.** `uart_gps` gains `gnss`/`gps`/`uc6580`/`ublox` aliases + a `gnss` use-case, and a name that mentions GNSS/UC6580.

## Notes

- The V4's `lora_sx1262`/`rf_fem` onboard-seed warnings remain (cosmetic; the radio + FEM are handled by the LoRaWAN RadioLib path and by Meshtastic firmware, not the generic ESPHome seed).
- Enable-pin driving is on the LoRaWAN path only; a generic-ESPHome GPS on this board would still need an always-on GPIO output.
- V4 vs V4-R8 note for future work: the R8 is a separate Meshtastic variant (`heltec-v4-r8-oled`) and uses `GPS_EN` on GPIO42, not 34. This PR covers the non-R8 V4.

## Tests

Full suite green (897 passed, 13 skipped). Added: V4 GNSS UART crossover, seeded-V4 firmware enable+FEM init, V4 in the seed-render matrix. Regenerated the `wemosgps` ASCII golden for the new component name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)