### PR TITLE
fix: six hardware-found LoRaWAN bugs; workbench remote flash (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Workbench remote flash transport (phase 1, server side).** New
+  `wirestudio.workbench` client and `/workbench/*` routes behind a
+  `WORKBENCH_URL` + `WORKBENCH_TOKEN` gate: `GET /workbench/status`
+  (always 200, carries `available`/`reason`/`configure_hint` like the
+  fleet and enclosure gates), `GET /workbench/slots`, and
+  `POST /workbench/flash` streaming the bench's esptool output as SSE.
+  The studio uploads the image and the Pi flashes its own USB rather
+  than the studio driving esptool over RFC2217 -- esptool's block
+  protocol is round-trip bound, so one bulk transfer survives the very
+  link that makes remote flashing necessary, and the bench keeps owning
+  the bench. RFC2217 remains what phase 2 relays for serial.
+- **Hardware-validated against the reference bench.** The wire format is
+  verified, not assumed: parts are keyed `bin@<offset>`, and the portal
+  answers once with `{ok, output, returncode}` rather than streaming, so
+  the client parses that log into per-line SSE events and treats a
+  non-zero `returncode` as a failure instead of reporting a successful
+  flash. Progress therefore arrives at completion, not live; liveness
+  needs the phase-2 serial relay.
+- **Slot pre-flight.** A flash is refused before the stream opens (409)
+  when the slot is busy, flapping, or holds no serial device, so a
+  wedged bench reports as a bench fault rather than a firmware failure.
+  A token is required alongside the URL: the studio pushes firmware at
+  an operator-supplied host, so a URL-only gate would let any
+  deployment flash any reachable bench.
+
+### Fixed
+
+- **LoRaWAN builds could not run in the deployed image.** Three faults
+  stacked. (1) The `-full` image builds on `kicad/kicad:8.0`, which
+  already occupies uid 1000, so its bare `useradd appuser` landed on
+  1001 while manifests pin `runAsUser: 1000`. (2) PlatformIO creates
+  platform directories `0700`, so the prewarmed toolchain was unreadable
+  to any other uid -- `PermissionError` on a plain `listdir`. (3)
+  `PLATFORMIO_CORE_DIR` was baked to `/opt/pio`, but PlatformIO writes
+  `appstate.json` and lockfiles there on every invocation, which cannot
+  work under `readOnlyRootFilesystem: true`. The core dir now defaults to
+  `/data/pio` with the prewarmed toolchain kept read-only via
+  `PLATFORMIO_PLATFORMS_DIR` / `PLATFORMIO_PACKAGES_DIR`, the cache under
+  `/tmp`, and the baked tree is `chmod a+rX` so any runtime uid can read
+  it. No re-download, and uid no longer has to match.
+- **`platformio_status()` reported available for a toolchain that could
+  not build.** It only ran `pio --version`, which never touches the core
+  dir, so the UI offered the LoRaWAN flow and the failure surfaced as a
+  mid-build traceback. It now verifies the core dir is writable and the
+  platform tree readable, and reports the specific reason.
+- **Uplinks silently stopped at DR0 (`PACKET_TOO_LONG`).** The datarate
+  was set once after join, so a restored session or an ADR downlink could
+  drop the device to DR0, whose US915 payload cap is 11 bytes. Every
+  `sendReceive` then failed `RADIOLIB_ERR_PACKET_TOO_LONG` (-4) while the
+  device stayed joined and looked healthy -- the only evidence was a
+  serial line nobody reads. Hardware-confirmed on a T-Beam: a 22-byte
+  payload failed -4 indefinitely, and re-asserting the rate per uplink
+  fixed it (`fCnt` advancing at DR1, decoded object correct).
+- **Generated codec fabricated zeros for a short payload.** `decodeUplink`
+  read its full field layout unconditionally, so an uplink shorter than
+  the layout read past the end -- JS yields `undefined`, the shifts coerce
+  it to 0, and the codec returned a complete set of plausible zeros with
+  `errors: []`. Home Assistant showed those as real readings. The codec
+  now length-checks first and reports the mismatch as a decode error.
+  Observed live: a device sending one `0x00` byte decoded as nine
+  zero-valued sensor fields.
+- **DHT pin rendered as literal `None` in LoRaWAN firmware.** A DHT
+  requested through `lorawan.dht22` has no wiring, so `firmware_gen`
+  sets the render context's `pin` to `None`; Jinja's `default()` only
+  substitutes for *undefined* values, so the chain never fell through
+  to `params.pin` and emitted `DHT dht(None, DHT22);` -- C++ that does
+  not compile. The template now tests for none explicitly (and avoids
+  `or`, which would discard a legitimate GPIO0). Regression tests cover
+  the synthesized-DHT path and the T-Beam's AXP192 rail init, neither
+  of which was exercised before.
+
 ### Changed
 
 - **Roadmap: Workbench featureset.** docs/index.md gains a planned
@@ -16,6 +89,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   loop with SDR TX checks -- phased and env-gated like every other
   integration. docs/workbench.md carries the full capability map and
   design constraints.
+- **Roadmap accuracy pass.** Four claims in docs/index.md contradicted
+  the repo and are corrected: coverage is "zero unexplained gaps", not
+  "zero uncovered" (`axp192` is a permanent baseline entry, so the
+  matrix reads 63/64); the `.kicad_sch` render in CI moves from Next to
+  shipped (the `kicad-render` gate already runs it); PCB layout is
+  "Verified (routed)" now that the `pcb-route` gate holds examples to
+  the routed bar; CircuitPython flashing is tagged 0.24 rather than
+  unreleased. The outstanding mcp 2.x migration behind the 0.24.1
+  `mcp<2` pin is recorded as Known debt.
+- **Workbench: constraints and phase rationale.** Phase 1 is motivated
+  by reach rather than convenience -- a LoRaWAN board can only be
+  join-tested where a gateway is in range, so a bench remote from the
+  developer has no WebSerial path at all. Four design constraints
+  folded in: `WORKBENCH_URL` alone is not authorization (host allowlist
+  + token ship with the transport, since the workbench API is
+  unauthenticated and the server-side fetch is an SSRF primitive);
+  bench resources are exclusive and callers must expect a busy state;
+  hardware faults report distinctly from test failures behind a
+  pre-flight self-test; RF checks assert against a fixed-gain baseline
+  rather than energy presence. The phase-3 self-hosted runner is stated
+  as a prerequisite cost.
 
 ## [0.24.1] — 2026-07-29
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,8 +90,22 @@ if [ "$WITH_LORAWAN" = "true" ]; then
     mkdir -p "$PLATFORMIO_CORE_DIR"
     python -c "from wirestudio.library import default_library; from wirestudio.model import Design; from wirestudio.targets import get_target; from wirestudio.targets.lorawan.compile import compile_firmware; lib=default_library(); [compile_firmware(Design(schema_version='0.1', id='prewarm-'+b, name=b, target='lorawan', lorawan={}, board={'library_id': b, 'mcu': 'esp32'}, power={'supply':'usb','rail_voltage_v':3.3}), lib, use_cache=False) for b in get_target('lorawan').board_ids(lib)]"
     chown -R appuser:appuser "$PLATFORMIO_CORE_DIR"
+    # PlatformIO creates platform dirs 0700, so the baked toolchain is
+    # unreadable to any uid but the one that built it -- and a manifest is
+    # free to pin a different runAsUser than this image's appuser. Readable
+    # by everyone, writable by no one: the runtime never writes here.
+    chmod -R a+rX "$PLATFORMIO_CORE_DIR"
 fi
 EOF
+
+# PlatformIO writes appstate.json + lockfiles into its core dir on every
+# invocation, so a baked-in core dir cannot work under a read-only root
+# filesystem. Split it: state on the writable volume, the prewarmed
+# toolchain read-only where the build stage left it.
+ENV PLATFORMIO_CORE_DIR=/data/pio \
+    PLATFORMIO_PLATFORMS_DIR=/opt/pio/platforms \
+    PLATFORMIO_PACKAGES_DIR=/opt/pio/packages \
+    PLATFORMIO_CACHE_DIR=/tmp/pio-cache
 
 ENV PYTHONUNBUFFERED=1 \
     WIRESTUDIO_STATIC_DIR=/app/web-dist \

--- a/Dockerfile.pcb
+++ b/Dockerfile.pcb
@@ -83,8 +83,23 @@ if [ "$WITH_LORAWAN" = "true" ]; then
     mkdir -p "$PLATFORMIO_CORE_DIR"
     /opt/venv/bin/python -c "from wirestudio.library import default_library; from wirestudio.model import Design; from wirestudio.targets import get_target; from wirestudio.targets.lorawan.compile import compile_firmware; lib=default_library(); [compile_firmware(Design(schema_version='0.1', id='prewarm-'+b, name=b, target='lorawan', lorawan={}, board={'library_id': b, 'mcu': 'esp32'}, power={'supply':'usb','rail_voltage_v':3.3}), lib, use_cache=False) for b in get_target('lorawan').board_ids(lib)]"
     chown -R appuser:appuser "$PLATFORMIO_CORE_DIR"
+    # This base image already has a user at uid 1000 (kicad), so `useradd`
+    # above lands appuser on 1001 while manifests pin runAsUser: 1000 --
+    # and PlatformIO creates platform dirs 0700, so the baked toolchain ends
+    # up unreadable to the uid that actually runs. Readable by everyone,
+    # writable by no one: the runtime never writes here.
+    chmod -R a+rX "$PLATFORMIO_CORE_DIR"
 fi
 EOF
+
+# PlatformIO writes appstate.json + lockfiles into its core dir on every
+# invocation, so a baked-in core dir cannot work under a read-only root
+# filesystem. Split it: state on the writable volume, the prewarmed
+# toolchain read-only where the build stage left it.
+ENV PLATFORMIO_CORE_DIR=/data/pio \
+    PLATFORMIO_PLATFORMS_DIR=/opt/pio/platforms \
+    PLATFORMIO_PACKAGES_DIR=/opt/pio/packages \
+    PLATFORMIO_CACHE_DIR=/tmp/pio-cache
 
 ENV PYTHONUNBUFFERED=1 \
     PATH=/opt/venv/bin:$PATH \

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -16,9 +16,17 @@
 #     (sessions JSONL + designs JSON files) is file-on-disk and not
 #     safe across multiple writers. RWX volumes don't help -- the
 #     file format itself isn't multi-writer.
-#   - The image runs as a non-root `appuser` (uid 1000); the pod's
-#     securityContext below pins that explicitly + forbids privilege
-#     escalation, so the manifest is PSS-Restricted-friendly.
+#   - The image runs as a non-root `appuser`; the pod's securityContext
+#     below pins a uid explicitly + forbids privilege escalation, so the
+#     manifest is PSS-Restricted-friendly. Note the `-full` image is built
+#     on kicad/kicad:8.0, which already occupies uid 1000, so its appuser
+#     is 1001 -- runAsUser here does NOT have to match, because nothing
+#     the runtime writes lives on the image filesystem (see below).
+#   - LoRaWAN builds need a writable PLATFORMIO_CORE_DIR. The image points
+#     it at /data/pio and keeps the prewarmed toolchain read-only under
+#     /opt/pio, so this works with readOnlyRootFilesystem: true. Mounting
+#     anything over /opt/pio would mask the baked toolchain and force a
+#     multi-hundred-MB re-download on first build.
 
 ---
 # Optional: wirestudio-secrets. Apply this with real values out-of-band:
@@ -121,6 +129,10 @@ spec:
             #   value: "true"
           volumeMounts:
             - { name: data, mountPath: /data }
+            # PLATFORMIO_CACHE_DIR lives here. Required once the root
+            # filesystem is read-only, which is how a PSS-Restricted
+            # deployment runs this image.
+            - { name: tmp, mountPath: /tmp }
           readinessProbe:
             httpGet: { path: /api/health, port: http }
             periodSeconds: 5
@@ -140,6 +152,8 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: wirestudio-data
+        - name: tmp
+          emptyDir: {}
 
 ---
 apiVersion: v1

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,10 +90,13 @@ non-negotiable bar: every artifact the studio emits round-trips
 through upstream `esphome config`. Shipped: the `esphome config` CI
 gate over every bundled example; a nightly `esphome compile` smoke;
 the component-coverage matrix ([`library-coverage.md`](library-coverage.md))
-with a `--strict` no-regression gate now at **zero uncovered** (every
-component and board is exercised — esphome examples, or the lorawan
-firmware build for radio boards — see
-[`library-coverage.md`](library-coverage.md) for the live counts); a
+with a `--strict` no-regression gate holding **zero unexplained gaps** —
+every board and every component but one is exercised (esphome examples,
+or the lorawan firmware build for radio boards); the sole exception,
+`axp192`, is a permanent baseline entry, since the T-Beam's PMIC has no
+standalone ESPHome platform and is materialized implicitly by the
+LoRaWAN generator rather than named by any example — see
+[`library-coverage.md`](library-coverage.md) for the live counts; a
 pinned ESPHome version called out in the README + workflow; an
 [`esphome-matrix`](../.github/workflows/esphome-matrix.yml) compatibility
 report that runs the gate across the pin + latest stables so a pin bump
@@ -108,9 +111,14 @@ importer (`python -m wirestudio.kicad.import`) shipped. The
 every bundled example's SKiDL script against the pinned upstream KiCad
 symbol libraries and fails the PR unless it builds a netlist with no
 unresolved symbols or pins; parts KiCad ships no stock symbol for
-render as labeled generic headers. Next: ERC on the generated netlist;
-a full `.kicad_sch` render in CI; pin-solver property tests on
-randomized designs; compatibility-checker fuzzing.
+render as labeled generic headers. The
+[`kicad-render`](../.github/workflows/kicad-render.yml) gate carries the
+pipeline the rest of the way — SKiDL script → `.kicad_sch` →
+`kicad-cli sch export svg` on real KiCad 8 — catching what only
+kicad-cli's parser sees (schematic grammar, embedded `lib_symbols`,
+toolchain env), which the netlist gate cannot. Next: ERC on the
+generated netlist; pin-solver property tests on randomized designs;
+compatibility-checker fuzzing.
 
 **Priority 3 — Enclosures.** *Verified.* Parametric OpenSCAD
 generator + Thingiverse search relay shipped. The
