### PR TITLE
feat(lorawan): headless bring-up on a workbench slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an operator-supplied host, so a URL-only gate would let any
   deployment flash any reachable bench.
 
+### Added
+
+- **Headless LoRaWAN bring-up on a bench slot.**
+  `POST /lorawan/workbench/provision` flashes, registers, provisions and
+  verifies a board in one call, streaming a phase per step. Registration
+  already existed and was designed around a host that supplies the eFuse
+  MAC and types the keys into the device's serial prompt; that host could
+  only be the browser. `wirestudio.workbench.serial.answer_prompts` drives
+  the same dialogue over the slot's RFC2217 port, so the flow no longer
+  needs anyone at the bench. Phase order is forced by the hardware: the
+  flash runs first because esptool's own output is the only place the MAC
+  appears (the bench exposes no chip-detect), and the erase must precede
+  registration so `provision_device`'s DevNonce flush lands after the
+  device's counter restarts. Keys are redacted from the log
+  case-insensitively -- devices echo them back, in uppercase.
+
 ### Fixed
 
+- **A tenant-scoped ChirpStack API key was reported as unusable.**
+  `ping()` and `default_tenant_id()` both probed `TenantService.List`,
+  which is admin-only, so the least-privilege key the ChirpStack UI hands
+  out made `/lorawan/chirpstack/status` report the server as down and
+  every provisioning chain fail with a bare `UNAUTHENTICATED`. Set
+  `CHIRPSTACK_TENANT_ID` and the client skips the admin-only lookup and
+  probes with a tenant-scoped call instead; the error now says so rather
+  than reading as a bad token.
 - **LoRaWAN builds could not run in the deployed image.** Three faults
   stacked. (1) The `-full` image builds on `kicad/kicad:8.0`, which
   already occupies uid 1000, so its bare `useradd appuser` landed on

--- a/tests/test_chirpstack.py
+++ b/tests/test_chirpstack.py
@@ -288,3 +288,23 @@ def test_provision_device_flushes_nonces():
     stubs.device.FlushDevNonces.assert_called_once()
     stubs.device.Create.assert_called_once()
     stubs.device.CreateKeys.assert_called_once()
+
+
+def test_tenant_scoped_key_is_told_how_to_fix_itself():
+    """Listing tenants is admin-only, so a tenant-scoped key -- the
+    least-privilege choice the UI hands out -- cannot discover its own
+    tenant. Reporting that as a bare UNAUTHENTICATED reads as a bad token."""
+    stubs = _stubs()
+    stubs.tenant.List.side_effect = _RpcError(grpc.StatusCode.UNAUTHENTICATED)
+    with pytest.raises(cs.ChirpStackUnavailable, match="CHIRPSTACK_TENANT_ID"):
+        _client(stubs).default_tenant_id()
+
+
+def test_configured_tenant_id_skips_the_admin_only_lookup():
+    stubs = _stubs()
+    stubs.tenant.List.side_effect = _RpcError(grpc.StatusCode.UNAUTHENTICATED)
+    client = cs.ChirpStackClient(
+        url="host:8080", token="t", stubs=stubs, tenant_id="tenant-1"
+    )
+    assert client.default_tenant_id() == "tenant-1"
+    stubs.tenant.List.assert_not_called()

