### PR TITLE
CircuitPython flash option + starter code.py; documentation sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CircuitPython flashing.** The unified flash dialog gains a CircuitPython
+  framework: `GET /circuitpython/firmware?board=` proxies the official
+  release image from downloads.circuitpython.org (combined binary, flashed
+  at 0x0 with full erase over the same WebSerial/esptool-js mechanism),
+  resolving the newest stable version from the adafruit/circuitpython
+  releases API. All 22 ESP32/S3/C3/C6 boards map to a verified build --
+  exact where upstream has one (Heltec V3, M5Stack Atom family, XIAO,
+  SuperMinis, devkits), a pin-compatible generic image otherwise (flagged
+  in the status response and warned about in the UI). ESP8266 boards are
+  unsupported (CircuitPython dropped the port).
+- **Starter code.py.** `GET /circuitpython/code?board=` generates a
+  dependency-free starter from the board's library metadata -- Vext
+  power-up, onboard-LED blink, default-I2C scan, and a boot-time pin
+  listing. The flash dialog shows it post-flash with save-to-CIRCUITPY
+  (File System Access API) and download buttons.
+
+### Changed
+
+- **Documentation sweep.** README / docs index / user guide / library
+  reference / integrations / deployment / web README brought current:
+  the five-framework flash dialog, firmware-proxy endpoints, module map
+  (seed, intent, inventory, jlcpcb), the boards and components added
+  since 0.19 (SuperMinis, XIAO C3, TTGO LoRa32 V2.1, steppers/fans/
+  potentiometer/Grove AHT20/AXP192), version examples bumped to 0.23.0,
+  and stale claims removed (web UI persistence, test counts, shipped
+  PCB milestones still listed as future).
+
 ## [0.23.0] — 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ join-status polling all from the web UI. Both paths target US915 radio
 boards (TTGO T-Beam / LoRa32, Heltec WiFi LoRa 32 V2 / V3 / V4) and
 provision against ChirpStack.
 