@@ -122,7 +130,7 @@ e.g. [YAPP_Box](https://github.com/mrWheel/YAPP_Box) and integrate
 instead of reimplementing? Next: more boards' `enclosure:` metadata
 (only 5 carry it today); a lid + snap-fit; slicer-side print validation.
 
-**Priority 4 — PCB layout.** *Verified (unrouted).* Shipped in three
+**Priority 4 — PCB layout.** *Verified (routed).* Shipped in three
 steps: the footprint-coverage gate (every component + board names a
 real KiCad footprint that resolves in the pinned libraries, 0.13), the
 `.kicad_pcb` emit (footprints placed, pads bound to nets, `Edge.Cuts`
@@ -162,7 +170,7 @@ nothing is generated from the design. Region/channel config is protobuf
 over serial, so the dialog links to client.meshtastic.org; an in-studio
 config push via `@meshtastic/js` stays in the backlog.
 
-**CircuitPython flashing (unreleased).** *Works.* The unified flash
+**CircuitPython flashing (0.24).** *Works.* The unified flash
 dialog gains a CircuitPython framework: `GET /circuitpython/firmware`
 proxies the official release image from downloads.circuitpython.org
 (combined binary at 0x0, full erase), resolving the newest stable from
@@ -196,14 +204,27 @@ workbench API behind a `WORKBENCH_URL` env gate (the usual integration
 seam), never re-implements slots/serial/RF. Full capability map and
 design constraints in [workbench.md](workbench.md).
 
-Phases, each independently shippable:
+Phases, each independently shippable. Note the payoff is not evenly
+distributed: phase 1 is what makes a remote bench reachable at all,
+and phase 3 is what retires the "no live-flash gate" caveats above.
 
-1. **Remote flash transport.** `/workbench/status` + `/workbench/flash`:
-   the server fetches the framework image exactly as today, writes it
-   with esptool over `rfc2217://<pi>:<slot-port>`, streams progress over
-   SSE. The flash dialog gains a Local USB / Workbench-slot target
-   toggle — flashing from any browser, no WebSerial, no physical
-   presence.
+1. **Remote flash transport.** `/workbench/status`, `/workbench/slots`
+   and `/workbench/flash`: the server fetches the framework image
+   exactly as today, uploads it to the bench, and streams progress over
+   SSE while the Pi runs esptool against its own USB. The flash dialog
+   gains a Local USB / Workbench-slot target toggle. Flashing is
+   delegated rather than driven over RFC2217 from the studio — esptool's
+   block protocol is round-trip bound, so one bulk upload plus a local
+   flash survives the very link that makes this phase necessary.
+   This is not merely a convenience over WebSerial — it removes
+   the requirement that the developer be in the same room as the board.
+   The motivating case is LoRaWAN: a radio board has to be flashed
+   where it can actually reach a gateway, so when the bench and the
+   ChirpStack instance sit at one site and the developer at another,
+   WebSerial cannot close the loop at all. Remote flash makes the
+   provision → flash → join cycle runnable against the real network
+   from anywhere, and is the prerequisite for every headless/MCP-driven
+   use of the bench.
 2. **Boot-marker verification.** Stream the slot's serial into the flash
    dialog and assert per-framework success signatures (ESPHome boot
    log, Meshtastic banner, CIRCUITPY enumeration, LoRaWAN join) —
@@ -212,7 +233,10 @@ Phases, each independently shippable:
 3. **Nightly hardware gate.** A scheduled job flashes a representative
    example per framework to a dedicated slot and asserts boot/join, so
    the "Works (lighter checks)" tiers hold hardware-validated status
-   continuously instead of as a one-time claim.
+   continuously instead of as a one-time claim. Prerequisite: a runner
+   that can reach the bench network — hosted GitHub runners cannot, so
+   this phase carries a self-hosted runner as real setup and
+   maintenance cost, not a footnote.
 4. **Functional loop + RF truth.** Flash generated ESPHome firmware,
    provision against the workbench's AP, assert the device's API/MQTT
    entities appear; for radio boards, an SDR power-spectrum capture
@@ -262,3 +286,9 @@ task list (to promote the agent from Experimental); a multi-writer
 state backend so the studio can run as a HA replica; attributing
 `esphome-matrix` failures to specific components for per-release
 support tables.
+
+**Known debt** — `mcp` is pinned to `<2` (0.24.1). mcp 2.0.0 removed
+the `mcp.server.fastmcp` import path the MCP server is built on, so
+images built against it crashed at boot; the pin restores a bootable
+image but freezes the dependency. Migrating to the mcp 2.x API is
+outstanding.

--- a/docs/workbench.md
+++ b/docs/workbench.md
@@ -16,10 +16,15 @@ KiCad netlists, OpenSCAD renders, firmware compiles), but nothing today
 verifies them against silicon:
 
 - Flashing is WebSerial-only — Chrome/Edge, local USB, human present.
+  When the boards live at a different site from the developer, that is
+  not an inconvenience but a hard stop: there is no path to the silicon
+  at all.
 - The Meshtastic and CircuitPython tiers ship with "no live-flash gate";
   a release can pass every CI check and still fail at boot on hardware.
 - LoRaWAN join verification on the external-component path is a manual,
-  one-time claim rather than a repeatable gate.
+  one-time claim rather than a repeatable gate — and it can only be made
+  where a gateway is in range, which is wherever the bench is, not
+  wherever the developer is.
 - Radio-path bugs (e.g. an RF front end whose enable pins are never
   driven) are invisible to serial output: firmware reports transmitting
   while nothing leaves the antenna.
@@ -34,7 +39,8 @@ receiver plus signal generator.
 
 | Workbench capability | Studio integration | Value |
 |---|---|---|
-| RFC2217 serial per slot | Remote flash transport: flash dialog gains a Local USB / Workbench-slot target; server-side esptool writes over `rfc2217://<pi>:<port>` | Flash benched boards from any browser (no WebSerial requirement, no physical presence); enables headless/MCP-driven flashing |
+| Slot flash API (Pi-local esptool) | Remote flash transport: flash dialog gains a Local USB / Workbench-slot target; the studio uploads the image and the Pi flashes its own USB | Reaches boards at a remote site, where WebSerial has no path at all; enables headless/MCP-driven flashing |
+| RFC2217 serial per slot | Serial relay for boot verification (phase 2) and remote monitoring | Slot output without being at the bench |
 | Serial monitor + UDP logging | Post-flash boot verification: stream slot serial into the flash dialog over SSE; assert per-framework boot markers (ESPHome boot log, Meshtastic banner, CIRCUITPY enumeration, LoRaWAN join) | Upgrades "flashed" to "flashed and booted" — the failure class CI cannot see |
 | Chip detect over the slot | Remote Connect-device: USB-detect/bootstrap for benched boards (chip family, eFuse MAC → DevEUI) | Design bootstrap + LoRaWAN provisioning without walking to the bench |
 | WiFi SoftAP + HTTP relay + MQTT broker | Functional gate: flash generated ESPHome firmware, provision against the Pi's AP, assert the device's API/MQTT entities appear | The strongest possible claim — the generated device actually works, not just that the YAML validates |
@@ -47,20 +53,52 @@ receiver plus signal generator.
 Each phase is independently shippable; later phases build on earlier
 ones but none blocks the others' value.
 
-1. **Remote flash transport.** `WORKBENCH_URL` env gate (the usual
-   integration seam) enabling `/workbench/status` and
-   `/workbench/flash`: the server fetches the framework's image exactly
-   as the existing proxies do, writes it with esptool over RFC2217, and
-   streams progress over SSE. The flash dialog gains the target toggle.
+1. **Remote flash transport.** `WORKBENCH_URL` + `WORKBENCH_TOKEN` env
+   gate (the usual integration seam) enabling `/workbench/status`,
+   `/workbench/slots` and `/workbench/flash`: the server fetches the
+   framework's image exactly as the existing proxies do, uploads it to
+   the bench, and streams progress over SSE while the Pi runs esptool
+   against its own USB. The flash dialog gains the target toggle.
+
+   Flashing is delegated rather than driven over RFC2217 from the
+   studio. esptool's block protocol is a long series of round trips, so
+   driving it across the link that separates developer from bench is
+   exactly the latency-bound case; one bulk upload followed by a local
+   flash is both more robust and thinner, leaving the bench owning the
+   bench. RFC2217 is still what phase 2 relays for serial.
+
+   On the reference bench this is not merely the faster option but the
+   only one that works: esptool driven over RFC2217 cannot pull the
+   board into download mode (it resets into normal boot and reports
+   `Wrong boot mode 0x33`), and the portal's GPIO boot control is
+   broken by a libgpiod v1/v2 API mismatch. The Pi's local esptool
+   drives DTR/RTS on the real devnode and enters download mode fine.
+
+   Two behaviours the bench actually exhibits, worth encoding rather
+   than assuming: upload parts are keyed `bin@<offset>`, and the portal
+   buffers esptool and answers once with `{ok, output, returncode}`.
+   A non-zero `returncode` arrives under HTTP 200, so success must be
+   read from that field, and log lines only reach the operator when the
+   flash finishes.
+
+   This is the phase that makes a remote bench usable, and the LoRaWAN
+   case is why it comes first. A radio board can only be join-tested
+   where it can reach a gateway, so when the bench and the ChirpStack
+   instance sit at one site and the developer at another, the whole
+   provision → flash → join cycle is unreachable over WebSerial. Remote
+   flash runs that cycle against the real network from anywhere, and
+   every later phase — and every headless or MCP-driven use of the
+   bench — depends on it.
 2. **Boot-marker verification.** A `/workbench/verify` step and serial
    SSE relay in the dialog, with per-framework success/failure
    signatures over the slot's serial.
 3. **Nightly hardware gate.** A scheduled job flashes a representative
    example per framework to a dedicated slot and asserts boot/join —
    the "Works (lighter checks)" tiers hold hardware-validated status
-   continuously instead of as a one-time claim. Runs from
-   infrastructure that can reach the workbench's network (hosted CI
-   runners generally cannot).
+   continuously instead of as a one-time claim. This phase's real
+   prerequisite is a self-hosted runner on the bench network: hosted CI
+   runners cannot reach it, so the runner is setup and maintenance cost
+   the phase has to carry, not an implementation detail.
 4. **Functional loop + RF truth.** AP provision + MQTT/API entity
    assertions for generated ESPHome devices; SDR TX power check for
    radio boards.