--- a/tests/test_workbench_provision.py
+++ b/tests/test_workbench_provision.py
@@ -1,0 +1,305 @@
+"""Headless LoRaWAN bring-up on a workbench slot.
+
+The invariants asserted here are the ones that produced wrong results on
+real hardware, not hypotheticals.
+"""
+import re
+
+import pytest
+
+from wirestudio.library import default_library
+from wirestudio.model import Design
+from wirestudio.workbench import WorkbenchUnavailable
+from wirestudio.workbench.serial import SerialUnavailable, answer_prompts
+from wirestudio.targets.lorawan.workbench_provision import (
+    dev_eui_from_mac,
+    mac_from_flash_log,
+    provision_events,
+)
+
+FLASH_LOG = [
+    "esptool v5.3.1",
+    "Chip type:          ESP32-D0WDQ6 (revision v1.0)",
+    "MAC:                10:52:1c:66:b6:e0",
+    "Wrote 552528 bytes at 0x00000000 in 5.8 seconds.",
+    "Hash of data verified.",
+]
+
+
+def _design(board="ttgo-t-beam", **lorawan):
+    kw = {}
+    if lorawan:
+        kw["lorawan"] = lorawan
+    return Design(
+        schema_version="0.1",
+        id="d1",
+        name="d1",
+        target="lorawan",
+        board={"library_id": board, "mcu": "esp32"},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+        **kw,
+    )
+
+
+# ----------------------------------------------------------------------
+# DevEUI derivation
+# ----------------------------------------------------------------------
+
+
+def test_dev_eui_matches_the_browser_derivation():
+    """The board must keep one identity whichever host provisioned it."""
+    assert dev_eui_from_mac("10:52:1c:66:b6:e0") == "10521cfffe66b6e0"
+    assert dev_eui_from_mac("64:b7:08:ab:89:74") == "64b708fffeab8974"
+
+
+def test_dev_eui_rejects_a_non_mac():
+    with pytest.raises(ValueError):
+        dev_eui_from_mac("not-a-mac")
+
+
+def test_mac_read_from_the_flash_log():
+    """The bench exposes no chip-detect, so esptool's own output is the only
+    place the eFuse MAC appears."""
+    assert mac_from_flash_log(FLASH_LOG) == "10:52:1c:66:b6:e0"
+    assert mac_from_flash_log(["no mac here"]) is None
+
+
+# ----------------------------------------------------------------------
+# Serial prompt driver
+# ----------------------------------------------------------------------
+
+
+class FakeSerial:
+    """One prompt at a time, like the real firmware.
+
+    An empty line re-prints the current prompt rather than advancing -- that
+    is what the device does ("Error: '' is not a supported band"), and it is
+    what lets the driver attach after the first prompt has already scrolled
+    past.
+    """
+
+    def __init__(self, prompts, join="JOINED"):
+        self.prompts = list(prompts)
+        self.join = join
+        self.written = []
+        self.current = self.prompts.pop(0) if self.prompts else ""
+        self._out = self.current.encode()
+        self.closed = False
+
+    def read(self, _n):
+        out, self._out = self._out, b""
+        return out
+
+    def write(self, data):
+        text = data.decode().strip()
+        self.written.append(text)
+        echo = data  # devices echo what they were sent
+        if not text:
+            self._out = echo + self.current.encode()  # re-print, do not advance
+        elif self.prompts:
+            self.current = self.prompts.pop(0)
+            self._out = echo + self.current.encode()
+        else:
+            self._out = echo + f"\n{self.join}\n".encode()
+        return len(data)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def fake_serial(monkeypatch):
+    import serial as pyserial
+
+    holder = {}
+
+    def make(script, join="JOINED"):
+        dev = FakeSerial(script, join)
+        holder["dev"] = dev
+        monkeypatch.setattr(pyserial, "serial_for_url", lambda *a, **k: dev)
+        return dev
+
+    holder["make"] = make
+    return holder
+
+
+def _rules(key="ab" * 16):
+    return [
+        (re.compile(r"sub-?band", re.I), "2"),
+        (re.compile(r"\bband\b", re.I), "US915"),
+        (re.compile(r"dev\s?eui", re.I), "10521cfffe66b6e0"),
+        (re.compile(r"join\s?eui", re.I), "0" * 16),
+        (re.compile(r"app\s?key", re.I), key),
+        (re.compile(r"nwk\s?key", re.I), key),
+    ]
+
+
+def test_prompts_answered_in_order(fake_serial):
+    dev = fake_serial["make"]([
+        "Enter LoRaWAN band (e.g. EU868 or US915)\n",
+        "Enter subband for your frequency plan\n",
+        "Enter joinEUI (64 bits)\n",
+        "Enter devEUI (64 bits)\n",
+        "Enter appKey (128 bits)\n",
+        "Enter nwkKey (128 bits)\n",
+    ])
+    events = list(answer_prompts("loop://", _rules(), done=re.compile(r"JOINED"), timeout=10, min_interval=0.0))
+    assert events[-1] == {"type": "result", "matched": "JOINED"}
+    # written[0] is the empty nudge that provokes the re-print.
+    assert [w for w in dev.written if w][:2] == ["US915", "2"]
+    assert dev.closed
+
+
+def test_key_is_redacted_from_the_log(fake_serial):
+    """Devices echo what they were sent, so the key comes back on the wire."""
+    key = "cd" * 16
+    fake_serial["make"](["Enter appKey (128 bits)\n"])
+    logs = "".join(
+        e["data"]
+        for e in answer_prompts(
+            "loop://", _rules(key), done=re.compile(r"JOINED"), secrets=[key], timeout=10, min_interval=0.0
+        )
+        if e["type"] == "log"
+    )
+    assert key not in logs
+    assert "<redacted>" in logs
+
+
+def test_uppercase_echo_is_still_redacted():
+    """Firmware echoes hex uppercase even when the key was sent lowercase --
+    a case-sensitive redaction would leak it straight into the SSE log."""
+    from wirestudio.workbench.serial import _redact
+
+    key = "ef" * 16
+    assert key not in _redact(f"[{key.upper()}]", [key])
+    assert key.upper() not in _redact(f"[{key.upper()}]", [key])
+
+
+def test_stalled_dialogue_raises_rather_than_hanging(fake_serial):
+    fake_serial["make"](["nothing to match here\n"])
+    with pytest.raises(SerialUnavailable, match="did not reach"):
+        list(answer_prompts("loop://", _rules(), done=re.compile(r"JOINED"), timeout=1.5, min_interval=0.0))
+
+
+# ----------------------------------------------------------------------
+# Orchestration
+# ----------------------------------------------------------------------
+
+
+class FakeWorkbench:
+    def __init__(self, log=None, serial_url="rfc2217://bench:4001"):
+        self.log = log if log is not None else FLASH_LOG
+        self.serial_url = serial_url
+        self.flashed = []
+
+    def flash_sync(self, *, slot, images, erase, **kw):
+        self.flashed.append({"slot": slot, "images": images, "erase": erase})
+        for line in self.log:
+            yield {"type": "log", "data": line}
+        yield {"type": "done", "ok": True, "slot": slot, "returncode": 0}
+
+    def slot_sync(self, label):
+        from wirestudio.workbench import Slot
+
+        return Slot(label, "idle", True, None, None, self.serial_url, False, None)
+
+
+class FakeChirp:
+    def __init__(self, activation=True):
+        self.calls = []
+        self._activation = activation
+
+    def provision_device(self, **kw):
+        self.calls.append(kw)
+        return {"application_id": "app-1", "device_profile_id": "dp-1"}
+
+    def get_activation(self, dev_eui):
+        return {"dev_addr": "0136e110"} if self._activation else None
+
+
+_PROMPTS = [
+    "Enter LoRaWAN band\n", "Enter subband\n", "Enter joinEUI\n",
+    "Enter devEUI\n", "Enter appKey\n", "Enter nwkKey\n",
+]
+
+
+def _run(fake_serial, wb=None, chirp=None, design=None, join="JOINED"):
+    fake_serial["make"](_PROMPTS, join=join)
+    return list(
+        provision_events(
+            design or _design(),
+            default_library(),
+            slot="SLOT1",
+            workbench=wb or FakeWorkbench(),
+            chirpstack=chirp or FakeChirp(),
+            images=[(0x0, b"fw")],
+            serial_timeout=10, serial_min_interval=0.0,
+        )
+    )
+
+
+def test_full_flow_reaches_done(fake_serial):
+    chirp = FakeChirp()
+    events = _run(fake_serial, chirp=chirp)
+    phases = [e["phase"] for e in events if e["type"] == "phase"]
+    assert phases == ["flash", "detect", "register", "registered", "provision", "verify"]
+    assert events[-1]["type"] == "done"
+    assert events[-1]["dev_eui"] == "10521cfffe66b6e0"
+    assert events[-1]["dev_addr"] == "0136e110"
+
+
+def test_registration_follows_the_flash(fake_serial):
+    """The DevEUI comes out of esptool's log, so registration cannot precede
+    the flash -- and provision_device's DevNonce flush has to land after the
+    erase restarted the device's counter, not before."""
+    events = _run(fake_serial)
+    order = [e.get("phase") for e in events if e["type"] == "phase"]
+    assert order.index("flash") < order.index("detect") < order.index("register")
+
+
+def test_erase_is_on_by_default(fake_serial):
+    """An erase empties NVS so the device re-prompts; pairing it with the
+    flush in provision_device is what keeps the join from being rejected as
+    a DevNonce replay."""
+    wb = FakeWorkbench()
+    _run(fake_serial, wb=wb)
+    assert wb.flashed[0]["erase"] is True
+
+
+def test_registered_key_is_the_one_pushed_to_the_device(fake_serial):
+    """A mismatch here joins nothing and reports nothing useful."""
+    chirp = FakeChirp()
+    fake_serial["make"]([
+        "Enter LoRaWAN band\n", "Enter subband\n", "Enter joinEUI\n",
+        "Enter devEUI\n", "Enter appKey\n", "Enter nwkKey\n",
+    ])
+    list(provision_events(
+        _design(), default_library(), slot="SLOT1",
+        workbench=FakeWorkbench(), chirpstack=chirp,
+        images=[(0x0, b"fw")], serial_timeout=10, serial_min_interval=0.0,
+    ))
+    sent = fake_serial["dev"].written
+    assert chirp.calls[0]["app_key"] in sent
+
+
+def test_missing_mac_is_a_clear_failure(fake_serial):
+    wb = FakeWorkbench(log=["esptool v5.3.1", "Hash of data verified."])
+    with pytest.raises(WorkbenchUnavailable, match="did not report a MAC"):
+        _run(fake_serial, wb=wb)
+
+
+def test_join_failure_is_not_reported_as_success(fake_serial):
+    """The device answers every prompt and still fails to join -- provisioning
+    that reported success here would be worse than useless."""
+    with pytest.raises(SerialUnavailable, match="JOIN FAILED"):
+        _run(fake_serial, join="JOIN FAILED")
+
+
+def test_device_claim_is_checked_against_chirpstack(fake_serial):
+    """JOINED is the device's own word for it; the activation is independent
+    and is what an uplink actually gets decoded against."""
+    with pytest.raises(Exception, match="no activation"):
+        _run(fake_serial, chirp=FakeChirp(activation=False))