+One flash dialog covers five firmware frameworks over the same
+WebSerial + esptool-js mechanism: **ESPHome** (OTA via fleet push),
+**Tasmota** (official release image + template push over serial),
+**LoRaWAN** (compiled RadioLib firmware), **Meshtastic** (official
+release factory image for the radio boards), and **CircuitPython**
+(official release image plus a generated starter `code.py` for the
+CIRCUITPY drive).
+
 Not affiliated with the ESPHome project — see
 [`weirded/fleet-for-esphome`](https://github.com/weirded/fleet-for-esphome)
 for the OTA-deploy companion this studio's **Push to fleet** flow
@@ -48,7 +56,7 @@ Detailed docs live in [`docs/`](docs/):
 
 ## Status
 
-`v0.19.1` — on PyPI (`pip install wirestudio`). The studio has wide
+`v0.23.0` — on PyPI (`pip install wirestudio`). The studio has wide
 surface area (YAML, schematic, PCB + fab outputs, enclosure, agent,
 MCP server, fleet handoff, web UI, two LoRaWAN flash/provision paths —
 standalone Arduino and an external-component path that emits ESPHome
@@ -72,6 +80,7 @@ Tiers, in priority order:
 | **Works (hardware-validated)** | LoRaWAN target | build RadioLib + LoRaWAN_ESP32 firmware for US915 radio boards, flash over WebSerial, provision against ChirpStack | every radio board's firmware builds in CI ([gate](.github/workflows/lorawan-firmware.yml)); validated end-to-end on a TTGO T-Beam and Heltec WiFi LoRa 32 V2 and V3 against live ChirpStack 4.17 — no automated live-device gate |
 | **Verified** | Tasmota target | emit a Tasmota device template (`/tasmota/template`) mapping solved pins to Tasmota GPIO function ids | function ids + per-chip layouts sourced from `tasmota_template.h`; unit tests pin the Sonoff S31 template convention for the smart-plug example |
 | **Works (lighter checks)** | Meshtastic flashing | proxy the official release factory image (`/meshtastic/firmware`) for the radio boards and flash it via the unified WebSerial dialog | endpoint tests with mocked upstream; board-to-variant map checked against `meshtastic/firmware` variants; no live-flash gate |
+| **Works (lighter checks)** | CircuitPython flashing | proxy the official release image (`/circuitpython/firmware`) for ESP32/S3/C3/C6 boards, flash via the unified dialog, serve a generated starter `code.py` (`/circuitpython/code`) | endpoint tests with mocked upstream; every board-id mapping verified against downloads.circuitpython.org; generated starters parse as valid Python; no live-flash gate |
 | **Works (lighter checks)** | MCP server | drive the design tools from Claude Code / Desktop over the Model Context Protocol | tool / auth / resource tests in `tests/test_mcp_*.py`; not exercised against a live MCP client in CI |
 | **Experimental** | Thingiverse search relay | rank community models for a board | smoke-tested; depends on a third-party search API that ranks unevenly |
 | **Experimental** | Agent (Claude tool-using) | natural-language design driving | works in practice; tool surface is small; no auto-eval against task list yet |
@@ -97,7 +106,7 @@ that pin moves, this line moves with it.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:0.19.1
+  ghcr.io/moellere/wirestudio:0.23.0
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +
@@ -140,7 +149,7 @@ The [User guide](docs/user_guide.md) walks the panes and header actions.
 ## Tests
 
 ```sh
-python -m pytest                          # ~680 cases
+python -m pytest                          # ~900 cases
 python -m ruff check .                    # lint
 cd web && npx vitest run                  # vitest + jsdom
 pip install 'esphome==2025.12.7'

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,7 +11,7 @@ FastAPI serves the API and the built SPA from one process.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:0.19.1
+  ghcr.io/moellere/wirestudio:0.23.0
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +
@@ -23,12 +23,12 @@ Available tags:
 
 | Tag | What it tracks |
 |---|---|
-| `:0.19.1` / `:0.19` / `:latest` | the v0.19.0 release |
+| `:0.23.0` / `:0.23` / `:latest` | the v0.23.0 release |
 | `:main` | latest commit on `main` (rolling) |
 | `:sha-<short>` | a specific commit |
-| `:<tag>-lorawan` (e.g. `:main-lorawan`, `:0.19.1-lorawan`) | same image **plus** the LoRaWAN compile worker (PlatformIO baked in) — see below |
-| `:<tag>-pcb` (e.g. `:main-pcb`, `:0.19.1-pcb`) | the PCB toolchain variant: KiCad 8 (kicad-cli + pcbnew), the pinned symbol/footprint libraries, a JRE, and Freerouting — everything the board/fab/autoroute endpoints gate on — see below |
-| `:<tag>-full` (e.g. `:main-full`, `:0.19.1-full`) | the every-feature image prod runs: `-pcb` **plus** the LoRaWAN compile worker (PlatformIO + prewarmed espressif32) |
+| `:<tag>-lorawan` (e.g. `:main-lorawan`, `:0.23.0-lorawan`) | same image **plus** the LoRaWAN compile worker (PlatformIO baked in) — see below |
+| `:<tag>-pcb` (e.g. `:main-pcb`, `:0.23.0-pcb`) | the PCB toolchain variant: KiCad 8 (kicad-cli + pcbnew), the pinned symbol/footprint libraries, a JRE, and Freerouting — everything the board/fab/autoroute endpoints gate on — see below |
+| `:<tag>-full` (e.g. `:main-full`, `:0.23.0-full`) | the every-feature image prod runs: `-pcb` **plus** the LoRaWAN compile worker (PlatformIO + prewarmed espressif32) |
 
 All feature-gating env vars are optional — the studio runs without any
 of them, just with the corresponding feature turned off. See
@@ -97,7 +97,7 @@ so both run side by side from one source tree with independent PVCs.
 
 | App | Overlay | Image | Upgrades when |
 |---|---|---|---|
-| `wirestudio-prod` | `deploy/overlays/prod` | pinned release, e.g. `:0.19.1` | the tag changes in git (bump by hand or via image-updater) |
+| `wirestudio-prod` | `deploy/overlays/prod` | pinned release, e.g. `:0.23.0-full` | the tag changes in git (bump by hand or via image-updater) |
 | `wirestudio-dev` | `deploy/overlays/dev` | rolling `:main-lorawan` | image-updater digest-pins a new `main` build |
 
 ```sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,16 +27,21 @@ under upstream ESPHome.
   ┌─ wirestudio.model         pydantic models mirroring the schema
   ├─ wirestudio.library       loads boards/ + components/ YAML
   ├─ wirestudio.generate      design + library → ESPHome YAML + ASCII
-  ├─ wirestudio.targets       generation targets: esphome (wraps generate) + lorawan
+  ├─ wirestudio.targets       generation targets: esphome (wraps generate) + lorawan + tasmota
   ├─ wirestudio.csp           pin solver + port-compatibility checker
   ├─ wirestudio.recommend     deterministic capability ranking
+  ├─ wirestudio.seed          board onboard-peripheral auto-placement
+  ├─ wirestudio.intent        automation (trigger/action) validation + lowering
+  ├─ wirestudio.inventory     owned-parts inventory store
   ├─ wirestudio.agent         Claude tool-using agent + session store
   ├─ wirestudio.designs       file-backed designs/<id>.json store
   ├─ wirestudio.fleet         fleet-for-esphome HTTP client
   ├─ wirestudio.enclosure     parametric OpenSCAD + Thingiverse search
-  ├─ wirestudio.kicad         SKiDL schematic emitter + .kicad_sym importer
+  ├─ wirestudio.kicad         SKiDL schematic emitter, PCB emit/route, .kicad_sym importer
+  ├─ wirestudio.jlcpcb        fab outputs (BOM / CPL / Gerber + drill)
   ├─ wirestudio.mcp           MCP server over the agent tool surface
-  └─ wirestudio.api           FastAPI HTTP layer (mounts everything above)
+  └─ wirestudio.api           FastAPI HTTP layer (mounts everything above,
+                              plus the meshtastic + circuitpython firmware proxies)
                           serve.py adds the production wrapper:
                           API at /api/*, web bundle at /
 ```
@@ -55,7 +60,7 @@ reads.
 wirestudio/              python package — see Architecture above for the module map
 wirestudio/schema/       JSON Schema for design.json (source of truth)
 wirestudio/library/      board + component manifests (electrical, ESPHome, enclosure, kicad)
-wirestudio/targets/      generation targets: esphome + lorawan (firmware gen, ChirpStack, compile)
+wirestudio/targets/      generation targets: esphome + lorawan (firmware gen, ChirpStack, compile) + tasmota (device template)
 wirestudio/examples/     bundled design.json files (every one pinned by goldens)
 web/                     React 19 + Vite + Tailwind v4 SPA
 tests/                   pytest + golden artifacts; vitest tests under web/src
@@ -83,9 +88,10 @@ through upstream `esphome config`. Shipped: the `esphome config` CI
 gate over every bundled example; a nightly `esphome compile` smoke;
 the component-coverage matrix ([`library-coverage.md`](library-coverage.md))
 with a `--strict` no-regression gate now at **zero uncovered** (every
-one of the 60 components and 23 boards is exercised (esphome examples,
-or the lorawan firmware build for radio boards); a pinned ESPHome version called
-out in the README + workflow; an
+component and board is exercised — esphome examples, or the lorawan
+firmware build for radio boards — see
+[`library-coverage.md`](library-coverage.md) for the live counts); a
+pinned ESPHome version called out in the README + workflow; an
 [`esphome-matrix`](../.github/workflows/esphome-matrix.yml) compatibility
 report that runs the gate across the pin + latest stables so a pin bump
 is evidence-driven; CONTRIBUTING.md establishes the gate as the merge
@@ -153,11 +159,23 @@ nothing is generated from the design. Region/channel config is protobuf
 over serial, so the dialog links to client.meshtastic.org; an in-studio
 config push via `@meshtastic/js` stays in the backlog.
 
+**CircuitPython flashing (unreleased).** *Works.* The unified flash
+dialog gains a CircuitPython framework: `GET /circuitpython/firmware`
+proxies the official release image from downloads.circuitpython.org
+(combined binary at 0x0, full erase), resolving the newest stable from
+the adafruit/circuitpython releases API. Every ESP32/S3/C3/C6 board
+maps to a verified build — exact where upstream has one, a
+pin-compatible generic image otherwise (flagged in the status response
+and warned about in the UI); ESP8266 has no CircuitPython port.
+`GET /circuitpython/code` serves a starter code.py generated from the
+board's library metadata (Vext power-up, LED blink, I2C scan, pin
+listing) with save-to-CIRCUITPY and download buttons post-flash.
+
 **Target backlog.** Next: Meshtastic config push (`@meshtastic/js`
-region/channel/key setup over the existing serial session), then
-CircuitPython
-(emit a code.py scaffold with pin constants + driver init per
-component, the LoRaWAN-fragment pattern; timed with Adafruit outreach).
+region/channel/key setup over the existing serial session), then full
+CircuitPython code.py generation from the design (per-component driver
+init + Adafruit bundle libs, the LoRaWAN-fragment pattern — the
+interpreter flash + starter above is the shipped first step).
 Deliberately deferred: generic Arduino/PlatformIO scaffolds (per-driver
 maintenance sinkhole), Zephyr, Zigbee/Thread on the C6.
 
@@ -199,9 +217,8 @@ solver (`0.6`), fleet handoff (`0.7`), enclosure (`0.8`), KiCad
 schematic (`0.9`), MCP server + KiCad symbol importer (`0.10`),
 Docker single-image deploy + K8s manifest.
 
-**Future** — PCB layout (Priority 4): SKiDL → KiCad PCB, Freerouting,
-Gerber + JLCPCB export, now that the schematic is Verified; an agent
-eval harness scoring tool-use against a fixed task list (to promote the
-agent from Experimental); a multi-writer state backend so the studio
-can run as a HA replica; attributing `esphome-matrix` failures to
-specific components for per-release support tables.
+**Future** — an agent eval harness scoring tool-use against a fixed
+task list (to promote the agent from Experimental); a multi-writer
+state backend so the studio can run as a HA replica; attributing
+`esphome-matrix` failures to specific components for per-release
+support tables.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -96,7 +96,7 @@ pin map.
 ## LoRaWAN / ChirpStack
 
 Two paths for US915 radio boards — TTGO LoRa32 / T-Beam (SX1276), Heltec
-WiFi LoRa 32 V2 (SX1276) / V3 (SX1262).
+WiFi LoRa 32 V2 (SX1276) / V3 / V4 (SX1262).
 
 ### Standalone Arduino path (`Design.target: "lorawan"`)
 
@@ -166,6 +166,25 @@ sub-2. Multi-region is a tracked backlog item (safety-sensitive, so
 it's not half-shipped). The network server is ChirpStack v4 over gRPC;
 TTN / other servers aren't wired yet. The external-component path is
 hardware-join-verified pending a live test against a real gateway.
+
+## Firmware proxies (Tasmota / Meshtastic / CircuitPython)
+
+The unified flash dialog's non-ESPHome frameworks need no configuration
+— the server proxies the official upstream release images so the
+browser can flash them over WebSerial without CORS trouble:
+
+- **Tasmota** — `GET /tasmota/firmware?chip=` streams the release image
+  from ota.tasmota.com for the design's chip variant.
+- **Meshtastic** — `GET /meshtastic/firmware?board=` streams the factory
+  image from meshtastic.github.io for the mapped radio boards.
+- **CircuitPython** — `GET /circuitpython/firmware?board=` streams the
+  release image from downloads.circuitpython.org for ESP32/S3/C3/C6
+  boards; `GET /circuitpython/code?board=` serves a generated starter
+  `code.py`.
+
+Each has a `/firmware/status` endpoint reporting upstream reachability
+(and, for CircuitPython, which boards fall back to a pin-compatible
+generic image); the UI gates its flash buttons on it.
 
 ## MCP server
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -13,12 +13,17 @@ exercised by a bundled example, see
 - `esp32-devkitc-v4` — ESP32 DevKitC V4 (ESP32-WROOM-32, 4MB flash)
 - `nodemcu-32s` — NodeMCU-32S (ESP32-WROOM-32, marks I2S-capable pins)
 - `ttgo-lora32-v1` — LilyGO TTGO LoRa32 V1 (ESP32 + onboard SX1276 + onboard SSD1306)
+- `ttgo-lora32-v2` — TTGO LoRa32 V2.1 (T3 v1.6.1; ESP32 + SX1276 + SSD1306, own PlatformIO key)
 - `ttgo-t-beam` — LilyGO TTGO T-Beam v1.x (ESP32 + onboard SX1276 + NEO-6M GPS + AXP192 PMIC + 18650)
 - `heltec-wifi-lora32-v2` — Heltec WiFi LoRa 32 V2 (ESP32 + SX1276 + onboard SSD1306; LoRaWAN hardware-validated)
 - `heltec-wifi-lora32-v3` — Heltec WiFi LoRa 32 V3 (ESP32-S3 + SX1262 + onboard SSD1306; LoRaWAN hardware-validated)
 - `heltec-wifi-lora32-v4` — Heltec WiFi LoRa 32 V4 (ESP32-S3R2 + SX1262 + GC1109/KCT8103L PA to 28dBm + onboard SSD1315)
 - `esp32-c3-devkitm-1` — ESP32-C3-DevKitM-1 (single-core RISC-V, USB-Serial-JTAG, onboard WS2812)
+- `esp32-c3-supermini` — ESP32-C3 SuperMini (tiny C3 breakout, onboard status LED)
+- `esp32-c6-supermini` — ESP32-C6 SuperMini (WiFi 6 / Zigbee-capable C6, onboard WS2812)
 - `esp32-s3-devkitc-1` — ESP32-S3-DevKitC-1 (dual-core Xtensa, native USB, onboard WS2812)
+- `esp32-s3-supermini` — ESP32-S3 SuperMini (compact S3 breakout, onboard WS2812)
+- `seeed-xiao-esp32c3` — Seeed Studio XIAO ESP32C3 (thumbnail-size C3 with Grove ecosystem)
 - `esp32cam-ai-thinker` — AI-Thinker ESP32-CAM (ESP32-WROVER-B + OV2640 + microSD)
 - `esp32-wrover-cam` — ESP32-WROVER-CAM (Freenove-style, OV2640 with the WROVER pinout)
 - `m5stack-atom` — M5Stack Atom Lite / Echo (ESP32-PICO-D4, 24mm cube, onboard SK6812)
@@ -44,6 +49,7 @@ _Environmental sensors:_
 - `htu21d` — TE Connectivity HTU21D temperature + humidity (I2C; covers Si7021 / SHT2x)
 - `sht3xd` — Sensirion SHT3x / SHT4x precision temp + humidity (I2C; modern default)
 - `aht10` — Aosong AHT10 / AHT20 cheap temp + humidity (I2C; AliExpress weather modules)
+- `grove-aht20` — Seeed Grove AHT20 temp + humidity (I2C; plug-in Grove module)
 - `ds18b20` — Dallas DS18B20 1-Wire temperature sensor (single-pin bus + 4.7kΩ pull-up)
 - `bh1750` — BH1750FVI ambient light sensor in lux (I2C; GY-30 / GY-302 modules)
 
@@ -91,7 +97,13 @@ _Generic IO:_
 - `gpio_input` — generic binary_sensor on a GPIO or expander pin (buttons, limit switches, door/window/motion sensors)
 - `gpio_output` — generic switch on a GPIO or expander pin (relays, indicators)
 - `adc` — generic analog input (battery monitoring, potentiometers, LDRs)
+- `potentiometer` — analog knob / slider on an ADC pin
 - `pulse_counter` — pulse counter / tachometer (RPM, flow, energy meters)
+
+_Actuators / power:_
+- `uln2003` — ULN2003 stepper driver for the 28BYJ-48 geared stepper
+- `pwm_fan` — 12V 4-wire PWM fan with tachometer feedback
+- `axp192` — X-Powers AXP192 PMIC (T-Beam battery/rail management; no ESPHome core component yet)
 
 _Light / audio / camera:_
 - `ws2812b` — WS2812B / SK6812 addressable RGB LED (1-wire NeoPixel; bit-banged or ESP8266-DMA)

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -27,8 +27,18 @@
   parametric OpenSCAD enclosure (`.scad`), and a SKiDL Python script
   the user runs locally to produce a `.kicad_sch`. Bundled examples
   pinned as goldens.
+- **Flash.** One flash dialog (**Flash firmware**, radio icon) covers
+  five frameworks over the same WebSerial + esptool-js mechanism:
+  **ESPHome** hands off to the fleet push (OTA, no serial flash),
+  **Tasmota** fetches the official release image for the design's chip
+  and offers a post-flash template + WiFi push over serial,
+  **LoRaWAN** compiles and flashes the RadioLib firmware,
+  **Meshtastic** flashes the official factory image for the mapped
+  radio boards (config happens at client.meshtastic.org), and
+  **CircuitPython** flashes the official release image and serves a
+  generated starter `code.py` (save-to-CIRCUITPY or download).
 - **LoRaWAN (radio boards).** Two flows for US915 radio boards (TTGO
-  LoRa32 / T-Beam, Heltec WiFi LoRa 32 V2 / V3):
+  LoRa32 / T-Beam, Heltec WiFi LoRa 32 V2 / V3 / V4):
   - **Flash LoRaWAN firmware** (radio icon, advanced mode) builds the
     standalone RadioLib + LoRaWAN_ESP32 path and flashes over WebSerial
     with runtime serial provisioning. Hardware-validated.
@@ -63,9 +73,12 @@ Inspector surfaces:
 
 Header buttons: **New design**, **Reset**, **Save**, **Download JSON**,
 **Solve pins**, **strict** (toggle), **Connect device** (USB
-bootstrap), **Add by function** (capability picker), **Schematic**
-(KiCad export), **Enclosure** (parametric `.scad` + Thingiverse
-search), **Push to fleet**, **Settings** (gear).
+bootstrap), **Add by function** (capability picker), **Flash firmware**
+(the unified flash dialog), **Provision LoRaWAN device** (key icon),
+**Schematic** (KiCad export), **Enclosure** (parametric `.scad` +
+Thingiverse search), **Push to fleet**, **Agent** (chat sidebar),
+**Settings** (gear). Advanced mode reveals the Agent, Schematic,
+Enclosure, and Fleet options.
 
 The **Settings** dialog surfaces the MCP bearer token: reveal, copy, or
 regenerate it without leaving the browser (read-only when the token is
@@ -94,6 +107,15 @@ pinned via `WIRESTUDIO_MCP_TOKEN`). See [the MCP guide](mcp.md#auth).
 | `GET`  | `/fleet/jobs/{run_id}` | aggregated compile verdict for a Push-to-fleet run |
 | `GET`  | `/fleet/jobs/{run_id}/log?offset=N` | poll the addon's build log for a compile run; returns `{log, offset, finished}` |
 | `GET`  | `/fleet/jobs/{run_id}/log/stream` | Server-Sent Events relay over the same log endpoint; ~300ms cadence, exits with `event: done` when the build finishes |
+| `POST` | `/tasmota/template` | emit a Tasmota device template (solved pins → GPIO function ids) |
+| `GET`  | `/tasmota/firmware?chip=` | proxy the official Tasmota release image for the chip (`/tasmota/firmware/status` gates it) |
+| `GET`  | `/meshtastic/firmware?board=` | proxy the official Meshtastic factory image for a mapped radio board (`/meshtastic/firmware/status` gates it) |
+| `GET`  | `/circuitpython/firmware?board=` | proxy the official CircuitPython release image for an ESP32-family board (`/circuitpython/firmware/status` gates it, and flags generic-image fallbacks) |
+| `GET`  | `/circuitpython/code?board=` | starter `code.py` generated from the board's library metadata |
+
+The table above is a working subset — schematic/PCB/fab/route, LoRaWAN,
+designs, seed, inventory, and agent endpoints are all in the
+auto-generated OpenAPI docs, which are authoritative.
 
 The HTTP API is a thin layer over the studio's pure-function modules
 (`wirestudio.generate`, `wirestudio.csp`, `wirestudio.recommend`, `wirestudio.fleet`,

--- a/tests/test_circuitpython.py
+++ b/tests/test_circuitpython.py
@@ -1,0 +1,111 @@
+from fastapi.testclient import TestClient
+
+from wirestudio.api.app import create_app
+import wirestudio.api.circuitpython as C
+
+
+def test_status_reports_boards_version_and_generic(monkeypatch):
+    monkeypatch.setattr(C, "_latest_stable", lambda: "10.2.1")
+    client = TestClient(create_app())
+    body = client.get("/circuitpython/firmware/status").json()
+    assert body["available"] is True
+    assert body["version"] == "10.2.1"
+    assert "heltec-wifi-lora32-v3" in body["boards"]
+    assert "wemos-d1-mini" not in body["boards"]  # esp8266: no CP port
+    # V4 flashes the V3 image (same substitution as the PlatformIO key).
+    assert "heltec-wifi-lora32-v4" in body["generic"]
+    assert body["images"]["heltec-wifi-lora32-v4"] == "heltec_esp32s3_wifi_lora_v3"
+    assert "heltec-wifi-lora32-v3" not in body["generic"]
+
+
+def test_status_degrades_when_release_lookup_unreachable(monkeypatch):
+    def boom():
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(C, "_latest_stable", boom)
+    client = TestClient(create_app())
+    body = client.get("/circuitpython/firmware/status").json()
+    assert body["available"] is False
+    assert "offline" in body["reason"]
+
+
+def test_firmware_resolves_image_and_version(monkeypatch):
+    fetched = {}
+
+    def fake_fetch(url):
+        fetched["url"] = url
+        return b"CIRCUIT"
+
+    monkeypatch.setattr(C, "_latest_stable", lambda: "10.2.1")
+    monkeypatch.setattr(C, "_fetch_firmware", fake_fetch)
+    client = TestClient(create_app())
+    r = client.get("/circuitpython/firmware?board=m5stack-atoms3")
+    assert r.status_code == 200
+    assert r.content == b"CIRCUIT"
+    assert r.headers["x-flash-offset"] == "0"
+    assert fetched["url"] == (
+        f"{C._BIN_BASE}/m5stack_atoms3/en_US/"
+        "adafruit-circuitpython-m5stack_atoms3-en_US-10.2.1.bin"
+    )
+
+
+def test_firmware_explicit_version_skips_release_lookup(monkeypatch):
+    def boom():
+        raise RuntimeError("should not be called")
+
+    monkeypatch.setattr(C, "_latest_stable", boom)
+    monkeypatch.setattr(C, "_fetch_firmware", lambda url: b"CIRCUIT")
+    client = TestClient(create_app())
+    r = client.get("/circuitpython/firmware?board=esp32-devkitc-v4&version=v9.2.8")
+    assert r.status_code == 200
+
+
+def test_firmware_esp8266_board_422():
+    client = TestClient(create_app())
+    assert client.get("/circuitpython/firmware?board=wemos-d1-mini").status_code == 422
+
+
+def test_firmware_upstream_failure_502(monkeypatch):
+    monkeypatch.setattr(C, "_latest_stable", lambda: "10.2.1")
+
+    def boom(url):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(C, "_fetch_firmware", boom)
+    client = TestClient(create_app())
+    r = client.get("/circuitpython/firmware?board=esp32-devkitc-v4")
+    assert r.status_code == 502
+
+
+def test_code_serves_starter_for_board():
+    client = TestClient(create_app())
+    r = client.get("/circuitpython/code?board=heltec-wifi-lora32-v3")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/x-python")
+    body = r.text
+    assert "import board" in body
+    assert 'find_pin("LED", "IO35"' in body  # onboard LED from the board def
+    assert "IO36" in body  # Vext power-up
+
+
+def test_code_marks_generic_builds():
+    client = TestClient(create_app())
+    body = client.get("/circuitpython/code?board=heltec-wifi-lora32-v4").text
+    assert "no official CircuitPython build" in body
+    exact = client.get("/circuitpython/code?board=heltec-wifi-lora32-v3").text
+    assert "no official CircuitPython build" not in exact
+
+
+def test_code_unsupported_board_422():
+    client = TestClient(create_app())
+    assert client.get("/circuitpython/code?board=wemos-d1-mini").status_code == 422
+
+
+def test_code_generates_valid_python_for_every_board():
+    import ast
+
+    client = TestClient(create_app())
+    for board in C._BOARDS:
+        r = client.get(f"/circuitpython/code?board={board}")
+        assert r.status_code == 200, board
+        ast.parse(r.text)

--- a/web/README.md
+++ b/web/README.md
@@ -30,8 +30,6 @@ into an empty WeMos D1 Mini design also lays down `i2c0` on `D2/D1`).
 Digital GPIO pins land as empty placeholders that the connection editor
 shows as `(invalid: <unset>)` until you wire them.
 
-Drag-and-drop wiring and the agent sidebar are later iterations.
-
 Header buttons:
 - **Solve pins** runs the pin-assignment solver against the current
   design: every unbound connection (gpio with empty pin, bus with empty
@@ -76,6 +74,20 @@ Header buttons:
   The top match is badged "top pick" but the user is free to pick a
   different one — handy when you have a specific part on hand and
   want to use *that* sensor rather than the library default.
+- **Flash firmware** opens the unified flash dialog: a framework picker
+  (ESPHome / Tasmota / LoRaWAN / Meshtastic / CircuitPython) over one
+  WebSerial + esptool-js mechanism (`lib/flash.ts`). ESPHome hands off
+  to the fleet push; the others fetch their firmware through the
+  server's proxy endpoints and flash it, with per-framework post-flash
+  steps (Tasmota template/WiFi push over serial, CircuitPython starter
+  `code.py` with save-to-CIRCUITPY).
+- **Provision LoRaWAN device** drives the lorawan-for-esphome
+  external-component flow: detect DevEUI from eFuse MAC, mint keys
+  against ChirpStack, push to fleet with secrets inlined, poll the
+  OTAA join.
+- **Schematic** / **Enclosure** / **Settings** and the theme toggle
+  round out the header; advanced mode reveals Agent, Schematic,
+  Enclosure, and Fleet.
 
 ## Dev
 
@@ -111,18 +123,31 @@ src/
 │   ├── debounce.ts          # useDebouncedValue
 │   ├── design.ts            # immutable design helpers (params, connections,
 │   │                        # board, fleet, requirements, warnings, add/remove)
-│   ├── design.test.ts       # vitest unit tests covering the helpers
 │   ├── bootstrap.ts         # normalizeChipFamily + candidateBoardsFor + bootstrapDesign
-│   ├── bootstrap.test.ts    # vitest tests for the bootstrap helpers
-│   └── usb-detect.ts        # esptool-js wrapper (dynamic-imported)
+│   ├── usb-detect.ts        # esptool-js chip detect (dynamic-imported)
+│   ├── flash.ts             # WebSerial flashing + serial monitor (esptool-js)
+│   ├── provision.ts         # LoRaWAN DevEUI derivation + provisioning helpers
+│   ├── tasmota.ts           # Tasmota template → Backlog console commands
+│   ├── theme.ts / uiMode.ts # theme toggle + basic/advanced mode
+│   └── *.test.ts            # vitest units alongside each module
 ├── components/
-│   ├── LeftSidebar.tsx      # tabs: Examples / Boards / Components, with search
+│   ├── LeftSidebar.tsx      # tabs: Examples / Saved / Boards / Components, with search
 │   ├── DesignPane.tsx       # tabs: ASCII / YAML / JSON; design metadata header
+│   ├── WiringView.tsx / PinoutView.tsx  # wiring diagram + drag-and-drop pinout
+│   ├── ServerRenderView.tsx # schematic/PCB raster previews
 │   ├── Inspector.tsx        # routes between design / board / component / instance views
 │   ├── ParamForm.tsx        # form generated from params_schema
 │   ├── ConnectionForm.tsx   # per-connection editor (rail/gpio/bus/expander_pin)
+│   ├── BusList.tsx          # bus add/rename/edit with compat warnings
 │   ├── UsbDetectDialog.tsx  # WebSerial chip-detect modal + bootstrap picker
-│   ├── AgentSidebar.tsx     # Claude agent chat drawer; replaces the working design on each turn
+│   ├── NewDesignDialog.tsx  # fresh design from a board (seeds onboard parts)
+│   ├── CapabilityPickerDialog.tsx  # Add by function picker
+│   ├── FlashDialog.tsx      # unified flash dialog (ESPHome/Tasmota/LoRaWAN/Meshtastic/CircuitPython)
+│   ├── LorawanFlashDialog.tsx      # standalone LoRaWAN compile-flash-provision flow
+│   ├── LorawanProvisionEsphomeDialog.tsx  # external-component provision + join polling
+│   ├── PushToFleetDialog.tsx       # fleet push + compile log tail
+│   ├── SchematicDialog.tsx / EnclosureDialog.tsx / InventoryDialog.tsx / SettingsDialog.tsx
+│   ├── AgentSidebar.tsx     # Claude agent chat drawer (streamed tool calls)
 │   └── SolveResultBanner.tsx  # transient banner surfacing assignments + warnings from /design/solve_pins
 ├── App.tsx                  # state + data flow; three-pane grid
 ├── main.tsx
@@ -136,18 +161,17 @@ npm test            # vitest, runs once
 npm run test:watch  # watch mode
 ```
 
-Currently 49 tests across `lib/design.ts` (immutable patch helpers,
-isDirty, readers, add/remove with auto-wiring + auto-bus) and
-`lib/bootstrap.ts` (chip-family normalization, board candidate
-matching, bootstrap-design shape). Component-level RTL tests are a
-future iteration once we set up jsdom; the WebSerial flow gets
-manual test only because there's no headless ESP.
+~200 tests across the `lib/` helpers (design patching, bootstrap,
+flash, provision, tasmota) and component-level RTL suites under jsdom
+(Inspector, FlashDialog, provisioning dialogs, API client). The actual
+WebSerial write path gets manual testing only — there's no headless
+ESP.
 
 ## Editing model
 
-- The current design is held entirely in browser state. There is no
-  `/design/save` endpoint and no persistence; modifications stay local
-  until you hit Download JSON.
+- The current design is held in browser state; **Save** persists it to
+  the server's designs store (`designs/<id>.json`, listed under the
+  **Saved** tab), and **Download JSON** exports it to disk.
 - Every edit goes through `updateComponentParam` (in `lib/design.ts`),
   which never mutates -- it returns a new design with the targeted
   `params` key changed.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -216,6 +216,27 @@ export const api = {
     const offset = parseInt(res.headers.get("x-flash-offset") ?? "0", 10) || 0;
     return { data: new Uint8Array(await res.arrayBuffer()), offset };
   },
+  circuitpythonFirmwareStatus: () =>
+    request<{
+      available: boolean;
+      version: string | null;
+      boards: string[];
+      generic: string[];
+      images: Record<string, string>;
+      reason: string | null;
+    }>("/circuitpython/firmware/status"),
+  circuitpythonFirmware: async (board: string): Promise<{ data: Uint8Array; offset: number }> => {
+    const res = await fetch(`${API_BASE}/circuitpython/firmware?board=${encodeURIComponent(board)}`);
+    if (!res.ok) {
+      let body: unknown = undefined;
+      try { body = await res.json(); } catch { /* not json */ }
+      throw new ApiError(res.status, apiErrorMessage("GET", "/circuitpython/firmware", res.status, body), body);
+    }
+    const offset = parseInt(res.headers.get("x-flash-offset") ?? "0", 10) || 0;
+    return { data: new Uint8Array(await res.arrayBuffer()), offset };
+  },
+  circuitpythonCode: (board: string) =>
+    requestText(`/circuitpython/code?board=${encodeURIComponent(board)}`),
   kicadRouteStatus: () =>
     request<KicadRouteStatus>("/design/kicad/route/status"),
   kicadRoutedBoard: (cacheKey: string) =>

