### PR TITLE
fix: pin mcp<2; release 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] — 2026-07-29
+
+### Fixed
+
+- **Pin `mcp<2`.** mcp 2.0.0 (released 2026-07-28) removed the
+  `mcp.server.fastmcp` import path, so images built after it crashed at
+  boot with ModuleNotFoundError -- the 0.24.0-full image never came up
+  (prod stayed on 0.23.0). Migrating to the mcp 2.x API is follow-up
+  work; the pin restores a bootable image.
+
 ## [0.24.0] — 2026-07-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "anthropic>=0.40",
     "httpx>=0.27",
     "slowapi>=0.1.9",
-    "mcp>=1.27",
+    "mcp>=1.27,<2",
 ]
 
 [project.optional-dependencies]

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.24.0"
+__version__ = "0.24.1"


### PR DESCRIPTION
mcp 2.0.0 (released 2026-07-28) removed the `mcp.server.fastmcp` import path. `pyproject.toml` had `mcp>=1.27` unbounded, so the 0.24.0-full image (and recent main-full builds — hence wirestudio-dev's Degraded state) pulled 2.0.0 and crash-looped at boot:

```
File "/app/wirestudio/mcp/server.py", line 21, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

Prod never rolled — the old 0.23.0 pod kept serving. This pins `mcp>=1.27,<2` and cuts 0.24.1. Migrating to the mcp 2.x API is tracked follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyuSdksSuJZ33JGFftk2wK