--- a/wirestudio/targets/lorawan/api.py
+++ b/wirestudio/targets/lorawan/api.py
@@ -46,6 +46,30 @@ _ZERO_EUI = "0000000000000000"
 _SSE_HEADERS = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
 
 
+def _decode_images(raw) -> list[tuple[int, bytes]]:
+    """[{offset, data}] -> [(int, bytes)]; `data` is base64.
+
+    Offsets arrive as strings like "0x10000", so they are parsed base 0 --
+    reading them as decimal would flash a valid-looking image to the wrong
+    address.
+    """
+    import base64
+
+    if not raw:
+        raise HTTPException(status_code=422, detail="images is required")
+    out: list[tuple[int, bytes]] = []
+    for i, img in enumerate(raw):
+        try:
+            offset = int(str(img["offset"]), 0)
+            data = base64.b64decode(img["data"], validate=True)
+        except (KeyError, ValueError, TypeError) as exc:
+            raise HTTPException(status_code=422, detail=f"image {i}: {exc}") from exc
+        if offset < 0 or not data:
+            raise HTTPException(status_code=422, detail=f"image {i}: empty or negative offset")
+        out.append((offset, data))
+    return out
+
+
 def build_router(library: Library, backend: BuildBackend) -> APIRouter:
     """`backend` is the build path the compile/firmware routes drive. The
     endpoints know nothing about PlatformIO -- swapping in a remote build worker
@@ -148,6 +172,72 @@ def build_router(library: Library, backend: BuildBackend) -> APIRouter:
             "application_id": result["application_id"],
             "device_profile_id": result["device_profile_id"],
         }
+
+    @router.post("/workbench/provision")
+    def workbench_provision(body: dict) -> StreamingResponse:
+        """Flash, register, provision and verify a board on a bench slot.
+
+        The headless counterpart of the browser flow: WebSerial supplied the
+        eFuse MAC and typed the keys into the device's prompt, and a slot on
+        the workbench can do both. Everything checkable up front is validated
+        before the stream opens, since SSE cannot carry a status change once
+        it has.
+        """
+        from wirestudio.targets.lorawan import chirpstack as cs
+        from wirestudio.targets.lorawan.workbench_provision import provision_events
+        from wirestudio.workbench import WorkbenchClient, WorkbenchUnavailable
+        from wirestudio.workbench.serial import SerialUnavailable
+
+        slot = body.get("slot")
+        if not slot or not isinstance(slot, str):
+            raise HTTPException(status_code=422, detail="slot is required")
+        try:
+            design = Design.model_validate(body["design"])
+        except KeyError as exc:
+            raise HTTPException(status_code=422, detail="design is required") from exc
+        except ValidationError as exc:
+            raise HTTPException(status_code=422, detail=exc.errors()) from exc
+
+        images = _decode_images(body.get("images"))
+
+        wb = WorkbenchClient()
+        if not wb.is_configured():
+            raise HTTPException(
+                status_code=503,
+                detail="workbench not configured (set WORKBENCH_URL and WORKBENCH_TOKEN)",
+            )
+        chirp = cs.ChirpStackClient()
+        if not chirp.is_configured():
+            raise HTTPException(
+                status_code=503,
+                detail="ChirpStack not configured (set CHIRPSTACK_API_TOKEN / CHIRPSTACK_API_URL)",
+            )
+        try:
+            ok, reason = wb.slot_sync(slot).flashable
+        except WorkbenchUnavailable as exc:
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+        if not ok:
+            raise HTTPException(status_code=409, detail=reason)
+
+        def events():
+            try:
+                for event in provision_events(
+                    design,
+                    library,
+                    slot=slot,
+                    workbench=wb,
+                    chirpstack=chirp,
+                    images=images,
+                    erase=bool(body.get("erase", True)),
+                    application_name=str(body.get("application_name") or "wirestudio"),
+                ):
+                    yield f"data: {json.dumps(event)}\n\n"
+            except (WorkbenchUnavailable, SerialUnavailable, cs.ChirpStackUnavailable) as exc:
+                yield f"event: error\ndata: {json.dumps({'message': str(exc)})}\n\n"
+
+        return StreamingResponse(
+            events(), media_type="text/event-stream", headers=_SSE_HEADERS
+        )
 
     @router.post("/provision-esphome")
     def provision_esphome(body: dict) -> dict:

--- a/wirestudio/targets/lorawan/chirpstack.py
+++ b/wirestudio/targets/lorawan/chirpstack.py
@@ -85,9 +85,17 @@ class ChirpStackClient:
         *,
         tls: Optional[bool] = None,
         stubs: Optional[ChirpStackStubs] = None,
+        tenant_id: Optional[str] = None,
     ) -> None:
         self.url = url or os.environ.get("CHIRPSTACK_API_URL") or DEFAULT_URL
         self._token = token if token is not None else os.environ.get("CHIRPSTACK_API_TOKEN", "")
+        # Listing tenants is admin-only, so a tenant-scoped API key -- the
+        # least-privilege choice, and what the ChirpStack UI hands out by
+        # default -- cannot discover its own tenant. Naming it explicitly lets
+        # such a key do everything else it is entitled to.
+        self._tenant_id = (
+            tenant_id if tenant_id is not None else os.environ.get("CHIRPSTACK_TENANT_ID", "")
+        )
         self._tls = (
             (os.environ.get("CHIRPSTACK_API_TLS", "").lower() == "true")
             if tls is None
@@ -125,19 +133,37 @@ class ChirpStackClient:
         ChirpStackUnavailable on any transport/auth error."""
         grpc, m = _load()
         try:
-            self._get_stubs().tenant.List(
-                m.tenant.ListTenantsRequest(limit=1), metadata=self._auth
-            )
+            if self._tenant_id:
+                # A tenant-scoped key cannot list tenants, so probing with
+                # tenant.List would report a perfectly usable key as down.
+                self._get_stubs().application.List(
+                    m.app.ListApplicationsRequest(limit=1, tenant_id=self._tenant_id),
+                    metadata=self._auth,
+                )
+            else:
+                self._get_stubs().tenant.List(
+                    m.tenant.ListTenantsRequest(limit=1), metadata=self._auth
+                )
         except grpc.RpcError as exc:
             raise ChirpStackUnavailable(f"ChirpStack unreachable: {_rpc_msg(exc)}") from exc
 
     def default_tenant_id(self) -> str:
+        if self._tenant_id:
+            return self._tenant_id
         grpc, m = _load()
         try:
             resp = self._get_stubs().tenant.List(
                 m.tenant.ListTenantsRequest(limit=1), metadata=self._auth
             )
         except grpc.RpcError as exc:
+            if exc.code().name in ("UNAUTHENTICATED", "PERMISSION_DENIED"):
+                # The key works for everything else; it just cannot enumerate
+                # tenants. Say so, rather than reporting the server as down.
+                raise ChirpStackUnavailable(
+                    f"{_rpc_msg(exc)} listing tenants is admin-only and this "
+                    "API key is tenant-scoped -- set CHIRPSTACK_TENANT_ID to "
+                    "the tenant the key belongs to"
+                ) from exc
             raise ChirpStackUnavailable(_rpc_msg(exc)) from exc
         if not resp.result:
             raise ChirpStackUnavailable("ChirpStack has no tenant to provision under")