@@ -74,3 +112,36 @@ ones but none blocks the others' value.
   the UI surfaces why, same as fleet/ChirpStack/Thingiverse.
 - **No bench state in `design.json`.** Slot assignments and workbench
   hosts are deployment configuration, not design content.
+- **The URL is not sufficient authorization.** Every comparable gate
+  pairs a host with a credential (`FLEET_URL` + `FLEET_TOKEN`,
+  `CHIRPSTACK_API_URL` + `CHIRPSTACK_API_TOKEN`); the workbench API is
+  unauthenticated, and phase 1 has the server push firmware at a device
+  on an operator-supplied host. A `WORKBENCH_URL` alone would make any
+  hosted studio a relay for flashing arbitrary images onto someone's
+  bench. Phase 1 therefore ships `WORKBENCH_TOKEN` alongside the
+  transport rather than as a follow-up. Note there is no existing
+  outbound-SSRF guard in the codebase to reuse: `WIRESTUDIO_ALLOWED_ORIGINS`
+  is CORS and `WIRESTUDIO_MCP_ALLOWED_HOSTS` is the MCP SDK's *inbound*
+  DNS-rebinding mitigation. Only the comma-split env parsing idiom
+  carries over; the enforcement is new code.
+- **Bench resources are exclusive; model the contention.** A slot's
+  serial port admits one reader, and the SDR is a single dongle behind
+  a global lock — a capture in flight rejects the next caller outright.
+  Phase 2 streams a slot, phase 3 flashes on a schedule, and an
+  operator may be driving the bench UI through any of it. Every
+  workbench call therefore has to expect and surface a busy state, and
+  anything long-running has to hold an explicit lease it releases on
+  failure rather than assuming the bench is idle.
+- **Distinguish a broken build from a broken bench.** Bench hardware
+  wedges under sustained use: the RTL-SDR still enumerates but streams
+  nothing until a USB reset, sometimes until the Pi reboots. A nightly
+  gate that reports those as firmware failures gets muted within a
+  month. Every hardware assertion runs behind a pre-flight self-test
+  (slot enumerates, chip detects) and reports infrastructure faults as
+  a distinct outcome from test failures.
+- **RF checks are comparisons, not presence tests.** With AGC a
+  near-field transmitter rails the receiver, so a healthy radio can
+  read as garbage and an OOK burst can misdetect entirely. The phase-4
+  TX check pins a fixed gain and asserts against a known-good baseline
+  captured under the same geometry — a bare "is there energy at the
+  carrier" test proves nothing.

--- a/scripts/coverage_baseline.yaml
+++ b/scripts/coverage_baseline.yaml
@@ -16,6 +16,11 @@
 # the LoRaWAN firmware generator materializes it implicitly from the board's
 # `onboard_peripherals`. So no example references it by id; this is a
 # permanent, deliberate baseline entry, not a coverage gap to close.
+# battery_adc is the same case: the divider is a board property (Heltec V2
+# GPIO37/3.2, TTGO LoRa32 GPIO35/2.0) that the LoRaWAN generator materializes
+# from `onboard_peripherals`, so no example names it by id either. Its ESPHome
+# template is empty -- battery sense on the ESPHome path is the `adc` platform.
 components:
   - axp192
+  - battery_adc
 boards: []

--- a/tests/golden/t-beam.cpp
+++ b/tests/golden/t-beam.cpp
@@ -130,6 +130,13 @@ while (GPSSerial.available()) gps.encode(GPSSerial.read());  // keep the fix cur
   uint16_t _v_batt_mv = batteryMv;
   payload[17] = (uint8_t)(_v_batt_mv >> 8);
   payload[18] = (uint8_t)(_v_batt_mv);
+      // Re-assert the rate every uplink. Setting it once after join is not
+      // enough: a restored session or an ADR downlink can drop us to DR0,
+      // whose payload cap is below these 19 bytes, and then
+      // every sendReceive fails RADIOLIB_ERR_PACKET_TOO_LONG (-4) with nothing
+      // but a serial line to show for it -- the device stays joined and
+      // silently stops uplinking.
+      node->setDatarate(1);
       int16_t state = node->sendReceive(payload, sizeof(payload));
       Serial.printf("uplink: RadioLib state %d\n", state);
       persist.saveSession(node);

--- a/tests/golden/t-beam.ini
+++ b/tests/golden/t-beam.ini
@@ -4,6 +4,17 @@ platform = espressif32
 board = ttgo-t-beam
 framework = arduino
 monitor_speed = 115200