--- a/web/src/components/FlashDialog.test.tsx
+++ b/web/src/components/FlashDialog.test.tsx
@@ -22,6 +22,9 @@ vi.mock("../api/client", async () => {
       tasmotaFirmware: vi.fn(),
       meshtasticFirmwareStatus: vi.fn(),
       meshtasticFirmware: vi.fn(),
+      circuitpythonFirmwareStatus: vi.fn(),
+      circuitpythonFirmware: vi.fn(),
+      circuitpythonCode: vi.fn(),
     },
   };
 });
@@ -36,6 +39,9 @@ const mockApi = api as unknown as {
   tasmotaFirmware: ReturnType<typeof vi.fn>;
   meshtasticFirmwareStatus: ReturnType<typeof vi.fn>;
   meshtasticFirmware: ReturnType<typeof vi.fn>;
+  circuitpythonFirmwareStatus: ReturnType<typeof vi.fn>;
+  circuitpythonFirmware: ReturnType<typeof vi.fn>;
+  circuitpythonCode: ReturnType<typeof vi.fn>;
 };
 
 const design: Design = {
@@ -70,6 +76,18 @@ beforeEach(() => {
     boards: ["heltec-wifi-lora32-v3", "ttgo-t-beam"],
     reason: null,
   });
+  mockApi.circuitpythonFirmwareStatus.mockReset().mockResolvedValue({
+    available: true,
+    version: "10.2.1",
+    boards: ["heltec-wifi-lora32-v3", "heltec-wifi-lora32-v4"],
+    generic: ["heltec-wifi-lora32-v4"],
+    images: {
+      "heltec-wifi-lora32-v3": "heltec_esp32s3_wifi_lora_v3",
+      "heltec-wifi-lora32-v4": "heltec_esp32s3_wifi_lora_v3",
+    },
+    reason: null,
+  });
+  mockApi.circuitpythonCode.mockReset().mockResolvedValue("import board\n");
 });
 
 function renderDialog(overrides: Partial<Parameters<typeof FlashDialog>[0]> = {}) {
@@ -127,6 +145,31 @@ describe("FlashDialog", () => {
       expect(screen.getByText(/no meshtastic firmware mapping/i)).toBeInTheDocument(),
     );
     expect(screen.getByRole("button", { name: /flash meshtastic/i })).toBeDisabled();
+  });
+
+  it("circuitpython rejects unsupported (esp8266) boards", async () => {
+    renderDialog();
+    await userEvent.click(screen.getByRole("button", { name: /circuitpython/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/no circuitpython build for/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /flash circuitpython/i })).toBeDisabled();
+  });
+
+  it("circuitpython enables flashing and warns on a generic image", async () => {
+    const v4Design = {
+      ...design,
+      board: { library_id: "heltec-wifi-lora32-v4", mcu: "esp32s3" },
+    } as Design;
+    const v4Boards = [
+      { id: "heltec-wifi-lora32-v4", name: "Heltec V4", chip_variant: "esp32s3" } as BoardSummary,
+    ];
+    renderDialog({ design: v4Design, boards: v4Boards });
+    await userEvent.click(screen.getByRole("button", { name: /circuitpython/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /flash circuitpython/i })).toBeEnabled(),
+    );
+    expect(screen.getByText(/no official circuitpython build/i)).toBeInTheDocument();
   });
 
   it("meshtastic enables flashing for a supported board", async () => {

--- a/web/src/components/FlashDialog.tsx
+++ b/web/src/components/FlashDialog.tsx
@@ -7,13 +7,14 @@ import { tasmotaConfigCommands, type TasmotaTemplate } from "../lib/tasmota";
 import { Button, Dialog, FieldLabel, Input } from "./ui";
 import { LorawanFlashDialog } from "./LorawanFlashDialog";
 
-type Framework = "esphome" | "tasmota" | "lorawan" | "meshtastic";
+type Framework = "esphome" | "tasmota" | "lorawan" | "meshtastic" | "circuitpython";
 
 const FRAMEWORKS: Array<{ id: Framework; label: string; note: string; disabled?: boolean }> = [
   { id: "esphome", label: "ESPHome", note: "OTA via fleet-for-esphome; no serial flash needed" },
   { id: "tasmota", label: "Tasmota", note: "official release image + template push over serial" },
   { id: "lorawan", label: "LoRaWAN", note: "compile RadioLib firmware, flash, provision" },
   { id: "meshtastic", label: "Meshtastic", note: "official release image; configure via client.meshtastic.org" },
+  { id: "circuitpython", label: "CircuitPython", note: "official release image + starter code.py for the CIRCUITPY drive" },
 ];
 
 interface Props {
@@ -80,6 +81,10 @@ export function FlashDialog({ design, boards, onClose, onOpenFleet }: Props) {
 
         {framework === "meshtastic" && (
           <MeshtasticFlash design={design} boards={boards} />
+        )}
+
+        {framework === "circuitpython" && (
+          <CircuitPythonFlash design={design} boards={boards} />
         )}
       </div>
     </Dialog>
@@ -196,6 +201,197 @@ function MeshtasticFlash({ design, boards }: { design: Design | null; boards: Bo
             client.meshtastic.org
           </a>{" "}
           (Serial connection) after closing this dialog to free the port.
+        </div>
+      )}
+
+      {serial && (
+        <pre className="max-h-40 overflow-auto rounded-lg bg-surface-0 p-2 font-mono text-[11px] leading-snug text-emerald-300/90 ring-1 ring-line">
+          {serial}
+        </pre>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-rose-500/40 bg-rose-500/10 p-3 text-xs text-rose-200 whitespace-pre-wrap">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type CircuitPythonPhase = "idle" | "fetching" | "flashing" | "flashed";
+
+function CircuitPythonFlash({ design, boards }: { design: Design | null; boards: BoardSummary[] | null }) {
+  const [status, setStatus] = useState<{
+    available: boolean;
+    version: string | null;
+    boards: string[];
+    generic: string[];
+    images: Record<string, string>;
+    reason: string | null;
+  } | null>(null);
+  const [phase, setPhase] = useState<CircuitPythonPhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<number>(0);
+  const [log, setLog] = useState<string[]>([]);
+  const [serial, setSerial] = useState<string>("");
+  const [starter, setStarter] = useState<string | null>(null);
+  const [saved, setSaved] = useState<string | null>(null);
+  const sessionRef = useRef<FlashSession | null>(null);
+
+  const boardLibraryId = String((design?.board as Record<string, unknown> | undefined)?.library_id ?? "");
+  const board = useMemo(
+    () => (boards ?? []).find((b) => b.id === boardLibraryId) ?? null,
+    [boards, boardLibraryId],
+  );
+  const supported = status?.boards.includes(boardLibraryId) ?? false;
+  const generic = status?.generic.includes(boardLibraryId) ?? false;
+  const image = status?.images[boardLibraryId];
+
+  useEffect(() => {
+    let cancelled = false;
+    api.circuitpythonFirmwareStatus()
+      .then((s) => { if (!cancelled) setStatus(s); })
+      .catch((e) => {
+        if (!cancelled) {
+          setStatus({ available: false, version: null, boards: [], generic: [], images: {}, reason: e instanceof Error ? e.message : String(e) });
+        }
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (!supported) { setStarter(null); return; }
+    let cancelled = false;
+    api.circuitpythonCode(boardLibraryId)
+      .then((code) => { if (!cancelled) setStarter(code); })
+      .catch(() => { if (!cancelled) setStarter(null); });
+    return () => { cancelled = true; };
+  }, [supported, boardLibraryId]);
+
+  useEffect(() => () => { void sessionRef.current?.close(); }, []);
+
+  function appendLog(line: string) {
+    setLog((l) => [...l.slice(-200), line]);
+  }
+
+  async function handleFlash() {
+    setError(null);
+    setPhase("fetching");
+    try {
+      const { data, offset } = await api.circuitpythonFirmware(boardLibraryId);
+      appendLog(`fetched CircuitPython ${status?.version ?? "release"} image (${(data.length / 1024).toFixed(0)} KiB)`);
+      setPhase("flashing");
+      const session = await flashFirmware({
+        images: [{ data, address: offset }],
+        eraseAll: true,
+        onProgress: (written, total) => setProgress(total ? written / total : 0),
+        onLog: appendLog,
+        onSerial: (text) => setSerial((s) => (s + text).slice(-8000)),
+      });
+      sessionRef.current = session;
+      setPhase("flashed");
+    } catch (e) {
+      setError(e instanceof ApiError ? `${e.status}: ${e.message}` : e instanceof Error ? e.message : String(e));
+      setPhase("idle");
+    }
+  }
+
+  /** Write code.py straight onto the CIRCUITPY drive via the File System
+   *  Access API (Chrome/Edge -- same support matrix as WebSerial). */
+  async function handleSaveToDrive() {
+    if (!starter) return;
+    setError(null);
+    try {
+      const picker = (window as Window & { showDirectoryPicker?: (opts?: unknown) => Promise<FileSystemDirectoryHandle> }).showDirectoryPicker;
+      if (!picker) throw new Error("This browser can't write files directly. Use Download and copy code.py over by hand.");
+      const dir = await picker.call(window, { mode: "readwrite" });
+      const file = await dir.getFileHandle("code.py", { create: true });
+      const writable = await (file as FileSystemFileHandle & { createWritable: () => Promise<{ write: (d: string) => Promise<void>; close: () => Promise<void> }> }).createWritable();
+      await writable.write(starter);
+      await writable.close();
+      setSaved(`code.py saved to ${dir.name}/`);
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return; // user cancelled the picker
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  function handleDownload() {
+    if (!starter) return;
+    const url = URL.createObjectURL(new Blob([starter], { type: "text/x-python" }));
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "code.py";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="space-y-3">
+      {status !== null && !status.available && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-200">
+          <div className="font-semibold">Firmware download unavailable</div>
+          <div className="mt-1">{status.reason}</div>
+        </div>
+      )}
+
+      {generic && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-200">
+          No official CircuitPython build for <code className="font-mono">{board?.name ?? boardLibraryId}</code> —
+          flashing the pin-compatible <code className="font-mono">{image}</code> image.
+          It boots, but pin names and flash/PSRAM sizing may differ; the starter
+          code.py prints the pins the build actually exposes.
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-3 text-xs text-ink-dim">
+        <div>
+          {!design
+            ? "Open a design with an ESP32-family board (ESP8266 has no CircuitPython port)."
+            : supported
+              ? <>Flashing CircuitPython {status?.version ?? ""} (<code className="font-mono text-ink">{image}</code>) for <code className="font-mono text-ink">{board?.name ?? boardLibraryId}</code>, full-chip erase.</>
+              : <>No CircuitPython build for <code className="font-mono text-ink">{board?.name ?? boardLibraryId}</code>. ESP32/S3/C3/C6 boards are supported; ESP8266 is not.</>}
+        </div>
+        <Button
+          variant="primary"
+          disabled={!supported || !status?.available || phase === "fetching" || phase === "flashing"}
+          onClick={handleFlash}
+        >
+          <Zap className="h-3.5 w-3.5" />
+          {phase === "fetching" ? "Fetching…" : phase === "flashing" ? `Flashing ${(progress * 100).toFixed(0)}%` : "Flash CircuitPython"}
+        </Button>
+      </div>
+
+      {log.length > 0 && (
+        <pre className="max-h-32 overflow-auto rounded-lg bg-surface-0 p-2 font-mono text-[11px] leading-snug text-ink-dim ring-1 ring-line">
+          {log.join("\n")}
+        </pre>
+      )}
+
+      {phase === "flashed" && (
+        <div className="space-y-2 rounded-lg border border-line bg-surface-2/40 p-3 text-xs text-ink-dim">
+          <p>
+            Device flashed. After it reboots it mounts a <code className="font-mono text-ink">CIRCUITPY</code>{" "}
+            USB drive — close this dialog to free the serial port, then drop a{" "}
+            <code className="font-mono text-ink">code.py</code> onto the drive to run it.
+          </p>
+          {starter && (
+            <>
+              <div className="text-xs font-medium text-ink">Starter code.py for this board</div>
+              <pre className="max-h-40 overflow-auto rounded-md bg-surface-0 p-2 font-mono text-[10px] text-ink-dim ring-1 ring-line">
+                {starter}
+              </pre>
+              <div className="flex items-center gap-2">
+                <Button variant="primary" onClick={handleSaveToDrive}>
+                  <UploadCloud className="h-3.5 w-3.5" />
+                  Save to CIRCUITPY
+                </Button>
+                <Button onClick={handleDownload}>Download code.py</Button>
+                {saved && <span className="text-[10px] text-emerald-300/90">{saved}</span>}
+              </div>
+            </>
+          )}
         </div>
       )}
 

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -1453,6 +1453,10 @@ def create_app(
 
     app.include_router(meshtastic_router(), prefix="/meshtastic")
 
+    from wirestudio.api.circuitpython import router as circuitpython_router
+
+    app.include_router(circuitpython_router(lib), prefix="/circuitpython")
+
     if mcp_server is not None:
         # Streamable HTTP transport. mcp_server.streamable_http_app() registers
         # `/mcp` on its own Starlette app; we wrap it in BearerTokenMiddleware

--- a/wirestudio/api/circuitpython.py
+++ b/wirestudio/api/circuitpython.py
@@ -1,0 +1,263 @@
+"""CircuitPython firmware proxy + starter code.py.
+
+Not a target plugin: like Meshtastic, nothing is compiled from the design.
+Release binaries live on downloads.circuitpython.org (S3), one combined
+image per board id that flashes at 0x0 with a full erase; the newest
+stable version comes from the adafruit/circuitpython GitHub releases API.
+
+Builds are per-board and curated upstream, so the map below carries two
+tiers: boards with an official build for the exact hardware, and boards
+that fall back to a pin-compatible generic image (`exact: False` --
+surfaced in the status response so the UI can warn that pin names and
+flash/PSRAM sizing may differ). ESP8266 boards are absent: CircuitPython
+dropped that port years ago.
+
+A bare CircuitPython flash boots to an empty REPL, so `GET /code` also
+serves a starter code.py generated from the board's library metadata
+(LED blink, Vext power-up, I2C scan) for the user to drop onto the
+CIRCUITPY drive.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Response
+
+from wirestudio.library import Library, LibraryBoard
+
+_RELEASES_LATEST = "https://api.github.com/repos/adafruit/circuitpython/releases/latest"
+_BIN_BASE = "https://downloads.circuitpython.org/bin"
+_LANG = "en_US"
+
+# Library board id -> CircuitPython board id (the directory name under
+# ports/espressif/boards). exact=False marks a pin-compatible fallback
+# image rather than a build for this precise board. Every id verified
+# against downloads.circuitpython.org.
+_BOARDS: dict[str, dict] = {
+    "esp32-devkitc-v4":      {"image": "espressif_esp32_devkitc_v4_wroom_32e", "exact": True},
+    "esp32-wrover-cam":      {"image": "espressif_esp32_devkitc_v4_wrover", "exact": False},
+    "esp32cam-ai-thinker":   {"image": "espressif_esp32_devkitc_v4_wrover", "exact": False},
+    "heltec-wifi-lora32-v2": {"image": "espressif_esp32_devkitc_v4_wroom_32e", "exact": False},
+    "m5stack-atom":          {"image": "m5stack_atom_lite", "exact": True},
+    "m5stack-atom-echo":     {"image": "m5stack_atom_echo", "exact": True},
+    "m5stack-atom-matrix":   {"image": "m5stack_atom_matrix", "exact": True},
+    "m5stack-atomu":         {"image": "m5stack_atom_u", "exact": True},
+    "nodemcu-32s":           {"image": "espressif_esp32_devkitc_v4_wroom_32e", "exact": False},
+    "ttgo-lora32-v1":        {"image": "espressif_esp32_devkitc_v4_wroom_32e", "exact": False},
+    "ttgo-lora32-v2":        {"image": "espressif_esp32_devkitc_v4_wroom_32e", "exact": False},
+    "ttgo-t-beam":           {"image": "espressif_esp32_devkitc_v4_wroom_32e", "exact": False},
+    "esp32-c3-devkitm-1":    {"image": "espressif_esp32c3_devkitm_1_n4", "exact": True},
+    "esp32-c3-supermini":    {"image": "makergo_esp32c3_supermini", "exact": True},
+    "seeed-xiao-esp32c3":    {"image": "seeed_xiao_esp32c3", "exact": True},
+    "esp32-c6-supermini":    {"image": "makergo_esp32c6_supermini", "exact": True},
+    "esp32-s3-devkitc-1":    {"image": "espressif_esp32s3_devkitc_1_n8", "exact": True},
+    "esp32-s3-supermini":    {"image": "espressif_esp32s3_devkitc_1_n8", "exact": False},
+    "heltec-wifi-lora32-v3": {"image": "heltec_esp32s3_wifi_lora_v3", "exact": True},
+    # Same V3-for-V4 substitution as the PlatformIO board key: no upstream
+    # V4 build yet, and the V3 image boots the V4's S3 core.
+    "heltec-wifi-lora32-v4": {"image": "heltec_esp32s3_wifi_lora_v3", "exact": False},
+    "m5stack-atoms3":        {"image": "m5stack_atoms3", "exact": True},
+    "m5stack-atoms3-lite":   {"image": "m5stack_atoms3_lite", "exact": True},
+}
+
+_FIRMWARE_TIMEOUT = 120  # seconds; combined images are ~2 MB
+
+
+def _latest_stable() -> str:
+    """Newest stable release tag (e.g. '10.2.1') from GitHub."""
+    import httpx
+
+    resp = httpx.get(_RELEASES_LATEST, timeout=15, follow_redirects=True)
+    resp.raise_for_status()
+    return resp.json()["tag_name"].lstrip("v")
+
+
+def _fetch_firmware(url: str) -> bytes:
+    import httpx
+
+    resp = httpx.get(url, timeout=_FIRMWARE_TIMEOUT, follow_redirects=True)
+    resp.raise_for_status()
+    return resp.content
+
+
+def firmware_status() -> dict:
+    try:
+        version = _latest_stable()
+        available, reason = True, None
+    except Exception as e:
+        version, available, reason = None, False, f"release lookup failed: {e}"
+    return {
+        "available": available,
+        "version": version,
+        "boards": sorted(_BOARDS),
+        "generic": sorted(b for b, m in _BOARDS.items() if not m["exact"]),
+        "images": {b: m["image"] for b, m in sorted(_BOARDS.items())},
+        "reason": reason,
+    }
+
+
+def _pin_num(pin: object) -> str | None:
+    s = str(pin or "")
+    return s.removeprefix("GPIO") if s.startswith("GPIO") else None
+
+
+def starter_code(board: LibraryBoard, exact: bool) -> str:
+    """A dependency-free code.py (core modules only) from the board's
+    library metadata: Vext power-up, LED blink, I2C scan, pin listing.
+    Pin attributes vary per build, so lookups go through find_pin()."""
+    onboard = board.onboard_peripherals or {}
+    led = _pin_num((onboard.get("led") or {}).get("pin"))
+    vext = onboard.get("vext") or {}
+    vext_pin = _pin_num(vext.get("pin"))
+    i2c = (board.default_buses or {}).get("i2c") or {}
+    sda, scl = _pin_num(i2c.get("sda")), _pin_num(i2c.get("scl"))
+
+    lines: list[str] = [
+        f'"""{board.name} -- CircuitPython starter, generated by wirestudio.',
+        "",
+        "Copy this file to the CIRCUITPY drive as code.py. Output appears on",
+        "the serial console (any serial terminal, or the REPL in Thonny/Mu).",
+    ]
+    if not exact:
+        lines += [
+            "",
+            "NOTE: no official CircuitPython build exists for this exact board;",
+            "the flashed image targets pin-compatible hardware. Pin names may",
+            "differ -- the pin listing printed at boot shows what this build has.",
+        ]
+    if onboard:
+        lines += ["", "Onboard peripherals (from the wirestudio board library):"]
+        for key, params in onboard.items():
+            lines.append(f"  {key}: {params}")
+    lines += ['"""', "import time", "", "import board", "import digitalio", ""]
+
+    lines += [
+        "",
+        "def find_pin(*names):",
+        "    for n in names:",
+        "        p = getattr(board, n, None)",
+        "        if p is not None:",
+        "            return p",
+        "    return None",
+        "",
+    ]
+
+    if vext_pin:
+        polarity = "False" if vext.get("inverted") else "True"
+        lines += [
+            "",
+            f"# Vext gates the onboard peripherals ({'active low' if vext.get('inverted') else 'active high'}) -- switch it on.",
+            f'vext = find_pin("VEXT", "IO{vext_pin}", "GPIO{vext_pin}")',
+            "if vext is not None:",
+            "    vext_out = digitalio.DigitalInOut(vext)",
+            "    vext_out.direction = digitalio.Direction.OUTPUT",
+            f"    vext_out.value = {polarity}",
+            "",
+        ]
+
+    if led:
+        lines += [
+            "",
+            f"# Onboard LED (GPIO{led} in the wirestudio board library).",
+            f'led_pin = find_pin("LED", "IO{led}", "GPIO{led}", "D{led}")',
+            "led = None",
+            "if led_pin is not None:",
+            "    led = digitalio.DigitalInOut(led_pin)",
+            "    led.direction = digitalio.Direction.OUTPUT",
+            "",
+        ]
+
+    if sda and scl:
+        lines += [
+            "",
+            f"# Default I2C bus (SDA=GPIO{sda}, SCL=GPIO{scl}): scan for devices.",
+            "try:",
+            "    import busio",
+            "",
+            f'    sda = find_pin("SDA", "IO{sda}", "GPIO{sda}", "D{sda}")',
+            f'    scl = find_pin("SCL", "IO{scl}", "GPIO{scl}", "D{scl}")',
+            "    if sda is not None and scl is not None:",
+            "        i2c = busio.I2C(scl, sda)",
+            "        if i2c.try_lock():",
+            '            print("I2C scan:", [hex(a) for a in i2c.scan()])',
+            "            i2c.unlock()",
+            "except Exception as e:",
+            '    print("I2C scan failed:", e)',
+            "",
+        ]
+
+    lines += [
+        "",
+        'print("Pins this build exposes:")',
+        'print(" ".join(n for n in sorted(dir(board)) if not n.startswith("_")))',
+        "",
+        "n = 0",
+        "while True:",
+    ]
+    if led:
+        lines += [
+            "    if led is not None:",
+            "        led.value = not led.value",
+            "    else:",
+            '        print("heartbeat", n)',
+            "        n += 1",
+        ]
+    else:
+        lines += ['    print("heartbeat", n)', "    n += 1"]
+    lines += ["    time.sleep(1)", ""]
+    return "\n".join(lines)
+
+
+def router(lib: Library) -> APIRouter:
+    router = APIRouter(tags=["circuitpython"])
+
+    @router.get("/firmware/status")
+    def circuitpython_firmware_status() -> dict:
+        return firmware_status()
+
+    # No return annotation: `from __future__ import annotations` turns it
+    # into a string OpenAPI generation can't resolve.
+    @router.get("/firmware", response_class=Response)
+    def circuitpython_firmware(board: str, version: str | None = None):
+        entry = _BOARDS.get(board)
+        if entry is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"no CircuitPython build mapping for board '{board}'",
+            )
+        image = entry["image"]
+        try:
+            ver = (version or _latest_stable()).lstrip("v")
+            filename = f"adafruit-circuitpython-{image}-{_LANG}-{ver}.bin"
+            url = f"{_BIN_BASE}/{image}/{_LANG}/{filename}"
+            data = _fetch_firmware(url)
+        except Exception as e:
+            raise HTTPException(
+                status_code=502, detail=f"could not fetch firmware: {e}"
+            ) from e
+        return Response(
+            content=data,
+            media_type="application/octet-stream",
+            headers={
+                "X-Flash-Offset": "0",
+                "Content-Disposition": f'attachment; filename="{filename}"',
+            },
+        )
+
+    @router.get("/code", response_class=Response)
+    def circuitpython_code(board: str):
+        entry = _BOARDS.get(board)
+        if entry is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"no CircuitPython build mapping for board '{board}'",
+            )
+        try:
+            lib_board = lib.board(board)
+        except FileNotFoundError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
+        return Response(
+            content=starter_code(lib_board, exact=entry["exact"]),
+            media_type="text/x-python",
+            headers={"Content-Disposition": 'attachment; filename="code.py"'},
+        )
+
+    return router


### PR DESCRIPTION
## What

Adds **CircuitPython** as the fifth framework in the unified flash dialog, and sweeps the project documentation current.

## CircuitPython flashing (Phase B of the scoping)

CircuitPython distributes one combined image per curated board id, flashed at 0x0 with a full erase — the same shape as the Meshtastic proxy, so the WebSerial + esptool-js mechanism is reused unchanged.

- **`GET /circuitpython/firmware?board=`** proxies the official release image from downloads.circuitpython.org, resolving the newest stable from the adafruit/circuitpython releases API. `X-Flash-Offset: 0`, full erase.
- **Board map**: all 22 ESP32/S3/C3/C6 library boards map to a build **verified against the download host** (HTTP 200 on the actual .bin URLs). Exact builds where upstream has one (Heltec V3, M5Stack Atom family, XIAO C3, SuperMinis, devkits); pin-compatible generic fallbacks otherwise (Heltec V2/V4, TTGO LoRa32/T-Beam, S3 SuperMini) — flagged in `/circuitpython/firmware/status` and warned about in the UI. ESP8266 boards 422 (CircuitPython dropped the port).
- **`GET /circuitpython/code?board=`** generates a dependency-free starter `code.py` from the board's library metadata: Vext power-up (Heltec), onboard-LED blink, default-I2C scan, and a boot-time pin listing. Pin names vary per build, so lookups go through a `find_pin()` fallback chain (`LED` → `IOnn` → `GPIOnn` → `Dnn`). The dialog offers **Save to CIRCUITPY** (File System Access API) and download post-flash.
- Full `code.py` codegen from the design (per-component drivers + Adafruit bundle libs) is deliberately out of scope — tracked in the docs/index target backlog.

## Documentation sweep

README / docs index / user guide / library reference / integrations / deployment / web README validated against current development:

- Five-framework flash dialog + firmware-proxy endpoints documented (user guide, integrations, README lead + status table).
- Module map updated (seed, intent, inventory, jlcpcb, firmware proxies); stale "Future" items removed (PCB layout shipped).
- Library reference: boards/components added since 0.19 filled in (SuperMinis, XIAO C3, TTGO LoRa32 V2.1, ULN2003, PWM fan, potentiometer, Grove AHT20, AXP192).
- Version examples 0.19.1 → 0.23.0; test counts refreshed; web README false claims fixed (persistence exists, agent/drag-drop shipped, RTL suites exist).

## Tests

- `tests/test_circuitpython.py` mirrors the Meshtastic proxy tests + starter-code coverage (every board's starter parses as valid Python; generic-build marking; ESP8266 422).
- FlashDialog RTL tests for the unsupported-board and generic-image warning paths.
- Full suites green: **904 passed** (py), **208 passed** (web); web build + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyuSdksSuJZ33JGFftk2wK