--- a/wirestudio/targets/lorawan/workbench_provision.py
+++ b/wirestudio/targets/lorawan/workbench_provision.py
@@ -1,0 +1,187 @@
+"""Headless LoRaWAN bring-up on a workbench slot.
+
+Chains pieces that already exist -- compile, /workbench/flash,
+ChirpStack `provision_device`, `get_activation` -- plus the serial prompt
+driver, into one call. Before this the same sequence needed a browser at
+the bench: WebSerial supplied the eFuse MAC and typed the keys into the
+device's prompt.
+
+Phase order is forced by the hardware, not by taste:
+
+* Flash comes *before* registration, because esptool's own output is where
+  the eFuse MAC (and therefore the DevEUI) comes from. The bench exposes no
+  chip-detect endpoint, and esptool driven over RFC2217 cannot pull these
+  boards into download mode at all.
+* A full erase implies a DevNonce flush. Erasing empties NVS so the device
+  re-prompts for keys, but it also restarts its DevNonce counter, and
+  ChirpStack rejects a replayed nonce -- the join fails with nothing on the
+  wire to explain it. `provision_device` flushes, so the registration step
+  must follow the erase rather than precede it.
+"""
+from __future__ import annotations
+
+import re
+import secrets as _secrets
+from typing import Iterator, Optional
+
+from wirestudio.library import Library
+from wirestudio.model import Design
+from wirestudio.workbench import WorkbenchUnavailable
+from wirestudio.workbench.serial import SerialUnavailable, answer_prompts
+
+# LoRaWAN_ESP32's persist.manage() prompt set. Ordered: "sub-band" has to be
+# tested before the bare "band" or it would answer the wrong question.
+_PROMPT_RULES = [
+    (re.compile(r"sub-?band", re.I), "sub_band"),
+    (re.compile(r"\bband\b", re.I), "band"),
+    (re.compile(r"dev\s?eui", re.I), "dev_eui"),
+    (re.compile(r"join\s?eui|app\s?eui", re.I), "join_eui"),
+    (re.compile(r"app\s?key", re.I), "app_key"),
+    (re.compile(r"nwk\s?key|network key", re.I), "nwk_key"),
+]
+
+_DONE = re.compile(r"JOINED|JOIN FAILED")
+
+_MAC_RE = re.compile(r"MAC:\s*((?:[0-9a-f]{2}:){5}[0-9a-f]{2})", re.I)
+
+
+def dev_eui_from_mac(mac: str) -> str:
+    """EUI-64 from a 48-bit MAC, the standard fffe insertion.
+
+    Matches what the browser path derives, so a board keeps one identity
+    whichever way it was provisioned.
+    """
+    raw = mac.replace(":", "").replace("-", "").lower()
+    if len(raw) != 12 or not re.fullmatch(r"[0-9a-f]{12}", raw):
+        raise ValueError(f"not a 48-bit MAC: {mac!r}")
+    return raw[:6] + "fffe" + raw[6:]
+
+
+def mac_from_flash_log(lines: list[str]) -> Optional[str]:
+    """esptool prints `MAC: xx:xx:...` while flashing; that is the only
+    chip identity the bench surfaces, so it is what we key the DevEUI on."""
+    for line in lines:
+        m = _MAC_RE.search(line)
+        if m:
+            return m.group(1).lower()
+    return None
+
+
+def provision_events(
+    design: Design,
+    library: Library,
+    *,
+    slot: str,
+    workbench,
+    chirpstack,
+    images: list[tuple[int, bytes]],
+    erase: bool = True,
+    application_name: str = "wirestudio",
+    band: str = "US915",
+    sub_band: int = 2,
+    serial_timeout: float = 180.0,
+    serial_min_interval: float = 1.0,
+) -> Iterator[dict]:
+    """Flash, register, provision and verify one slot.
+
+    Yields ``{"type": "phase"|"log"|"done", ...}``. Every failure surfaces as
+    a raised WorkbenchUnavailable / SerialUnavailable / ChirpStackUnavailable
+    so the caller can map it to one status code per cause.
+    """
+    from wirestudio.targets.lorawan import chirpstack as cs
+    from wirestudio.targets.lorawan.codec import generate_codec, profile_name
+
+    # ---- flash -------------------------------------------------------
+    yield {"type": "phase", "phase": "flash", "slot": slot}
+    flash_log: list[str] = []
+    for event in workbench.flash_sync(slot=slot, images=images, erase=erase):
+        if event.get("type") == "log":
+            flash_log.append(event["data"])
+            yield {"type": "log", "data": event["data"]}
+
+    mac = mac_from_flash_log(flash_log)
+    if mac is None:
+        raise WorkbenchUnavailable(
+            "esptool did not report a MAC; cannot derive the DevEUI "
+            "(the bench exposes no separate chip-detect)"
+        )
+    dev_eui = dev_eui_from_mac(mac)
+    yield {"type": "phase", "phase": "detect", "mac": mac, "dev_eui": dev_eui}
+
+    # ---- register ----------------------------------------------------
+    # After the erase, so provision_device's DevNonce flush lands on a device
+    # whose counter has actually just restarted.
+    yield {"type": "phase", "phase": "register", "dev_eui": dev_eui}
+    app_key = _secrets.token_hex(16)
+    join_eui = (
+        design.lorawan.join_eui
+        if (design.lorawan and design.lorawan.join_eui)
+        else "0000000000000000"
+    )
+    result = chirpstack.provision_device(
+        dev_eui=dev_eui,
+        app_key=app_key,
+        application_name=application_name,
+        device_profile_name=profile_name(design, library),
+        join_eui=join_eui,
+        codec=generate_codec(design, library),
+    )
+    yield {
+        "type": "phase",
+        "phase": "registered",
+        "application_id": result.get("application_id"),
+        "device_profile_id": result.get("device_profile_id"),
+    }
+
+    # ---- serial provisioning ----------------------------------------
+    slot_info = workbench.slot_sync(slot)
+    if not slot_info.serial_url:
+        raise SerialUnavailable(f"{slot} exposes no serial url")
+    answers = {
+        "band": band,
+        "sub_band": str(sub_band),
+        "dev_eui": dev_eui,
+        "join_eui": join_eui,
+        "app_key": app_key,
+        "nwk_key": app_key,  # 1.0.x has one root key; both prompts take it
+    }
+    rules = [(pat, answers[key]) for pat, key in _PROMPT_RULES]
+
+    yield {"type": "phase", "phase": "provision", "url": slot_info.serial_url}
+    matched = None
+    for event in answer_prompts(
+        slot_info.serial_url,
+        rules,
+        done=_DONE,
+        secrets=[app_key],
+        timeout=serial_timeout,
+        min_interval=serial_min_interval,
+    ):
+        if event["type"] == "log":
+            yield event
+        else:
+            matched = event.get("matched")
+
+    if matched != "JOINED":
+        raise SerialUnavailable(f"device reported {matched or 'no join result'}")
+
+    # ---- verify ------------------------------------------------------
+    # "JOINED" is the device's own claim; the session in ChirpStack is the
+    # independent one, and it is what an uplink will actually be decoded
+    # against.
+    yield {"type": "phase", "phase": "verify"}
+    activation = chirpstack.get_activation(dev_eui)
+    if not activation:
+        raise cs.ChirpStackUnavailable(
+            f"{dev_eui} reported JOINED but has no activation in ChirpStack"
+        )
+
+    yield {
+        "type": "done",
+        "ok": True,
+        "dev_eui": dev_eui,
+        "slot": slot,
+        "dev_addr": activation.get("dev_addr"),
+        "application_id": result.get("application_id"),
+        "device_profile_id": result.get("device_profile_id"),
+    }

