### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute bus type lookups in WiringView

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Single-Pass Collection Building
 **Learning:** Chained array methods like `.filter().map()` inside `useMemo` still allocate intermediate arrays in JavaScript, causing unnecessary garbage collection overhead when building Sets or Maps.
 **Action:** Use single-pass `for...of` loops when building Sets or Maps from arrays to avoid intermediate allocations.
+
+## 2024-07-27 - O(N) Lookups in Render Loops
+**Learning:** Using `.find()` to lookup values in an array from inside a `.map()` or a `for` loop executing during rendering creates an O(N^2) time complexity bottleneck. In `buildModel` (WiringView.tsx), looking up a bus type by its ID via `.find()` across all components and connections repeatedly scanned the `buses` array.
+**Action:** Pre-compute lookup maps (e.g., `Map<id, value>`) before loops to achieve O(1) lookups during heavy data processing or rendering.

--- a/web/src/components/WiringView.tsx
+++ b/web/src/components/WiringView.tsx
@@ -302,6 +302,11 @@ function buildModel(design: Design) {
     boardRowY.set(r.net!, TOP + HEAD_H + PAD_Y + i * ROW_H + ROW_H / 2);
   });
 
+  const busTypeMap = new Map<string, string>();
+  for (const b of buses) {
+    busTypeMap.set(b.id, b.type);
+  }
+
   let busY = TOP;
   const busRowY = new Map<string, Map<string, number>>();
   for (const b of buses) {
@@ -368,7 +373,7 @@ function buildModel(design: Design) {
               ? "fill-amber-400"
               : "fill-rose-400"
           : c.target?.kind === "bus"
-            ? busClass(buses.find((b) => b.id === c.target!.bus_id)?.type ?? "")
+            ? busClass(busTypeMap.get(String(c.target!.bus_id)) ?? "")
                 .replace("stroke-", "fill-")
             : "fill-accent-400",
     }));
@@ -420,7 +425,7 @@ function buildModel(design: Design) {
             y1,
             x2: BUS_X + CARD_W,
             y2,
-            cls: busClass(buses.find((b) => b.id === c.target!.bus_id)?.type ?? ""),
+            cls: busClass(busTypeMap.get(String(c.target!.bus_id)) ?? ""),
             net,
           });
         }


### PR DESCRIPTION
💡 **What:** Added a `busTypeMap` in `web/src/components/WiringView.tsx` to pre-compute bus types by ID, replacing multiple array `.find()` calls inside the component and connection loops within `buildModel`.

🎯 **Why:** `buildModel` iterates over all connections across all components to build the visual nodes and edges. Previously, for bus connections, it repeatedly called `.find()` on the `buses` array to look up the `type` for styling (e.g. `buses.find(b => b.id === bus_id)`). Calling `.find()` inside a loop makes the operation O(C * B) where C is connections and B is buses, creating unnecessary CPU work during renders when graphs get larger.

📊 **Impact:** Reduces time complexity for bus type lookups from O(N^2) to O(N) (or O(1) per lookup). This cuts down repetitive array scans, directly improving rendering speeds for complex designs with many bus connections.

🔬 **Measurement:** Verify by running large designs containing multiple components sharing I2C/SPI buses (like sensor hubs). The diagram should render more snappily. Additionally, verify `npm run test` passes correctly (done).

---
*PR created automatically by Jules for task [33195199440923261](https://jules.google.com/task/33195199440923261) started by @moellere*