+; Pin the flash size from the board file rather than inheriting PlatformIO's
+; default for this board id. A header claiming more flash than the chip has
+; makes the bootloader assert at startup ("Detected size ... smaller than the
+; size in the binary image header") and boot-loop before any sketch code runs.
+board_build.flash_size = 4MB
+board_upload.flash_size = 4MB
+; The partition table has to match the flash size too. Pinning only the size
+; leaves the board's default table in place, and an 8 MB table on a 4 MB chip
+; fails verification ("partition N invalid - offset ... exceeds flash chip
+; size") -- a different boot loop one step later.
+board_build.partitions = default.csv
 lib_deps =
     jgromes/RadioLib@^7.6.0
     ropg/LoRaWAN_ESP32@^1.3.0

--- a/tests/golden/t-beam.js
+++ b/tests/golden/t-beam.js
@@ -1,5 +1,8 @@
 function decodeUplink(input) {
   var b = input.bytes;
+  if (b.length < 19) {
+    return { data: {}, warnings: [], errors: ['expected 19 bytes, got ' + b.length] };
+  }
   var data = {};
   data.uptime_s = (((b[0] << 24) | (b[1] << 16) | (b[2] << 8) | b[3]) >>> 0);
   data.boot_count = (((b[4] << 8) | b[5]) >>> 0);

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -32,10 +32,13 @@ def test_tbeam_adds_onboard_gps_and_battery():
     assert codec.payload_size(fields) == 19
 
 
-def test_radio_only_board_is_builtin_only():
+def test_radio_only_board_reports_battery_from_its_divider():
+    """No PMIC, but the board brings the cell out to an ADC through a divider,
+    so it still reports batt_mv -- a bare uptime heartbeat is not worth an
+    uplink."""
     lib = default_library()
     assert [f["name"] for f in codec.fields_for(_design("ttgo-lora32-v1"), lib)] == [
-        "uptime_s", "boot_count",
+        "uptime_s", "boot_count", "batt_mv",
     ]
 
 
@@ -56,13 +59,17 @@ def test_oled_is_display_only_no_payload_field():
     assert base == witholed
 
 
-def test_external_gps_adds_gps_fields_without_battery():
-    # Heltec has no onboard GPS/AXP; an external GPS config still adds GPS fields.
+def test_external_gps_adds_gps_fields():
+    # Heltec has no onboard GPS; an external GPS config still adds GPS fields.
     lib = default_library()
     design = _design("heltec-wifi-lora32-v3", gps={"rx_pin": "GPIO3", "tx_pin": "GPIO1"})
     names = [f["name"] for f in codec.fields_for(design, lib)]
     assert "lat" in names and "sats" in names
-    assert "batt_mv" not in names  # no AXP192 on the Heltec
+    # No AXP192, but the board has a battery divider, so batt_mv still appears
+    # -- and in the PMIC's slot (after GPS), so the layout is identical whether
+    # the cell is sensed by a PMIC or a divider.
+    assert "batt_mv" in names
+    assert names.index("lat") < names.index("batt_mv")
 
 
 def test_decode_js_offsets_and_scaling():
@@ -110,3 +117,17 @@ def test_ha_device_info_gps_emits_device_tracker():
     # a non-GPS board gets no device_tracker
     plain_js = codec.generate_codec(_design("ttgo-lora32-v1"), lib)
     assert "device_tracker" not in plain_js
+
+
+def test_decode_js_rejects_short_payload():
+    """A 1-byte uplink against a 22-byte layout reads past the end: JS gives
+    undefined, the shifts coerce to 0, and the codec returns a full set of
+    plausible zeros with errors:[]. Home Assistant then shows fabricated
+    readings that look exactly like real ones."""
+    fields = codec.fields_for(_design("ttgo-t-beam"), default_library())
+    js = codec.decode_js(fields)
+    size = codec.payload_size(fields)
+    assert f"if (b.length < {size})" in js
+    assert f"errors: ['expected {size} bytes, got ' + b.length]" in js
+    # The guard must precede the first field read, or it cannot prevent it.
+    assert js.index("b.length") < js.index("data.uptime_s")

--- a/tests/test_firmware_gen.py
+++ b/tests/test_firmware_gen.py
@@ -152,3 +152,24 @@ def test_lorawan_matches_golden(lib):
     assert fw["src/main.cpp"] == (golden_dir / "t-beam.cpp").read_text()
     assert fw["platformio.ini"] == (golden_dir / "t-beam.ini").read_text()
     assert codec == (golden_dir / "t-beam.js").read_text()
+
+
+def test_synthesized_dht_emits_its_configured_pin(lib):
+    """A DHT requested via `lorawan.dht22` has no wiring, so the render
+    context sets `pin` to None. Jinja's `default()` only fires on *undefined*,
+    so the old template fell through to a literal "None" in the C++."""
+    src = generate_firmware(
+        _design("ttgo-t-beam", dht22={"pin": "GPIO13"}), lib
+    )["src/main.cpp"]
+    assert "DHT dht(13, DHT22);" in src
+    assert "None" not in src
+
+
+def test_tbeam_powers_its_rails_before_using_them(lib):
+    """The T-Beam's LoRa and GPS rails hang off the AXP192. Without the PMIC
+    init the board boots and reports setting up LoRaWAN while the radio is
+    unpowered -- it never joins, and serial output looks healthy."""
+    src = generate_firmware(_design("ttgo-t-beam", dht22={"pin": "GPIO13"}), lib)["src/main.cpp"]
+    assert "XPowersLib.h" in src
+    assert "enableLDO2" in src and "enableLDO3" in src
+    assert src.index("power.begin") < src.index("GPSSerial.begin")

--- a/tests/test_lorawan_api.py
+++ b/tests/test_lorawan_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import types
 
 import pytest
 from fastapi.testclient import TestClient
@@ -218,7 +219,8 @@ def test_set_codec_reflects_external_gps(client, monkeypatch):
     design = _design("heltec-wifi-lora32-v3", gps={"rx_pin": "GPIO3", "tx_pin": "GPIO1"})
     r = client.post("/lorawan/codec", json={"dev_eui": "64b708fffeab8974", "design": design})
     assert r.status_code == 200
-    assert "data.lat" in fake.codec_set and "data.batt_mv" not in fake.codec_set
+    # batt_mv comes from the board's battery divider, not a PMIC.
+    assert "data.lat" in fake.codec_set and "data.batt_mv" in fake.codec_set
 
 
 def test_set_codec_rejects_bad_dev_eui(client, monkeypatch):
@@ -384,3 +386,42 @@ def test_provision_esphome_502_surfaces_grpc_status_on_chirpstack_unavailable(
     )
     assert r.status_code == 502
     assert "UNAUTHENTICATED" in r.json()["detail"]
+
+
+def test_platformio_status_flags_unwritable_core_dir(monkeypatch, tmp_path):
+    """`pio --version` never touches the core dir, so a status probe that
+    stops there stays green on an install that cannot build -- which is how
+    a read-only baked core dir reached users as a mid-build traceback."""
+    from wirestudio.targets.lorawan import compile as compile_mod
+
+    monkeypatch.setattr(compile_mod, "_pio_cmd", lambda: ["pio"])
+    monkeypatch.setattr(
+        compile_mod.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="PlatformIO Core 6.1", stderr=""),
+    )
+    ro = tmp_path / "pio"
+    ro.mkdir()
+    ro.chmod(0o500)
+    monkeypatch.setenv("PLATFORMIO_CORE_DIR", str(ro))
+    try:
+        status = compile_mod.platformio_status()
+    finally:
+        ro.chmod(0o700)
+    assert status["available"] is False
+    assert "not writable" in status["reason"]
+
+
+def test_platformio_status_available_when_core_dir_usable(monkeypatch, tmp_path):
+    from wirestudio.targets.lorawan import compile as compile_mod
+
+    monkeypatch.setattr(compile_mod, "_pio_cmd", lambda: ["pio"])
+    monkeypatch.setattr(
+        compile_mod.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="PlatformIO Core 6.1", stderr=""),
+    )
+    monkeypatch.setenv("PLATFORMIO_CORE_DIR", str(tmp_path / "pio"))
+    status = compile_mod.platformio_status()
+    assert status["available"] is True
+    assert status["reason"] is None

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -1,0 +1,352 @@
+"""Workbench remote flash transport (phase 1)."""
+import base64
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from wirestudio.api.app import create_app
+from wirestudio.workbench import Slot, WorkbenchClient, WorkbenchUnavailable
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _slot(label="SLOT1", **over):
+    d = {
+        "label": label,
+        "state": "idle",
+        "present": True,
+        "detected_chip": "esp32",
+        "url": f"rfc2217://bench:400{label[-1]}",
+        "flapping": False,
+        "last_error": None,
+        "usb_devices": [{"product": "CP2104 USB to UART Bridge Controller"}],
+    }
+    d.update(over)
+    return d
+
+
+class FakeBench:
+    """Stands in for the Pi's portal. Records what it was asked to flash."""
+
+    # Verified against the reference bench: one buffered JSON answer, not
+    # a line stream, and the esptool exit status is its own field.
+    OK_OUTPUT = (
+        "esptool v5.3.1\nConnecting......\nChip type:          ESP32-D0WDQ6\n"
+        "Writing at 0x00000000 [                    ]   0.0% 0/197883 bytes...\n"
+        "Wrote 365264 bytes at 0x00000000 in 4.6 seconds.\nHash of data verified.\n"
+    )
+    FAIL_OUTPUT = (
+        "esptool v5.3.1\nConnecting......\n"
+        "Writing at 0x00000000 [                    ]   0.0% 0/197883 bytes...\n"
+        "A fatal error occurred: Packet content transfer stopped\n"
+    )
+
+    def __init__(self, slots=None, flash_status=200, returncode=0, require_token="s3cret"):
+        self.slots = slots if slots is not None else [_slot()]
+        self.flash_status = flash_status
+        self.returncode = returncode
+        self.require_token = require_token
+        self.flashed: list[dict] = []
+
+    def handler(self, req: httpx.Request) -> httpx.Response:
+        if self.require_token and req.headers.get("authorization") != f"Bearer {self.require_token}":
+            return httpx.Response(401, json={"error": "unauthorized"})
+        if req.url.path == "/api/info":
+            return httpx.Response(200, json={"hostname": "bench", "slots_configured": len(self.slots)})
+        if req.url.path == "/api/devices":
+            return httpx.Response(200, json={"slots": self.slots})
+        if req.url.path == "/api/flash":
+            if self.flash_status >= 400:
+                return httpx.Response(
+                    self.flash_status, json={"ok": False, "error": "esptool: no serial data"}
+                )
+            self.flashed.append({"body": req.content})
+            ok = self.returncode == 0
+            return httpx.Response(
+                200,
+                json={
+                    "ok": ok,
+                    "output": self.OK_OUTPUT if ok else self.FAIL_OUTPUT,
+                    "returncode": self.returncode,
+                },
+            )
+        return httpx.Response(404)
+
+    def client(self, **kw) -> WorkbenchClient:
+        kw.setdefault("base_url", "http://bench:8080")
+        kw.setdefault("token", self.require_token or "t")
+        return WorkbenchClient(transport=httpx.MockTransport(self.handler), **kw)
+
+
+def _app(bench, monkeypatch):
+    monkeypatch.delenv("WORKBENCH_URL", raising=False)
+    monkeypatch.delenv("WORKBENCH_TOKEN", raising=False)
+    return TestClient(create_app(workbench_client_factory=bench.client))
+
+
+def _parse_sse(body: str) -> list[dict]:
+    events = []
+    for raw in body.split("\n\n"):
+        if not raw.strip():
+            continue
+        ev = {"event": "message"}
+        for line in raw.splitlines():
+            if line.startswith("event: "):
+                ev["event"] = line[len("event: "):]
+            elif line.startswith("data: "):
+                ev["data"] = json.loads(line[len("data: "):])
+        events.append(ev)
+    return events
+
+
+# ----------------------------------------------------------------------
+# Slot health
+# ----------------------------------------------------------------------
+
+
+def test_empty_slot_is_not_flashable():
+    ok, reason = Slot.from_api(
+        _slot(present=False, state="absent", usb_devices=[])
+    ).flashable
+    assert not ok
+    assert "empty" in reason
+
+
+def test_non_serial_peripheral_is_not_reported_as_empty():
+    """SLOT4 on the reference bench holds an SDR: attached, but no devnode."""
+    ok, reason = Slot.from_api(
+        _slot(present=False, state="absent", usb_devices=[{"product": "RTL2832U"}])
+    ).flashable
+    assert not ok
+    assert "no serial device" in reason and "RTL2832U" in reason
+
+
+def test_flapping_slot_is_refused_with_its_error():
+    ok, reason = Slot.from_api(
+        _slot(flapping=True, last_error="usb disconnect")
+    ).flashable
+    assert not ok
+    assert "flapping" in reason and "usb disconnect" in reason
+
+
+def test_busy_slot_is_refused_naming_its_state():
+    ok, reason = Slot.from_api(_slot(state="monitoring")).flashable
+    assert not ok
+    assert "monitoring" in reason
+
+
+def test_idle_present_slot_is_flashable():
+    ok, reason = Slot.from_api(_slot()).flashable
+    assert ok and reason is None
+
+
+# ----------------------------------------------------------------------
+# Config gate
+# ----------------------------------------------------------------------
+
+
+async def test_unconfigured_without_url(monkeypatch):
+    monkeypatch.delenv("WORKBENCH_URL", raising=False)
+    monkeypatch.delenv("WORKBENCH_TOKEN", raising=False)
+    ok, reason = await WorkbenchClient().is_available()
+    assert not ok and reason == "WORKBENCH_URL not set"
+
+
+async def test_url_alone_is_not_configured():
+    """A URL without a token must not be enough -- see docs/workbench.md."""
+    wc = WorkbenchClient(base_url="http://bench:8080", token="")
+    assert not wc.is_configured()
+    ok, reason = await wc.is_available()
+    assert not ok and reason == "WORKBENCH_TOKEN not set"
+
+
+async def test_bad_token_reports_unauthorized():
+    bench = FakeBench()
+    ok, reason = await bench.client(token="wrong").is_available()
+    assert not ok and "unauthorized" in reason
+
+
+async def test_available_when_configured_and_reachable():
+    ok, reason = await FakeBench().client().is_available()
+    assert ok and reason is None
+
+
+# ----------------------------------------------------------------------
+# Endpoints
+# ----------------------------------------------------------------------
+
+
+def test_status_reports_reason_and_hint_when_unconfigured(monkeypatch):
+    monkeypatch.delenv("WORKBENCH_URL", raising=False)
+    monkeypatch.delenv("WORKBENCH_TOKEN", raising=False)
+    body = TestClient(create_app()).get("/workbench/status").json()
+    assert body["available"] is False
+    assert body["reason"] == "WORKBENCH_URL not set"
+    assert "WORKBENCH_URL" in body["configure_hint"]
+
+
+def test_status_is_200_even_when_unavailable(monkeypatch):
+    """The UI keys off `available`; a status probe must not itself fail."""
+    monkeypatch.delenv("WORKBENCH_URL", raising=False)
+    assert TestClient(create_app()).get("/workbench/status").status_code == 200
+
+
+def test_slots_surface_flashability(monkeypatch):
+    bench = FakeBench(
+        slots=[_slot("SLOT1"), _slot("SLOT2", present=False, state="absent", usb_devices=[])]
+    )
+    r = _app(bench, monkeypatch).get("/workbench/slots")
+    assert r.status_code == 200
+    slots = {s["label"]: s for s in r.json()["slots"]}
+    assert slots["SLOT1"]["flashable"] is True
+    assert slots["SLOT2"]["flashable"] is False
+    assert "empty" in slots["SLOT2"]["blocked_reason"]
+
+
+def test_slots_503_when_unconfigured(monkeypatch):
+    monkeypatch.delenv("WORKBENCH_URL", raising=False)
+    monkeypatch.delenv("WORKBENCH_TOKEN", raising=False)
+    r = TestClient(create_app()).get("/workbench/slots")
+    assert r.status_code == 503
+    assert "WORKBENCH_URL" in r.json()["detail"]
+
+
+def test_flash_streams_bench_output_then_done(monkeypatch):
+    bench = FakeBench()
+    r = _app(bench, monkeypatch).post(
+        "/workbench/flash",
+        json={
+            "slot": "SLOT1",
+            "images": [{"offset": "0x10000", "data": base64.b64encode(b"firmware").decode()}],
+        },
+    )
+    assert r.status_code == 200
+    events = _parse_sse(r.text)
+    assert any("Hash of data verified" in e["data"].get("data", "") for e in events)
+    assert events[-1]["data"] == {
+        "type": "done", "ok": True, "slot": "SLOT1", "returncode": 0,
+    }
+    assert len(bench.flashed) == 1
+
+
+def test_uploads_parts_named_bin_at_offset(monkeypatch):
+    """The portal keys parts by `bin@<offset>`; any other name is ignored
+    and the flash fails as "no binaries to flash"."""
+    bench = FakeBench()
+    _app(bench, monkeypatch).post(
+        "/workbench/flash",
+        json={
+            "slot": "SLOT1",
+            "images": [{"offset": "0x10000", "data": base64.b64encode(b"fw").decode()}],
+        },
+    )
+    assert b'name="bin@0x10000"' in bench.flashed[0]["body"]
+
+
+def test_nonzero_returncode_is_a_failure_not_a_success(monkeypatch):
+    """esptool can exit non-zero with HTTP 200 and ok:false -- reporting
+    that as a successful flash is the worst failure this endpoint has."""
+    bench = FakeBench(returncode=2)
+    r = _app(bench, monkeypatch).post(
+        "/workbench/flash",
+        json={"slot": "SLOT1", "images": [{"offset": "0x0", "data": base64.b64encode(b"x").decode()}]},
+    )
+    events = _parse_sse(r.text)
+    assert events[-1]["event"] == "error"
+    assert "fatal error" in events[-1]["data"]["message"]
+    assert not any(e["data"].get("type") == "done" for e in events if e["event"] == "message")
+
+
+def test_esptool_log_is_split_into_lines(monkeypatch):
+    """The bench answers with one JSON blob; emitting it verbatim would
+    put escaped JSON in front of the operator instead of a log."""
+    bench = FakeBench()
+    r = _app(bench, monkeypatch).post(
+        "/workbench/flash",
+        json={"slot": "SLOT1", "images": [{"offset": "0x0", "data": base64.b64encode(b"x").decode()}]},
+    )
+    logs = [e["data"]["data"] for e in _parse_sse(r.text) if e["data"].get("type") == "log"]
+    assert "esptool v5.3.1" in logs
+    assert "Hash of data verified." in logs
+
+
+def test_flash_rejects_busy_slot_before_streaming(monkeypatch):
+    """409 rather than an SSE error frame -- the stream must not open."""
+    bench = FakeBench(slots=[_slot(state="flashing")])
+    r = _app(bench, monkeypatch).post(
+        "/workbench/flash",
+        json={"slot": "SLOT1", "images": [{"offset": "0x0", "data": base64.b64encode(b"x").decode()}]},
+    )
+    assert r.status_code == 409
+    assert "flashing" in r.json()["detail"]
+    assert not bench.flashed
+
+
+def test_flash_refuses_flapping_slot(monkeypatch):
+    bench = FakeBench(slots=[_slot(flapping=True, last_error="usb disconnect")])
+    r = _app(bench, monkeypatch).post(
+        "/workbench/flash",
+        json={"slot": "SLOT1", "images": [{"offset": "0x0", "data": base64.b64encode(b"x").decode()}]},
+    )
+    assert r.status_code == 409
+    assert not bench.flashed
+
+
+def test_flash_requires_images(monkeypatch):
+    bench = FakeBench()
+    r = _app(bench, monkeypatch).post("/workbench/flash", json={"slot": "SLOT1", "images": []})
+    assert r.status_code == 422
+
+
+def test_flash_rejects_malformed_base64(monkeypatch):
+    bench = FakeBench()
+    r = _app(bench, monkeypatch).post(
+        "/workbench/flash",
+        json={"slot": "SLOT1", "images": [{"offset": "0x0", "data": "not!base64"}]},
+    )
+    assert r.status_code == 422
+    assert not bench.flashed
+
+
+def test_flash_unknown_slot_is_502(monkeypatch):
+    bench = FakeBench()
+    r = _app(bench, monkeypatch).post(
+        "/workbench/flash",
+        json={"slot": "SLOT9", "images": [{"offset": "0x0", "data": base64.b64encode(b"x").decode()}]},
+    )
+    assert r.status_code == 502
+
+
+def test_flash_bench_error_becomes_sse_error_frame(monkeypatch):
+    """A failure after the pre-check passed can only surface mid-stream."""
+    bench = FakeBench(flash_status=500)
+    r = _app(bench, monkeypatch).post(
+        "/workbench/flash",
+        json={"slot": "SLOT1", "images": [{"offset": "0x0", "data": base64.b64encode(b"x").decode()}]},
+    )
+    assert r.status_code == 200
+    events = _parse_sse(r.text)
+    assert events[-1]["event"] == "error"
+    # The bench's own words, not a generic "http 500".
+    assert "esptool: no serial data" in events[-1]["data"]["message"]
+
+
+async def test_client_flash_refuses_empty_images():
+    with pytest.raises(WorkbenchUnavailable, match="no images"):
+        async for _ in FakeBench().client().flash("SLOT1", []):
+            pass
+
+
+async def test_offsets_parsed_as_hex():
+    """Browser sends "0x10000"; decimal parsing would flash at 10000."""
+    from wirestudio.api.workbench import _parse_images
+
+    images = _parse_images([{"offset": "0x10000", "data": base64.b64encode(b"x").decode()}])
+    assert images[0][0] == 0x10000

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -36,6 +36,9 @@ import type {
   SolvePinsResponse,
   ValidateResponse,
   Design,
+  WorkbenchStatus,
+  WorkbenchSlot,
+  WorkbenchFlashEvent,
 } from "../types/api";
 
 // In dev, Vite proxies /api/* to the studio API on :8765 (see vite.config.ts).
@@ -237,6 +240,8 @@ export const api = {
   },
   circuitpythonCode: (board: string) =>
     requestText(`/circuitpython/code?board=${encodeURIComponent(board)}`),
+  workbenchStatus: () => request<WorkbenchStatus>("/workbench/status"),
+  workbenchSlots: () => request<{ slots: WorkbenchSlot[] }>("/workbench/slots"),
   kicadRouteStatus: () =>
     request<KicadRouteStatus>("/design/kicad/route/status"),
   kicadRoutedBoard: (cacheKey: string) =>
@@ -530,6 +535,33 @@ export async function* lorawanCompile(design: Design): AsyncGenerator<LorawanCom
     throw new Error("lorawan/compile: no response body");
   }
   yield* parseSse<LorawanCompileEvent>(res.body);
