### PR TITLE
release 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] — 2026-07-30
+
 ### Added
 
 - **Workbench remote flash transport (phase 1, server side).** New

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.24.1"
+__version__ = "0.25.0"


### PR DESCRIPTION
Ships #188 and #189.

**Why now:** LoRaWAN builds cannot run in the current `-full` image at all — three stacked faults (uid mismatch, `0700` platform dirs, a baked `PLATFORMIO_CORE_DIR` under a read-only rootfs). That fix is merged but prod still runs `0.24.1-full`, so the `PermissionError` is live today.

## Highlights

- **Workbench remote flash transport** (roadmap phase 1) — `/workbench/status`, `/workbench/slots`, `/workbench/flash` behind `WORKBENCH_URL` + `WORKBENCH_TOKEN`, with a Local USB / Workbench-slot toggle in the flash dialog.
- **Headless LoRaWAN bring-up** — `/lorawan/workbench/provision` flashes, registers, provisions over serial and verifies in one call.
- **Six hardware-found generator bugs**, five of which were invisible to CI: the device stayed joined, logs looked healthy, and Home Assistant showed plausible numbers.
- **`battery_adc`** — boards that sense the cell through a divider now report `batt_mv` in the same payload slot as a PMIC.
- **Tenant-scoped ChirpStack keys** now work; previously the least-privilege key reported the server as down.

## Post-deploy

Three env vars are needed in the argocd repo before the new features do anything:

- `WORKBENCH_URL`, `WORKBENCH_TOKEN` — absent, so `/workbench/*` stays gated off
- `CHIRPSTACK_TENANT_ID` — prod has the API token but not the tenant id; if that key is tenant-scoped, provisioning fails without it

978 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