### PR TITLE
⚡ Bolt: [performance improvement] Single-pass loops for ConnectionForm lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-07-27 - O(N) Lookups in Render Loops
 **Learning:** Using `.find()` to lookup values in an array from inside a `.map()` or a `for` loop executing during rendering creates an O(N^2) time complexity bottleneck. In `buildModel` (WiringView.tsx), looking up a bus type by its ID via `.find()` across all components and connections repeatedly scanned the `buses` array.
 **Action:** Pre-compute lookup maps (e.g., `Map<id, value>`) before loops to achieve O(1) lookups during heavy data processing or rendering.
+
+## 2024-05-18 - Single-Pass Lookup Building in `useMemo`
+**Learning:** We often chain `.map()` to build an array of IDs and then loop again to build a dictionary mapping IDs to labels in `useMemo` hooks. This causes multiple iterations and intermediate array allocations.
+**Action:** When building both an array of IDs and a dictionary map from the same source data, use a single `for...of` loop to populate both simultaneously.

--- a/web/src/components/ConnectionForm.tsx
+++ b/web/src/components/ConnectionForm.tsx
@@ -54,15 +54,18 @@ export function ConnectionForm({
     return caveat ? `${p} — ${caveat}` : `${p} — safe`;
   };
 
-  const buses = useMemo(() => (design ? readBuses(design) : []), [design]);
-  const busIds = useMemo(() => buses.map((b) => b.id), [buses]);
-  const busDict = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const b of buses) {
-      map.set(b.id, `${b.id} (${b.type})`);
+  // ⚡ Bolt: Use single-pass loops to derive lookups directly, avoiding chained .map()/.filter() intermediate array allocations
+  const { busIds, busDict } = useMemo(() => {
+    const ids: string[] = [];
+    const dict = new Map<string, string>();
+    if (design) {
+      for (const b of readBuses(design)) {
+        ids.push(b.id);
+        dict.set(b.id, `${b.id} (${b.type})`);
+      }
     }
-    return map;
-  }, [buses]);
+    return { busIds: ids, busDict: dict };
+  }, [design]);
 
   const expanderLibIds = useMemo(() => {
     if (!libraryComponents) return new Set<string>();
@@ -75,31 +78,32 @@ export function ConnectionForm({
     return ids;
   }, [libraryComponents]);
 
-  const expanders = useMemo(() => {
-    return design ? readComponents(design).filter((c) => expanderLibIds.has(c.library_id)) : [];
-  }, [design, expanderLibIds]);
-  const expanderIds = useMemo(() => expanders.map((e) => e.id), [expanders]);
-  const expanderDict = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const e of expanders) {
-      map.set(e.id, `${e.id} (${e.library_id})`);
-    }
-    return map;
-  }, [expanders]);
+  // ⚡ Bolt: Derive expander and component IDs and Dictionaries in a single loop over components
+  const { expanderIds, expanderDict, componentIds, componentDict } = useMemo(() => {
+    const eIds: string[] = [];
+    const eDict = new Map<string, string>();
+    const cIds: string[] = [];
+    const cDict = new Map<string, string>();
 
-  const componentInstances = useMemo(() => {
-    return (design ? readComponents(design) : []).map((c) => ({
-      id: c.id, library_id: c.library_id,
-    }));
-  }, [design]);
-  const componentIds = useMemo(() => componentInstances.map((c) => c.id), [componentInstances]);
-  const componentDict = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const c of componentInstances) {
-      map.set(c.id, `${c.id} (${c.library_id})`);
+    if (design) {
+      for (const c of readComponents(design)) {
+        const label = `${c.id} (${c.library_id})`;
+
+        cIds.push(c.id);
+        cDict.set(c.id, label);
+
+        if (expanderLibIds.has(c.library_id)) {
+          eIds.push(c.id);
+          eDict.set(c.id, label);
+        }
+      }
     }
-    return map;
-  }, [componentInstances]);
+
+    return {
+      expanderIds: eIds, expanderDict: eDict,
+      componentIds: cIds, componentDict: cDict,
+    };
+  }, [design, expanderLibIds]);
 
   if (rows.length === 0) {
     return <div className="text-xs text-ink-faint">No connections.</div>;


### PR DESCRIPTION
💡 **What:** Refactored chained `.map()` and `.filter()` array methods into single-pass `for...of` loops in `ConnectionForm.tsx`.
🎯 **Why:** To avoid O(N) allocations of intermediate arrays and reduce garbage collection pressure when deriving lookup dictionaries (Maps) and ID arrays inside `useMemo` hooks.
📊 **Impact:** Eliminates 3 intermediate array allocations (`buses`, `expanders`, `componentInstances`) and 4 `.map()` iterations every time the design's component or bus list changes, speeding up re-renders of the ConnectionForm.
🔬 **Measurement:** Profile React render times for `ConnectionForm` when toggling connections or updating the design; memory snapshots will show fewer short-lived array allocations.

---
*PR created automatically by Jules for task [9726300942011320301](https://jules.google.com/task/9726300942011320301) started by @moellere*