--- a/wirestudio/workbench/client.py
+++ b/wirestudio/workbench/client.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import AsyncIterator, Optional
+from typing import AsyncIterator, Iterator, Optional
 
 import httpx
 
@@ -231,18 +231,7 @@ class WorkbenchClient:
         if not ok:
             raise WorkbenchUnavailable(reason or f"{slot} is not flashable")
 
-        # The portal keys each part by `bin@<offset>`; anything else is
-        # silently ignored and the request fails as "no binaries to flash".
-        files = [
-            (f"bin@{offset:#x}", (f"{offset:#x}.bin", data, "application/octet-stream"))
-            for offset, data in images
-        ]
-        form = {
-            "slot": slot,
-            "chip": chip,
-            "baud": str(baud),
-            "erase": "true" if erase else "false",
-        }
+        form, files = _flash_payload(slot, images, chip, erase, baud)
 
         try:
             async with self._client(timeout=self.flash_timeout) as c:
@@ -250,26 +239,116 @@ class WorkbenchClient:
         except httpx.HTTPError as e:
             raise WorkbenchUnavailable(f"flash transport failed: {e}") from e
 
-        if r.status_code >= 400:
-            raise WorkbenchUnavailable(f"flash rejected: {_error_text(r)}")
+        for event in _flash_events(r, slot):
+            yield event
 
+    # ------------------------------------------------------------------
+    # Synchronous variants
+    #
+    # The LoRaWAN target is synchronous (grpc + subprocess), so its routes
+    # are plain `def` and FastAPI runs them in a threadpool. Awaiting from
+    # there would need a nested event loop; these share the async path's
+    # payload building and response handling.
+    # ------------------------------------------------------------------
+
+    def _sync_client(self, timeout: Optional[float] = None) -> httpx.Client:
+        headers = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        return httpx.Client(
+            base_url=self.base_url, timeout=timeout or self.timeout, headers=headers
+        )
+
+    def slots_sync(self) -> list[Slot]:
+        if not self.is_configured():
+            raise WorkbenchUnavailable(
+                self.unconfigured_reason() or "workbench not configured"
+            )
         try:
-            body = r.json()
-        except ValueError as e:
-            raise WorkbenchUnavailable(f"flash: unparseable response: {r.text[:200]}") from e
+            with self._sync_client() as c:
+                r = c.get("/api/devices")
+        except httpx.HTTPError as e:
+            raise WorkbenchUnavailable(f"unreachable: {e}") from e
+        if r.status_code == 401:
+            raise WorkbenchUnavailable("unauthorized (check WORKBENCH_TOKEN)")
+        if r.status_code >= 400:
+            raise WorkbenchUnavailable(f"/api/devices: http {r.status_code}")
+        return [Slot.from_api(s) for s in r.json().get("slots", [])]
 
-        # The portal buffers esptool and answers once, as
-        # {ok, output, returncode} -- so these lines arrive together at
-        # the end rather than live. Progress liveness needs the phase-2
-        # serial relay; this at least gives the operator the real log.
-        output = body.get("output") or ""
-        for line in output.splitlines():
-            if line.strip():
-                yield {"type": "log", "data": line.rstrip()}
+    def slot_sync(self, label: str) -> Slot:
+        for s in self.slots_sync():
+            if s.label == label:
+                return s
+        raise WorkbenchUnavailable(f"no such slot '{label}'")
 