+}
+
+/**
+ * Flash a board on a workbench slot. The studio uploads the image and the
+ * bench runs esptool against its own USB, so this yields the whole log at
+ * completion rather than live progress -- the bench buffers.
+ */
+export async function* workbenchFlash(body: {
+  slot: string;
+  chip: string;
+  erase: boolean;
+  images: Array<{ offset: string; data: string }>;
+}): AsyncGenerator<WorkbenchFlashEvent> {
+  const res = await fetch(`${API_BASE}/workbench/flash`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "text/event-stream" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    let errBody: unknown = undefined;
+    try { errBody = await res.json(); } catch { /* not json */ }
+    throw new ApiError(res.status, apiErrorMessage("POST", "/workbench/flash", res.status, errBody), errBody);
+  }
+  if (!res.body) {
+    throw new Error("workbench/flash: no response body");
+  }
+  yield* parseSse<WorkbenchFlashEvent>(res.body);
 }
 
 export { ApiError };

--- a/web/src/components/FlashDialog.tsx
+++ b/web/src/components/FlashDialog.tsx
@@ -460,6 +460,12 @@ function CircuitPythonFlash({ design, boards }: { design: Design | null; boards:
         </div>
       )}
 
+      <FlashTargetPicker
+        target={target}
+        onChange={setTarget}
+        disabled={phase === "fetching" || phase === "flashing"}
+      />
+
       <div className="flex items-center justify-between gap-3 text-xs text-ink-dim">
         <div>
           {!design

--- a/web/src/components/FlashDialog.tsx
+++ b/web/src/components/FlashDialog.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Radio, UploadCloud, Zap } from "lucide-react";
-import type { BoardSummary, Design } from "../types/api";
+import type { BoardSummary, Design, WorkbenchSlot, WorkbenchStatus } from "../types/api";
 import { api, ApiError } from "../api/client";
-import { flashFirmware, type FlashSession } from "../lib/flash";
+import { flashToTarget, type FlashSession, type FlashTarget } from "../lib/flash";
 import { tasmotaConfigCommands, type TasmotaTemplate } from "../lib/tasmota";
 import { Button, Dialog, FieldLabel, Input } from "./ui";
 import { LorawanFlashDialog } from "./LorawanFlashDialog";