-        rc = body.get("returncode")
-        if not body.get("ok") or rc not in (0, None):
-            detail = body.get("error") or _last_meaningful(output) or f"returncode {rc}"
-            raise WorkbenchUnavailable(f"flash failed: {detail}")
+    def flash_sync(
+        self,
+        slot: str,
+        images: list[tuple[int, bytes]],
+        chip: str = "esp32",
+        erase: bool = False,
+        baud: int = 921600,
+    ) -> Iterator[dict]:
+        if not self.is_configured():
+            raise WorkbenchUnavailable(
+                self.unconfigured_reason() or "workbench not configured"
+            )
+        if not images:
+            raise WorkbenchUnavailable("no images to flash")
 
-        yield {"type": "done", "ok": True, "slot": slot, "returncode": rc}
+        ok, reason = self.slot_sync(slot).flashable
+        if not ok:
+            raise WorkbenchUnavailable(reason or f"{slot} is not flashable")
+
+        form, files = _flash_payload(slot, images, chip, erase, baud)
+        try:
+            with self._sync_client(timeout=self.flash_timeout) as c:
+                r = c.post("/api/flash", data=form, files=files)
+        except httpx.HTTPError as e:
+            raise WorkbenchUnavailable(f"flash transport failed: {e}") from e
+        yield from _flash_events(r, slot)
+
+
+def _flash_payload(slot, images, chip, erase, baud):
+    """Multipart body for /api/flash.
+
+    The portal keys each part by `bin@<offset>`; any other name is silently
+    ignored and the request fails as "no binaries to flash".
+    """
+    files = [
+        (f"bin@{offset:#x}", (f"{offset:#x}.bin", data, "application/octet-stream"))
+        for offset, data in images
+    ]
+    form = {
+        "slot": slot,
+        "chip": chip,
+        "baud": str(baud),
+        "erase": "true" if erase else "false",
+    }
+    return form, files
+
+
+def _flash_events(r: httpx.Response, slot: str) -> Iterator[dict]:
+    """Turn the portal's one buffered answer into log + done events.
+
+    The portal buffers esptool and replies once as {ok, output, returncode},
+    so the log arrives at completion rather than live -- and a non-zero
+    returncode comes back under HTTP 200, which is why success is read from
+    that field rather than the status code.
+    """
+    if r.status_code >= 400:
+        raise WorkbenchUnavailable(f"flash rejected: {_error_text(r)}")
+    try:
+        body = r.json()
+    except ValueError as e:
+        raise WorkbenchUnavailable(f"flash: unparseable response: {r.text[:200]}") from e
+
+    output = body.get("output") or ""
+    for line in output.splitlines():
+        if line.strip():
+            yield {"type": "log", "data": line.rstrip()}
+
+    rc = body.get("returncode")
+    if not body.get("ok") or rc not in (0, None):
+        detail = body.get("error") or _last_meaningful(output) or f"returncode {rc}"
+        raise WorkbenchUnavailable(f"flash failed: {detail}")
+
+    yield {"type": "done", "ok": True, "slot": slot, "returncode": rc}

--- a/wirestudio/workbench/serial.py
+++ b/wirestudio/workbench/serial.py
@@ -1,0 +1,114 @@
+"""Drive a slot's serial console over the workbench's RFC2217 port.
+
+This is the half of LoRaWAN provisioning that only the browser could do:
+reading the device's prompts and writing the answers back. The keys come
+from ChirpStack (`provision_device`); this module just gets them into the
+device's NVS without a human at the bench.
+"""
+from __future__ import annotations
+
+import re
+import time
+from typing import Iterator, Optional, Pattern, Sequence
+
+DEFAULT_BAUD = 115200
+
+
+class SerialUnavailable(RuntimeError):
+    """Raised when the slot's serial port is unusable or the dialogue stalls."""
+
+
+def _redact(text: str, secrets: Sequence[str]) -> str:
+    """Devices echo what they were sent, so a key comes back on the wire.
+
+    Matched case-insensitively: firmware commonly echoes hex uppercase even
+    when it was sent lowercase.
+    """
+    for s in secrets:
+        if not s:
+            continue
+        text = re.sub(re.escape(s), "<redacted>", text, flags=re.IGNORECASE)
+    return text
+
+
+def answer_prompts(
+    url: str,
+    rules: Sequence[tuple[Pattern[str], str]],
+    *,
+    done: Pattern[str],
+    secrets: Sequence[str] = (),
+    baud: int = DEFAULT_BAUD,
+    timeout: float = 180.0,
+    prompt_marker: str = "Enter",
+    nudge: bytes = b"\r\n",
+    min_interval: float = 1.0,
+) -> Iterator[dict]:
+    """Answer a device's serial prompts, yielding redacted log events.
+
+    `rules` is [(pattern, answer)] checked in order against the tail of the
+    output; first match wins. Yields ``{"type": "log", "data": ...}`` and a
+    final ``{"type": "result", "matched": <text or None>}``.
+
+    Raises SerialUnavailable if the port cannot be opened or the dialogue
+    stalls without reaching `done`.
+    """
+    try:
+        import serial  # noqa: PLC0415 -- optional dep, only needed on this path
+    except ImportError as exc:  # pragma: no cover - exercised by the extra
+        raise SerialUnavailable(
+            "pyserial is required for workbench serial provisioning "
+            "(pip install 'wirestudio[lorawan]')"
+        ) from exc
+
+    try:
+        port = serial.serial_for_url(url, baudrate=baud, timeout=1)
+    except Exception as exc:
+        raise SerialUnavailable(f"cannot open {url}: {exc}") from exc
+
+    buf = ""
+    last_sent = 0.0
+    deadline = time.monotonic() + timeout
+    try:
+        # The firmware prints its prompt once, before we attach. A bare newline
+        # is rejected and re-prints it, which is what gives us something to
+        # match -- without this the dialogue silently never starts.
+        if nudge:
+            time.sleep(0.5)
+            port.write(nudge)
+            port.flush()
+
+        while time.monotonic() < deadline:
+            chunk = port.read(512).decode("utf-8", "replace")
+            if chunk:
+                buf += chunk
+                yield {"type": "log", "data": _redact(chunk, secrets)}
+
+            hit = done.search(buf)
+            if hit:
+                yield {"type": "result", "matched": hit.group(0)}
+                return
+
+            tail = buf[-400:]
+            # Rate-limit so one prompt re-printed twice doesn't consume two
+            # answers and desynchronise the rest of the dialogue.
+            if prompt_marker in tail and time.monotonic() - last_sent > min_interval:
+                for pattern, answer in rules:
+                    if pattern.search(tail):
+                        port.write((answer + "\r\n").encode())
+                        port.flush()
+                        yield {
+                            "type": "log",
+                            "data": f"[sent {_redact(answer, secrets)}]\n",
+                        }
+                        buf = ""
+                        last_sent = time.monotonic()
+                        break
+    finally:
+        try:
+            port.close()
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+    raise SerialUnavailable(
+        f"serial dialogue did not reach {done.pattern!r} within {timeout:.0f}s"
+    )