@@ -22,6 +22,111 @@ interface Props {
   boards: BoardSummary[] | null;
   onClose: () => void;
   onOpenFleet: () => void;
+}
+
+/**
+ * Local USB vs a remote bench slot. Renders nothing until the workbench
+ * status probe answers, and nothing at all when no bench is configured --
+ * a lone "Local USB" toggle is noise for the majority who have none.
+ */
+function FlashTargetPicker({
+  target,
+  onChange,
+  disabled,
+}: {
+  target: FlashTarget;
+  onChange: (t: FlashTarget) => void;
+  disabled: boolean;
+}) {
+  const [status, setStatus] = useState<WorkbenchStatus | null>(null);
+  const [slots, setSlots] = useState<WorkbenchSlot[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.workbenchStatus()
+      .then((s) => {
+        if (cancelled) return;
+        setStatus(s);
+        if (!s.available) return;
+        return api.workbenchSlots()
+          .then((r) => { if (!cancelled) setSlots(r.slots); })
+          .catch(() => { if (!cancelled) setSlots([]); });
+      })
+      .catch(() => {
+        if (!cancelled) setStatus({ available: false, reason: null, url: null, configure_hint: null });
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!status?.available) return null;
+
+  const usable = (slots ?? []).filter((s) => s.flashable);
+
+  return (
+    <div className="space-y-2 rounded-lg border border-line bg-surface-2/40 p-3">
+      <FieldLabel>Flash target</FieldLabel>
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          disabled={disabled}
+          onClick={() => onChange({ kind: "usb" })}
+          className={`rounded-lg border px-3 py-2 text-left transition-colors disabled:opacity-40 ${
+            target.kind === "usb"
+              ? "border-accent-500/50 bg-accent-500/5"
+              : "border-line bg-surface-2/40 enabled:hover:border-line-strong"
+          }`}
+        >
+          <div className="text-sm font-medium text-ink">Local USB</div>
+          <div className="mt-0.5 text-[11px] text-ink-faint">WebSerial, board plugged into this machine</div>
+        </button>
+        <button
+          disabled={disabled || usable.length === 0}
+          onClick={() => usable[0] && onChange({ kind: "workbench", slot: usable[0].label })}
+          className={`rounded-lg border px-3 py-2 text-left transition-colors disabled:opacity-40 ${
+            target.kind === "workbench"
+              ? "border-accent-500/50 bg-accent-500/5"
+              : "border-line bg-surface-2/40 enabled:hover:border-line-strong"
+          }`}
+        >
+          <div className="text-sm font-medium text-ink">Workbench slot</div>
+          <div className="mt-0.5 text-[11px] text-ink-faint">
+            {slots === null
+              ? "checking slots…"
+              : usable.length === 0
+                ? "no slot ready"
+                : `${usable.length} slot${usable.length > 1 ? "s" : ""} ready`}
+          </div>
+        </button>
+      </div>
+
+      {target.kind === "workbench" && (
+        <div className="flex flex-wrap gap-1.5">
+          {(slots ?? []).map((s) => (
+            <button
+              key={s.label}
+              disabled={disabled || !s.flashable}
+              title={s.blocked_reason ?? s.product ?? undefined}
+              onClick={() => onChange({ kind: "workbench", slot: s.label })}
+              className={`rounded-md border px-2 py-1 font-mono text-[11px] transition-colors disabled:opacity-40 ${
+                target.slot === s.label
+                  ? "border-accent-500/50 bg-accent-500/10 text-ink"
+                  : "border-line bg-surface-2/40 text-ink-dim enabled:hover:border-line-strong"
+              }`}
+            >
+              {s.label}
+              {!s.flashable && <span className="ml-1 text-ink-faint">·{s.state}</span>}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {target.kind === "workbench" && (
+        <p className="text-[11px] text-ink-faint">
+          The bench runs esptool on its own USB and reports when the flash
+          finishes, so the log arrives at the end rather than live.
+        </p>
+      )}
+    </div>
+  );
 }
 
 /** One flashing surface for every framework. WebSerial + esptool-js is
@@ -105,6 +210,7 @@ function MeshtasticFlash({ design, boards }: { design: Design | null; boards: Bo
   const [progress, setProgress] = useState<number>(0);
   const [log, setLog] = useState<string[]>([]);
   const [serial, setSerial] = useState<string>("");
+  const [target, setTarget] = useState<FlashTarget>({ kind: "usb" });
   const sessionRef = useRef<FlashSession | null>(null);
 
   const boardLibraryId = String((design?.board as Record<string, unknown> | undefined)?.library_id ?? "");
@@ -139,9 +245,10 @@ function MeshtasticFlash({ design, boards }: { design: Design | null; boards: Bo
       const { data, offset } = await api.meshtasticFirmware(boardLibraryId);
       appendLog(`fetched ${status?.version ?? "release"} factory image (${(data.length / 1024).toFixed(0)} KiB)`);
       setPhase("flashing");
-      const session = await flashFirmware({
+      const session = await flashToTarget(target, {
         images: [{ data, address: offset }],
         eraseAll: true,
+        chip: board?.chip_variant,
         onProgress: (written, total) => setProgress(total ? written / total : 0),
         onLog: appendLog,
         onSerial: (text) => setSerial((s) => (s + text).slice(-8000)),
@@ -162,6 +269,12 @@ function MeshtasticFlash({ design, boards }: { design: Design | null; boards: Bo
           <div className="mt-1">{status.reason}</div>
         </div>
       )}
+
+      <FlashTargetPicker
+        target={target}
+        onChange={setTarget}
+        disabled={phase === "fetching" || phase === "flashing"}
+      />
 
       <div className="flex items-center justify-between gap-3 text-xs text-ink-dim">
         <div>
@@ -237,6 +350,7 @@ function CircuitPythonFlash({ design, boards }: { design: Design | null; boards:
   const [serial, setSerial] = useState<string>("");
   const [starter, setStarter] = useState<string | null>(null);
   const [saved, setSaved] = useState<string | null>(null);
+  const [target, setTarget] = useState<FlashTarget>({ kind: "usb" });
   const sessionRef = useRef<FlashSession | null>(null);
 
   const boardLibraryId = String((design?.board as Record<string, unknown> | undefined)?.library_id ?? "");
@@ -282,9 +396,10 @@ function CircuitPythonFlash({ design, boards }: { design: Design | null; boards:
       const { data, offset } = await api.circuitpythonFirmware(boardLibraryId);
       appendLog(`fetched CircuitPython ${status?.version ?? "release"} image (${(data.length / 1024).toFixed(0)} KiB)`);
       setPhase("flashing");
-      const session = await flashFirmware({
+      const session = await flashToTarget(target, {
         images: [{ data, address: offset }],
         eraseAll: true,
+        chip: board?.chip_variant,
         onProgress: (written, total) => setProgress(total ? written / total : 0),
         onLog: appendLog,
         onSerial: (text) => setSerial((s) => (s + text).slice(-8000)),
@@ -423,6 +538,7 @@ function TasmotaFlash({ design, boards }: { design: Design | null; boards: Board
   const [templateWarnings, setTemplateWarnings] = useState<string[]>([]);
   const [ssid, setSsid] = useState("");
   const [password, setPassword] = useState("");
+  const [target, setTarget] = useState<FlashTarget>({ kind: "usb" });
   const sessionRef = useRef<FlashSession | null>(null);
 
   const boardLibraryId = String((design?.board as Record<string, unknown> | undefined)?.library_id ?? "");
@@ -469,9 +585,10 @@ function TasmotaFlash({ design, boards }: { design: Design | null; boards: Board
       const { data, offset } = await api.tasmotaFirmware(chip);
       appendLog(`fetched release image (${(data.length / 1024).toFixed(0)} KiB) for ${chip}`);
       setPhase("flashing");
-      const session = await flashFirmware({
+      const session = await flashToTarget(target, {
         images: [{ data, address: offset }],
         eraseAll: true,
+        chip: board?.chip_variant,
         onProgress: (written, total) => setProgress(total ? written / total : 0),
         onLog: appendLog,
         onSerial: (text) => setSerial((s) => (s + text).slice(-8000)),
@@ -513,6 +630,8 @@ function TasmotaFlash({ design, boards }: { design: Design | null; boards: Board
         </div>
       )}
 
+      <FlashTargetPicker target={target} onChange={setTarget} disabled={busy} />
+
       <div className="flex items-center justify-between gap-3 text-xs text-ink-dim">
         <div>
           {chip
@@ -538,6 +657,14 @@ function TasmotaFlash({ design, boards }: { design: Design | null; boards: Board
       {(phase === "flashed" || phase === "pushing" || phase === "pushed") && (
         <div className="space-y-2 rounded-lg border border-line bg-surface-2/40 p-3">
           <div className="text-xs font-medium text-ink">Push configuration over serial</div>
+          {sessionRef.current === null && (
+            <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-[11px] text-amber-200">
+              Flashed on a workbench slot, so there is no serial session here to
+              push the template through — the bench owns the port. Push the
+              config from a local USB flash, or configure the device over its
+              own WiFi portal.
+            </div>
+          )}
           {template ? (
             <pre className="max-h-24 overflow-auto rounded-md bg-surface-0 p-2 font-mono text-[10px] text-ink-dim ring-1 ring-line">
               {JSON.stringify(template)}
@@ -569,7 +696,7 @@ function TasmotaFlash({ design, boards }: { design: Design | null; boards: Board
             </span>
             <Button
               variant="primary"
-              disabled={!template || phase === "pushing"}
+              disabled={!template || phase === "pushing" || sessionRef.current === null}
               onClick={handlePush}
             >
               <Radio className="h-3.5 w-3.5" />

--- a/web/src/lib/flash.ts
+++ b/web/src/lib/flash.ts
@@ -164,6 +164,59 @@ export async function flashFirmware(opts: FlashOptions): Promise<FlashSession> {
   };
 }
 
+/**
+ * Where the firmware goes. "usb" is WebSerial in this browser; "workbench"
+ * is a slot on a remote bench, which is the only path to a board that isn't
+ * physically here.
+ */
+export type FlashTarget = { kind: "usb" } | { kind: "workbench"; slot: string };
+
+/**
+ * Flash to either target. Returns a FlashSession for USB; returns null for
+ * the workbench, which has no serial session to hand back -- the bench owns
+ * the port and only answers once the flash is done. Boot output over a slot
+ * is phase 2.
+ */
+export async function flashToTarget(
+  target: FlashTarget,
+  opts: FlashOptions & { chip?: string },
+): Promise<FlashSession | null> {
+  if (target.kind === "usb") {
+    return flashFirmware(opts);
+  }
+  if (opts.images.length === 0) {
+    throw new Error("nothing to flash: no firmware images provided");
+  }
+
+  const { workbenchFlash } = await import("../api/client");
+  for await (const event of workbenchFlash({
+    slot: target.slot,
+    chip: opts.chip ?? "esp32",
+    erase: opts.eraseAll ?? false,
+    images: opts.images.map((i) => ({
+      offset: `0x${i.address.toString(16)}`,
+      data: toBase64(i.data),
+    })),
+  })) {
+    if (event.type === "log") opts.onLog?.(event.data);
+  }
+  // The bench reports bytes only in its log, so there is no honest
+  // incremental progress to report -- jump to complete rather than fake it.
+  opts.onProgress?.(1, 1);
+  return null;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  // btoa needs a binary string; chunk it so a multi-MB image doesn't blow
+  // the argument limit on String.fromCharCode.
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -308,6 +308,32 @@ export type KicadRouteEvent =
   | { type: "log"; data: string }
   | { type: "done"; ok: boolean; routed: boolean; cache_key: string; cache_hit: boolean };
 
+export interface WorkbenchStatus {
+  available: boolean;
+  reason: string | null;
+  url: string | null;
+  configure_hint: string | null;
+}
+
+export interface WorkbenchSlot {
+  label: string;
+  state: string;
+  present: boolean;
+  chip: string | null;
+  product: string | null;
+  serial_url: string | null;
+  flapping: boolean;
+  last_error: string | null;
+  flashable: boolean;
+  blocked_reason: string | null;
+}
+
+/** The bench buffers esptool, so every `log` arrives at completion --
+ *  there is no incremental progress to render. */
+export type WorkbenchFlashEvent =
+  | { type: "log"; data: string }
+  | { type: "done"; ok: boolean; slot: string; returncode: number | null };
+
 export interface FabStatus {
   bom: boolean;
   cpl: boolean;

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -211,6 +211,7 @@ def create_app(
     event_bus: Optional[DesignEventBus] = None,
     active_design: Optional[ActiveDesignTracker] = None,
     inventory: Optional[InventoryStore] = None,
+    workbench_client_factory=None,
 ) -> FastAPI:
     import os as _os
     lib = library or default_library()
@@ -1456,6 +1457,12 @@ def create_app(
     from wirestudio.api.circuitpython import router as circuitpython_router
 
     app.include_router(circuitpython_router(lib), prefix="/circuitpython")
+
+    # The workbench is a destination for firmware, not a source of it --
+    # the image still comes from whichever framework proxy serves it.
+    from wirestudio.api.workbench import router as workbench_router
+
+    app.include_router(workbench_router(workbench_client_factory), prefix="/workbench")
 
     if mcp_server is not None:
         # Streamable HTTP transport. mcp_server.streamable_http_app() registers

--- a/wirestudio/api/workbench.py
+++ b/wirestudio/api/workbench.py
@@ -1,0 +1,142 @@
+"""Workbench routes — remote flash transport (phase 1).
+
+Not a target plugin: the workbench is a place to put firmware, not a
+thing that generates it. The image comes from whichever framework proxy
+already serves it; this module only moves it to a slot.
+"""
+from __future__ import annotations
+
+import json
+from typing import Callable, Optional
+
+from fastapi import APIRouter, Body, HTTPException
+from fastapi.responses import StreamingResponse
+
+from wirestudio.workbench import WorkbenchClient, WorkbenchUnavailable
+
+_SSE_HEADERS = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+
+
+def _parse_images(raw: list[dict]) -> list[tuple[int, bytes]]:
+    """[{offset, data}] -> [(int, bytes)]. `data` is base64.
+
+    Offsets arrive as strings like "0x10000" from the browser, so they
+    are parsed with base=0 rather than assumed decimal.
+    """
+    import base64
+
+    if not raw:
+        raise ValueError("no images supplied")
+    out: list[tuple[int, bytes]] = []
+    for i, img in enumerate(raw):
+        try:
+            offset = int(str(img["offset"]), 0)
+            data = base64.b64decode(img["data"], validate=True)
+        except (KeyError, ValueError, TypeError) as e:
+            raise ValueError(f"image {i}: {e}") from e
+        if offset < 0:
+            raise ValueError(f"image {i}: negative offset")
+        if not data:
+            raise ValueError(f"image {i}: empty payload")
+        out.append((offset, data))
+    return out
+
+
+def router(client_factory: Optional[Callable[[], WorkbenchClient]] = None) -> APIRouter:
+    router = APIRouter(tags=["workbench"])
+    make_client = client_factory or WorkbenchClient
+
+    @router.get("/status")
+    async def workbench_status() -> dict:
+        wc = make_client()
+        ok, reason = await wc.is_available()
+        return {
+            "available": ok,
+            "reason": reason,
+            "url": wc.base_url or None,
+            "configure_hint": (
+                "Export WORKBENCH_URL=http://<pi>:8080 and WORKBENCH_TOKEN=<secret> "
+                "to flash boards on a remote bench."
+                if not ok
+                else None
+            ),
+        }
+
+    @router.get("/slots")
+    async def workbench_slots() -> dict:
+        wc = make_client()
+        if not wc.is_configured():
+            raise HTTPException(
+                status_code=503,
+                detail="workbench not configured (set WORKBENCH_URL and WORKBENCH_TOKEN)",
+            )
+        try:
+            slots = await wc.slots()
+        except WorkbenchUnavailable as e:
+            raise HTTPException(status_code=502, detail=str(e)) from e
+        return {
+            "slots": [
+                {
+                    "label": s.label,
+                    "state": s.state,
+                    "present": s.present,
+                    "chip": s.chip,
+                    "product": s.product,
+                    "serial_url": s.serial_url,
+                    "flapping": s.flapping,
+                    "last_error": s.last_error,
+                    "flashable": s.flashable[0],
+                    "blocked_reason": s.flashable[1],
+                }
+                for s in slots
+            ],
+        }
+
+    @router.post("/flash")
+    async def workbench_flash(body: dict = Body(...)) -> StreamingResponse:
+        """Flash a slot, streaming the bench's esptool output as SSE.
+
+        Everything checkable up front (config, slot health, payload
+        shape) is validated before the stream opens, since SSE cannot
+        carry a status change once it has.
+        """
+        wc = make_client()
+        if not wc.is_configured():
+            raise HTTPException(
+                status_code=503,
+                detail="workbench not configured (set WORKBENCH_URL and WORKBENCH_TOKEN)",
+            )
+
+        slot = body.get("slot")
+        if not slot or not isinstance(slot, str):
+            raise HTTPException(status_code=422, detail="slot is required")
+        try:
+            images = _parse_images(body.get("images") or [])
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+
+        try:
+            ok, reason = (await wc.slot(slot)).flashable
+        except WorkbenchUnavailable as e:
+            raise HTTPException(status_code=502, detail=str(e)) from e
+        if not ok:
+            raise HTTPException(status_code=409, detail=reason)
+
+        async def events():
+            try:
+                async for event in wc.flash(
+                    slot=slot,
+                    images=images,
+                    chip=body.get("chip", "esp32"),
+                    erase=bool(body.get("erase", False)),
+                    baud=int(body.get("baud", 921600)),
+                ):
+                    yield f"data: {json.dumps(event)}\n\n"
+            except WorkbenchUnavailable as e:
+                yield f"event: error\ndata: {json.dumps({'message': str(e)})}\n\n"
+
+        return StreamingResponse(
+            events(), media_type="text/event-stream", headers=_SSE_HEADERS
+        )
+
+    return router

--- a/wirestudio/library/boards/heltec-wifi-lora32-v2.yaml
+++ b/wirestudio/library/boards/heltec-wifi-lora32-v2.yaml
@@ -4,7 +4,11 @@ mcu: esp32
 chip_variant: esp32
 framework: arduino
 platformio_board: heltec_wifi_lora_32_V2
-flash_size_mb: 8
+# The V2 is an ESP32-PICO-D4, which integrates 4 MB. PlatformIO's board
+# definition claims 8 MB; building against that makes the bootloader assert on
+# the size mismatch and boot-loop. Verified on hardware: esptool reports
+# "Detected size(4096k)" and the 8 MB image never reaches setup().
+flash_size_mb: 4
 
 rails:
   - {name: "5V",  voltage: 5.0, source: usb}

--- a/wirestudio/library/components/battery_adc.yaml
+++ b/wirestudio/library/components/battery_adc.yaml
@@ -1,0 +1,72 @@
+id: battery_adc
+name: Onboard battery sense divider
+category: power
+use_cases: [power, battery, telemetry]
+aliases: [vbat, battery_divider]
+
+# Most LoRa dev boards without a PMIC bring the 18650/LiPo terminal out to an
+# ADC pin through a resistor divider (Heltec V2: GPIO37 / 3.2, TTGO LoRa32:
+# GPIO35 / 2.0). The board file carries the pin and the ratio; this component
+# turns them into the same `batt_mv` field the AXP192 contributes, so a board
+# reports battery voltage whichever way it senses it.
+electrical:
+  vcc_min: 3.0
+  vcc_max: 4.3
+  current_ma_typical: 0
+  current_ma_peak: 0
+  pins:
+    - {role: SENSE, kind: adc}
+
+esphome:
+  required_components: []
+  yaml_template: ""
+
+params_schema: {}
+
+notes: >
+  Read-only sense path. The divider ratio is a board property, not a user
+  choice, so it comes from the board's onboard_peripherals rather than params.
+
+lorawan:
+  globals: |
+    uint16_t batteryMv = 0;
+  setup: |
+    {# analogSetPinAttenuation() here fails "Pin is not configured as analog
+       channel" -- the Arduino core only attaches the pin on first read, and the
+       failed call takes setup() down with it (TG1WDT reset loop).
+       analogReadMilliVolts applies the calibration anyway. #}
+    {% if params.control is defined and params.control is not none -%}
+    pinMode({{ params.control }}, OUTPUT);
+    {% endif -%}
+  loop: |
+    {% if params.control is defined and params.control is not none -%}
+    // Some boards (Heltec V3) gate the divider behind a control pin; the
+    // reading is meaningless unless it is asserted for the measurement.
+    digitalWrite({{ params.control }}, LOW);
+    delay(10);
+    {% endif -%}
+    // analogReadMilliVolts applies the chip's own eFuse ADC calibration, which
+    // raw analogRead does not -- without it the reading is off by enough to
+    // look like a discharged cell.
+    batteryMv = (uint16_t)(analogReadMilliVolts({{ params.pin | default(35) }})
+                           * {{ params.divider | default(2.0) }});
+    {% if params.control is defined and params.control is not none -%}
+    digitalWrite({{ params.control }}, HIGH);
+    {% endif -%}
+  fields:
+    - name: batt_mv
+      bytes: 2
+      cpp_type: uint16_t
+      cpp_expr: batteryMv
+      ha_device_class: voltage
+      ha_unit: V
+      ha_state_class: measurement
+      ha_diagnostic: true
+      ha_divide: 1000
+
+# The divider is already on the board; what a schematic needs to show is the
+# cell wired to it, same treatment as the AXP192's battery terminal.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x02
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical

--- a/wirestudio/library/components/dht.yaml
+++ b/wirestudio/library/components/dht.yaml
@@ -24,7 +24,9 @@ lorawan:
     - "adafruit/DHT sensor library@^1.4.6"
   globals: |
     #include <DHT.h>
-    DHT dht({{ (pin | default(pins.DATA) | default(params.pin)) | string | replace('GPIO', '') }}, {{ params.model | default('DHT22') }});
+    {% set dht_pin = pin if pin is not none
+       else (pins.DATA if pins.DATA is defined and pins.DATA is not none else params.pin) -%}
+    DHT dht({{ dht_pin | string | replace('GPIO', '') }}, {{ params.model | default('DHT22') }});
     float dhtTempC = 0.0;
     float dhtHumidity = 0.0;
   setup: |

--- a/wirestudio/targets/lorawan/codec.py
+++ b/wirestudio/targets/lorawan/codec.py
@@ -61,6 +61,10 @@ def _pin(value) -> Optional[int]:
 _ONBOARD = [
     ("uart_gps", "gps_neo6m", "gps", "GPS", "gps"),
     ("axp192", "axp192", "axp192", "PMIC", "batt"),
+    # Same `batt_mv` field and `batt` tag as the PMIC: a board senses the cell
+    # either through a PMIC or through a divider, never both, so the payload
+    # layout and profile name stay identical whichever it is.
+    ("battery_adc", "battery_adc", "batt_adc", "Battery", "batt"),
     ("dht", None, "dht1", "DHT", "dht"),
     ("ssd1306", "oled_ssd1306", "oled", "OLED", None),
 ]
@@ -103,6 +107,13 @@ def _synth_params(lib_id, onboard_key, onboard, lw):
     on = onboard_key in onboard if onboard_key else False
     if lib_id == "axp192":
         return {} if on else None
+    if lib_id == "battery_adc":
+        # A PMIC already reports the cell; adding the divider too would collide
+        # on the batt_mv field name (fields_for raises on duplicates).
+        if not on or "axp192" in onboard:
+            return None
+        ob = onboard[onboard_key]
+        return {"pin": _pin(ob.get("pin")), "divider": ob.get("divider", 2.0)}
     if lib_id == "uart_gps":
         gps = getattr(lw, "gps", None)
         if gps is not None:
@@ -196,7 +207,20 @@ def pack_cpp(fields: list[Field], *, indent: str = "  ") -> str:
 def decode_js(fields: list[Field]) -> str:
     """ChirpStack `decodeUplink` reading the same big-endian layout, honoring
     each field's signedness and scale."""
-    lines = ["function decodeUplink(input) {", "  var b = input.bytes;", "  var data = {};"]
+    size = payload_size(fields)
+    lines = [
+        "function decodeUplink(input) {",
+        "  var b = input.bytes;",
+        # Without this guard a short payload reads past the end: JS yields
+        # undefined, the shifts coerce it to 0, and the decode returns a full
+        # set of plausible zeros with no error -- fabricated readings that
+        # reach Home Assistant looking exactly like real ones.
+        f"  if (b.length < {size}) {{",
+        f"    return {{ data: {{}}, warnings: [],"
+        f" errors: ['expected {size} bytes, got ' + b.length] }};",
+        "  }",
+        "  var data = {};",
+    ]
     offset = 0
     for fld in fields:
         nbits = fld["bytes"] * 8

--- a/wirestudio/targets/lorawan/compile.py
+++ b/wirestudio/targets/lorawan/compile.py
@@ -147,12 +147,43 @@ def platformio_status() -> dict:
         return {"available": False, "pio": " ".join(pio), "version": None, "reason": str(exc)}
     version = (proc.stdout or proc.stderr).strip()
     ok = proc.returncode == 0
+    if not ok:
+        return {"available": False, "pio": " ".join(pio), "version": None, "reason": version}
+    # `pio --version` never touches the core dir, so it stays green on an
+    # install that cannot build: PlatformIO writes appstate.json + lockfiles
+    # there on every run, and reads the platform tree. A read-only core dir
+    # (baked image + readOnlyRootFilesystem) or one owned by another uid
+    # fails only once a build is already underway.
+    reason = _core_dir_problem()
     return {
-        "available": ok,
+        "available": reason is None,
         "pio": " ".join(pio),
-        "version": version if ok else None,
-        "reason": None if ok else version,
+        "version": version,
+        "reason": reason,
     }
+
+
+def _core_dir_problem() -> Optional[str]:
+    """Why PlatformIO could not use its core dir, or None if it can."""
+    core = Path(os.environ.get("PLATFORMIO_CORE_DIR") or (Path.home() / ".platformio"))
+    try:
+        core.mkdir(parents=True, exist_ok=True)
+        probe = core / ".wirestudio-write-probe"
+        probe.touch()
+        probe.unlink()
+    except OSError as exc:
+        return f"PLATFORMIO_CORE_DIR {core} is not writable: {exc}"
+    platforms = Path(
+        os.environ.get("PLATFORMIO_PLATFORMS_DIR") or (core / "platforms")
+    )
+    if platforms.is_dir():
+        try:
+            for entry in platforms.iterdir():
+                if entry.is_dir():
+                    os.listdir(entry)
+        except OSError as exc:
+            return f"PlatformIO platform tree {platforms} is not readable: {exc}"
+    return None
 
 
 def compile_firmware_events(

--- a/wirestudio/targets/lorawan/firmware_gen.py
+++ b/wirestudio/targets/lorawan/firmware_gen.py
@@ -191,6 +191,7 @@ def generate_firmware(design: Design, library: Library) -> dict[str, str]:
             "platformio_board": board.platformio_board,
             "chip_variant": board.chip_variant,
             "mcu": board.mcu,
+            "flash_size_mb": board.flash_size_mb,
         },
         "region": region,
         "sub_band": sub_band,

--- a/wirestudio/targets/lorawan/templates/main.cpp.j2
+++ b/wirestudio/targets/lorawan/templates/main.cpp.j2
@@ -108,6 +108,13 @@ void loop() {
       // in lockstep with the ChirpStack decodeUplink codec on the profile.
       uint8_t payload[{{ payload_size }}];
 {{ payload_pack }}
+      // Re-assert the rate every uplink. Setting it once after join is not
+      // enough: a restored session or an ADR downlink can drop us to DR0,
+      // whose payload cap is below these {{ payload_size }} bytes, and then
+      // every sendReceive fails RADIOLIB_ERR_PACKET_TOO_LONG (-4) with nothing
+      // but a serial line to show for it -- the device stays joined and
+      // silently stops uplinking.
+      node->setDatarate({{ min_datarate }});
       int16_t state = node->sendReceive(payload, sizeof(payload));
       Serial.printf("uplink: RadioLib state %d\n", state);
       persist.saveSession(node);

--- a/wirestudio/targets/lorawan/templates/platformio.ini.j2
+++ b/wirestudio/targets/lorawan/templates/platformio.ini.j2
@@ -4,6 +4,19 @@ platform = espressif32
 board = {{ board.platformio_board }}
 framework = arduino
 monitor_speed = 115200
+{% if board.flash_size_mb %}
+; Pin the flash size from the board file rather than inheriting PlatformIO's
+; default for this board id. A header claiming more flash than the chip has
+; makes the bootloader assert at startup ("Detected size ... smaller than the
+; size in the binary image header") and boot-loop before any sketch code runs.
+board_build.flash_size = {{ board.flash_size_mb }}MB
+board_upload.flash_size = {{ board.flash_size_mb }}MB
+; The partition table has to match the flash size too. Pinning only the size
+; leaves the board's default table in place, and an 8 MB table on a 4 MB chip
+; fails verification ("partition N invalid - offset ... exceeds flash chip
+; size") -- a different boot loop one step later.
+board_build.partitions = {{ 'default.csv' if board.flash_size_mb == 4 else 'default_%dMB.csv' % board.flash_size_mb }}
+{% endif %}
 lib_deps =
     jgromes/RadioLib@^7.6.0
     ropg/LoRaWAN_ESP32@^1.3.0

--- a/wirestudio/workbench/__init__.py
+++ b/wirestudio/workbench/__init__.py
@@ -1,0 +1,12 @@
+"""Universal Embedded Workbench client — the studio's hardware truth layer.
+
+Thin client only: the workbench owns slots, serial and RF. The studio
+uploads an image and reads status; it never re-implements the bench.
+"""
+from wirestudio.workbench.client import (
+    Slot,
+    WorkbenchClient,
+    WorkbenchUnavailable,
+)
+
+__all__ = ["Slot", "WorkbenchClient", "WorkbenchUnavailable"]

--- a/wirestudio/workbench/client.py
+++ b/wirestudio/workbench/client.py
@@ -1,0 +1,275 @@
+"""HTTP client for a Universal Embedded Workbench.
+
+  WORKBENCH_URL    base URL of the Pi's portal (e.g. http://10.0.0.44:8080)
+  WORKBENCH_TOKEN  shared secret, sent as a Bearer token
+
+The token is required even though the stock portal does not check one:
+the studio uploads firmware to whatever host WORKBENCH_URL names, so a
+URL-only gate would let any studio deployment push arbitrary images at
+any reachable bench. Requiring the operator to set both keeps that
+deliberate. See docs/workbench.md.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import AsyncIterator, Optional
+
+import httpx
+
+
+class WorkbenchUnavailable(RuntimeError):
+    """Raised when the workbench is missing config, unreachable, or refuses."""
+
+
+def _error_text(r: httpx.Response) -> str:
+    """The portal answers failures as {"ok": false, "error": "..."}.
+
+    Falls back to the raw body: an error surfaced to an operator staring
+    at a bench in another town should carry the bench's own words.
+    """
+    try:
+        body = r.json()
+        if isinstance(body, dict) and body.get("error"):
+            return f"http {r.status_code}: {body['error']}"
+    except ValueError:
+        pass
+    return f"http {r.status_code}: {r.text[:200]}"
+
+
+def _last_meaningful(output: str) -> Optional[str]:
+    """Last non-progress line of an esptool log.
+
+    esptool's failures land after a wall of progress bars, so the tail is
+    the part worth putting in front of an operator.
+    """
+    for line in reversed(output.splitlines()):
+        line = line.strip()
+        if line and "[" not in line and not line.startswith("Writing at"):
+            return line
+    return None
+
+
+@dataclass
+class Slot:
+    """A USB slot on the bench.
+
+    `state` is the bench's own word for it -- "idle", "absent",
+    "flashing", "monitoring". `busy` collapses that plus the health
+    flags into the single question a caller has: can I flash here now?
+    """
+
+    label: str
+    state: str
+    present: bool
+    chip: Optional[str]
+    product: Optional[str]
+    serial_url: Optional[str]
+    flapping: bool
+    last_error: Optional[str]
+
+    @property
+    def busy(self) -> bool:
+        return self.state not in ("idle", "absent")
+
+    @property
+    def flashable(self) -> tuple[bool, Optional[str]]:
+        """(ok, reason) -- the pre-flight the bench cannot answer for us.
+
+        Refusing a flash onto a flapping slot is deliberate: a slot whose
+        USB link is dropping produces failures that read as firmware
+        faults, which is the confusion a hardware gate must not create.
+        """
+        if not self.present:
+            # `present` tracks the serial devnode, so a slot holding a
+            # non-serial peripheral (an SDR dongle, say) reads as absent.
+            # Saying "empty" there sends the operator to look at the wrong
+            # slot.
+            if self.product:
+                return False, f"{self.label} has no serial device ({self.product} attached)"
+            return False, f"{self.label} is empty"
+        if self.flapping:
+            return False, f"{self.label} USB link is flapping ({self.last_error or 'unstable'})"
+        if self.busy:
+            return False, f"{self.label} is {self.state}"
+        return True, None
+
+    @classmethod
+    def from_api(cls, d: dict) -> "Slot":
+        usb = d.get("usb_devices") or []
+        return cls(
+            label=d.get("label", "?"),
+            state=d.get("state", "unknown"),
+            present=bool(d.get("present")),
+            chip=d.get("detected_chip"),
+            product=(usb[0].get("product") if usb else None),
+            serial_url=d.get("url"),
+            flapping=bool(d.get("flapping")),
+            last_error=d.get("last_error"),
+        )
+
+
+class WorkbenchClient:
+    """Talks to a workbench portal over HTTP.
+
+    Configured from the environment by default so the API layer stays
+    process-state-free. is_available() returns (ok, reason) so callers
+    can surface the specific gap rather than a generic failure.
+    """
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        timeout: float = 30.0,
+        flash_timeout: float = 300.0,
+        transport: Optional[httpx.AsyncBaseTransport] = None,
+    ) -> None:
+        self.base_url = (
+            base_url if base_url is not None else os.environ.get("WORKBENCH_URL", "")
+        ).rstrip("/")
+        self.token = token if token is not None else os.environ.get("WORKBENCH_TOKEN", "")
+        self.timeout = timeout
+        self.flash_timeout = flash_timeout
+        self._transport = transport
+
+    def _client(self, timeout: Optional[float] = None) -> httpx.AsyncClient:
+        headers = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        return httpx.AsyncClient(
+            base_url=self.base_url,
+            timeout=timeout or self.timeout,
+            headers=headers,
+            transport=self._transport,
+        )
+
+    # ------------------------------------------------------------------
+    # Status
+    # ------------------------------------------------------------------
+
+    def is_configured(self) -> bool:
+        return bool(self.base_url and self.token)
+
+    def unconfigured_reason(self) -> Optional[str]:
+        if not self.base_url:
+            return "WORKBENCH_URL not set"
+        if not self.token:
+            return "WORKBENCH_TOKEN not set"
+        return None
+
+    async def is_available(self) -> tuple[bool, Optional[str]]:
+        """Cheap readiness probe against GET /api/info. Never raises."""
+        reason = self.unconfigured_reason()
+        if reason:
+            return False, reason
+        try:
+            async with self._client() as c:
+                r = await c.get("/api/info")
+        except httpx.HTTPError as e:
+            return False, f"unreachable: {e}"
+        if r.status_code == 401:
+            return False, "unauthorized (check WORKBENCH_TOKEN)"
+        if r.status_code >= 400:
+            return False, f"http {r.status_code}"
+        return True, None
+
+    async def info(self) -> dict:
+        return await self._get_json("/api/info")
+
+    async def slots(self) -> list[Slot]:
+        data = await self._get_json("/api/devices")
+        return [Slot.from_api(s) for s in data.get("slots", [])]
+
+    async def slot(self, label: str) -> Slot:
+        for s in await self.slots():
+            if s.label == label:
+                return s
+        raise WorkbenchUnavailable(f"no such slot '{label}'")
+
+    async def _get_json(self, path: str) -> dict:
+        if not self.is_configured():
+            raise WorkbenchUnavailable(
+                self.unconfigured_reason() or "workbench not configured"
+            )
+        try:
+            async with self._client() as c:
+                r = await c.get(path)
+        except httpx.HTTPError as e:
+            raise WorkbenchUnavailable(f"unreachable: {e}") from e
+        if r.status_code == 401:
+            raise WorkbenchUnavailable("unauthorized (check WORKBENCH_TOKEN)")
+        if r.status_code >= 400:
+            raise WorkbenchUnavailable(f"{path}: http {r.status_code}")
+        return r.json()
+
+    # ------------------------------------------------------------------
+    # Flash
+    # ------------------------------------------------------------------
+
+    async def flash(
+        self,
+        slot: str,
+        images: list[tuple[int, bytes]],
+        chip: str = "esp32",
+        erase: bool = False,
+        baud: int = 921600,
+    ) -> AsyncIterator[dict]:
+        """Upload images and stream the bench's flash progress.
+
+        `images` is [(offset, bytes)]. Yields {"type": "log"|"done", ...}
+        so the API layer only has to JSON-encode. The bench runs esptool
+        against its own USB, so the payload crosses the network once
+        instead of once per block.
+        """
+        if not self.is_configured():
+            raise WorkbenchUnavailable(
+                self.unconfigured_reason() or "workbench not configured"
+            )
+        if not images:
+            raise WorkbenchUnavailable("no images to flash")
+
+        ok, reason = (await self.slot(slot)).flashable
+        if not ok:
+            raise WorkbenchUnavailable(reason or f"{slot} is not flashable")
+
+        # The portal keys each part by `bin@<offset>`; anything else is
+        # silently ignored and the request fails as "no binaries to flash".
+        files = [
+            (f"bin@{offset:#x}", (f"{offset:#x}.bin", data, "application/octet-stream"))
+            for offset, data in images
+        ]
+        form = {
+            "slot": slot,
+            "chip": chip,
+            "baud": str(baud),
+            "erase": "true" if erase else "false",
+        }
+
+        try:
+            async with self._client(timeout=self.flash_timeout) as c:
+                r = await c.post("/api/flash", data=form, files=files)
+        except httpx.HTTPError as e:
+            raise WorkbenchUnavailable(f"flash transport failed: {e}") from e
+
+        if r.status_code >= 400:
+            raise WorkbenchUnavailable(f"flash rejected: {_error_text(r)}")
+
+        try:
+            body = r.json()
+        except ValueError as e:
+            raise WorkbenchUnavailable(f"flash: unparseable response: {r.text[:200]}") from e
+
+        # The portal buffers esptool and answers once, as
+        # {ok, output, returncode} -- so these lines arrive together at
+        # the end rather than live. Progress liveness needs the phase-2
+        # serial relay; this at least gives the operator the real log.
+        output = body.get("output") or ""
+        for line in output.splitlines():
+            if line.strip():
+                yield {"type": "log", "data": line.rstrip()}
+
+        rc = body.get("returncode")
+        if not body.get("ok") or rc not in (0, None):
+            detail = body.get("error") or _last_meaningful(output) or f"returncode {rc}"
+            raise WorkbenchUnavailable(f"flash failed: {detail}")
+
+        yield {"type": "done", "ok": True, "slot": slot, "returncode": rc}


### PR DESCRIPTION
Every fix here was found by putting generated firmware on real silicon at a remote bench. **Five of the six were invisible to CI** — the device stayed joined, the serial log looked healthy, and Home Assistant showed plausible numbers.

## Bugs, in the order the hardware surfaced them

| # | Bug | Why CI missed it |
|---|---|---|
| 1 | `DHT dht(None, DHT22);` | Jinja `default()` only fires for *undefined*, never defined-as-`None`. No test covered the synthesized-DHT path. |
| 2 | Uplinks silently stopped at DR0 | Datarate asserted once after join; a restored session or ADR downlink dropped to DR0 (11-byte US915 cap), so every `sendReceive` returned `-4` while the device stayed joined. |
| 3 | Codec fabricated zeros | `decodeUplink` read its full layout unconditionally. A short uplink read past the end → `undefined` → shifts coerce to `0` → nine plausible zeros with `errors: []`. |
| 4 | Flash size / partition table never pinned | Generator inherited PlatformIO's board default. 8 MB header on a 4 MB PICO-D4 → bootloader assert → boot loop. |
| 5 | `battery_adc` declared but ignored | Boards without a PMIC sense the cell through a divider; it never reached the payload, so those boards could only report uptime. |
| 6 | `platformio_status()` false-green | Only ran `pio --version`, which never touches the core dir. |

**#3 is the one worth a second look.** A device sending a single `0x00` byte decoded as nine zero-valued sensor fields, and Home Assistant displayed them as real readings. Nothing anywhere reported an error. The codec now length-checks before reading.

## Deployment fix

LoRaWAN builds could not run in the deployed image at all — three stacked faults:

1. The `-full` image builds on `kicad/kicad:8.0`, which already occupies uid 1000, so a bare `useradd appuser` landed on **1001** while manifests pin `runAsUser: 1000`.
2. PlatformIO creates platform dirs `0700`, leaving the prewarmed toolchain unreadable to the running uid.
3. `PLATFORMIO_CORE_DIR` was baked to `/opt/pio`, which cannot work under `readOnlyRootFilesystem: true`.

Prod hit (3), dev hit (2) — same broken design, different symptom. The core dir now defaults to `/data/pio` with the toolchain kept read-only via `PLATFORMIO_PLATFORMS_DIR`/`PLATFORMIO_PACKAGES_DIR`, and the baked tree is `chmod a+rX` so uid no longer has to match. No re-download; the offline prewarm is preserved.

## Workbench remote flash (roadmap phase 1)

What made the hardware testing possible. `/workbench/status`, `/workbench/slots`, `/workbench/flash` behind a `WORKBENCH_URL` + `WORKBENCH_TOKEN` gate, plus a Local USB / Workbench-slot toggle in the flash dialog.

The studio uploads the image and the bench runs esptool on its own USB rather than driving it over RFC2217. That deviates from the roadmap deliberately: **on the reference bench RFC2217 cannot reach download mode at all** (`Wrong boot mode 0x33`), so delegating isn't merely faster, it's the only thing that works. A token is required alongside the URL — the server pushes firmware at an operator-supplied host, so a URL-only gate would let any deployment flash any reachable bench.

A flash is refused *before* the SSE stream opens (409) when the slot is busy, flapping, or holds no serial device, and a non-zero esptool `returncode` is treated as a failure rather than reported as success.

## Verification

Three boards at a remote bench, end to end:

- **T-Beam** — GPS/temperature/humidity/battery decoded into 12 HA entities. The AXP192 rail init (`enableLDO2`/`enableLDO3`) is what had been missing; without it the radio and GPS were never powered.
- **Heltec V2** — battery + uptime decoded, after fixes #4 and #5.
- **TTGO LoRa32** — codec attached to its previously codec-less profile.

962 passed, 12 skipped. `tsc --noEmit` clean. Goldens regenerated in the same diff per CLAUDE.md.

## Notes for review

- `deploy/k8s.yaml` is the reference manifest; prod is ArgoCD-managed elsewhere. The only manifest requirement is an emptyDir at `/tmp`, which both envs already have.
- The Heltec's OLED init hangs the I2C bus on that board (TG1WDT reset loop). Not fixed here — it's cosmetic, needs its own investigation, and I did not want to bundle a speculative fix with verified ones.
- `battery_adc` is added to the coverage baseline for the same reason as `axp192`: it is synthesized from board metadata and never named by id in a design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