### PR DESCRIPTION
Follow-on to #188. Registration was already built — and already designed around a host that supplies the eFuse MAC and types the keys into the device's serial prompt. `/lorawan/provision`'s own docstring says so:

> *"The browser supplies the DevEUI (derived from the chip's eFuse MAC) … and return the values **the host writes into the device's serial provisioning prompt**."*

That host could only ever be a browser over WebSerial. The workbench can be it instead, which makes the whole flow headless.

## What's new

`POST /lorawan/workbench/provision {slot, design, images}` → SSE, one phase per step:

```
flash → detect → register → provision → verify → done
```

It mostly chains things that already existed (`/workbench/flash`, `provision_device`, `get_activation`). The genuinely new piece is `wirestudio.workbench.serial.answer_prompts` — a prompt/response driver over the slot's RFC2217 port, which is the half only the browser could do.

## Phase order is dictated by the hardware

Not taste — both orderings were established the hard way:

- **Flash precedes registration**, because esptool's output is the only place the eFuse MAC appears. The bench exposes no chip-detect endpoint, and esptool driven over RFC2217 can't pull these boards into download mode at all.
- **Erase precedes registration**, so `provision_device`'s DevNonce flush lands *after* the device's counter has restarted. Reversed, the join is rejected as a replay with nothing on the wire to explain it — exactly how the Heltec failed when I did this by hand.

Both are asserted by tests, with the reasoning in the docstrings rather than lost in a commit message.

## Also fixes: a tenant-scoped API key reported as unusable

`ping()` and `default_tenant_id()` both probed `TenantService.List`, which is **admin-only**. So the least-privilege key the ChirpStack UI hands out by default made `/lorawan/chirpstack/status` report the server as down, and every provisioning chain die on a bare `UNAUTHENTICATED` that reads like a bad token.

`CHIRPSTACK_TENANT_ID` now skips the admin-only lookup and `ping()` probes with a tenant-scoped call. Verified against a live server — the *same* key:

```
without tenant id: {'available': False, 'reason': 'ChirpStack unreachable: UNAUTHENTICATED: '}
with tenant id:    {'available': True,  'reason': None}
```

The error message also now says what to do instead of just restating the status code.

## Secret handling

Keys are redacted from the streamed log **case-insensitively**, because devices echo what they were sent and firmware echoes hex uppercase — a case-sensitive redaction would leak the AppKey straight into the SSE stream. There's a test for exactly that.

## Verification

Run against a real T-Beam at a remote bench, one request:

```
PHASE flash      {'slot': 'SLOT28'}
PHASE detect     {'mac': '10:52:1c:66:b6:e0', 'dev_eui': '10521cfffe66b6e0'}
PHASE register   {'dev_eui': '10521cfffe66b6e0'}
PHASE registered {'application_id': '31accf5d…', 'device_profile_id': '1228ee73…'}
PHASE provision  {'url': 'rfc2217://10.254.0.44:4028'}
PHASE verify     {}
DONE  {"ok": true, "dev_addr": "002969cc", …}
```

and the device then uplinked:

```
fCnt 1 | 22 bytes | DR1
{"batt_mv": 4136, "temp_c": 34.79, "humidity": 51, "uptime_s": 67, …}
```

That's the eight manual steps from #188's session collapsed into one call.

978 passed, 12 skipped. `npm run build` clean.

## Notes for review

- `WorkbenchClient` gains sync variants (`slots_sync`/`slot_sync`/`flash_sync`). The LoRaWAN target is synchronous (grpc + subprocess) so its routes are plain `def`; awaiting from there would need a nested loop. Payload building and response handling are shared with the async path rather than duplicated.
- `pyserial` is imported lazily with a pointed error, so an ESPHome-only install is unaffected.
- The serial driver's 1 s inter-prompt rate limit exists because a re-printed prompt would otherwise consume two answers and desynchronise the dialogue. It's a parameter so tests don't pay for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