### PR TITLE
fix(workbench): make WORKBENCH_TOKEN optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`WORKBENCH_TOKEN` is optional.** Phase 1 required it, reasoning that
+  every comparable gate pairs a host with a credential. That was wrong:
+  those tokens authenticate to services that check them, and the stock
+  workbench portal checks nothing. Requiring it gated nothing -- anyone
+  able to set the URL can set a token too -- while implying a credential
+  that does not exist and pushing operators to seal a dummy value into a
+  secret store. `WORKBENCH_URL` alone now configures the integration, and
+  the token is sent only when set, for a bench fronted by something that
+  does authenticate.
+
 ## [0.25.0] — 2026-07-30
 
 ### Added

--- a/docs/workbench.md
+++ b/docs/workbench.md
@@ -53,7 +53,7 @@ receiver plus signal generator.
 Each phase is independently shippable; later phases build on earlier
 ones but none blocks the others' value.
 
-1. **Remote flash transport.** `WORKBENCH_URL` + `WORKBENCH_TOKEN` env
+1. **Remote flash transport.** A `WORKBENCH_URL` env
    gate (the usual integration seam) enabling `/workbench/status`,
    `/workbench/slots` and `/workbench/flash`: the server fetches the
    framework's image exactly as the existing proxies do, uploads it to
@@ -112,18 +112,25 @@ ones but none blocks the others' value.
   the UI surfaces why, same as fleet/ChirpStack/Thingiverse.
 - **No bench state in `design.json`.** Slot assignments and workbench
   hosts are deployment configuration, not design content.
-- **The URL is not sufficient authorization.** Every comparable gate
-  pairs a host with a credential (`FLEET_URL` + `FLEET_TOKEN`,
-  `CHIRPSTACK_API_URL` + `CHIRPSTACK_API_TOKEN`); the workbench API is
-  unauthenticated, and phase 1 has the server push firmware at a device
-  on an operator-supplied host. A `WORKBENCH_URL` alone would make any
-  hosted studio a relay for flashing arbitrary images onto someone's
-  bench. Phase 1 therefore ships `WORKBENCH_TOKEN` alongside the
-  transport rather than as a follow-up. Note there is no existing
-  outbound-SSRF guard in the codebase to reuse: `WIRESTUDIO_ALLOWED_ORIGINS`
-  is CORS and `WIRESTUDIO_MCP_ALLOWED_HOSTS` is the MCP SDK's *inbound*
-  DNS-rebinding mitigation. Only the comma-split env parsing idiom
-  carries over; the enforcement is new code.
+- **`WORKBENCH_URL` is the gate, and it is a real one.** The server
+  pushes firmware at a device on an operator-supplied host, so pointing
+  it anywhere but a bench you control is the whole risk. `WORKBENCH_TOKEN`
+  is optional and sent only when set — for a bench fronted by something
+  that authenticates; the stock portal ignores it.
+
+  Phase 1 originally *required* the token, reasoning that every
+  comparable gate pairs a host with a credential (`FLEET_URL` +
+  `FLEET_TOKEN`). That was wrong: those tokens authenticate to services
+  that check them, and this one is checked by nothing. Requiring it gated
+  nothing — anyone able to set the URL can set a token too — while
+  implying a credential that does not exist and pushing operators to seal
+  a dummy value into a secret store. An honest unauthenticated integration
+  beats a decorative credential.
+
+  A real outbound guard would be a host allowlist, and there is no
+  existing one to reuse: `WIRESTUDIO_ALLOWED_ORIGINS` is CORS and
+  `WIRESTUDIO_MCP_ALLOWED_HOSTS` is the MCP SDK's *inbound* DNS-rebinding
+  mitigation. Only the comma-split env parsing idiom carries over.
 - **Bench resources are exclusive; model the contention.** A slot's
   serial port admits one reader, and the SDR is a single dongle behind
   a global lock — a capture in flight rejects the next caller outright.

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -159,12 +159,27 @@ async def test_unconfigured_without_url(monkeypatch):
     assert not ok and reason == "WORKBENCH_URL not set"
 
 
-async def test_url_alone_is_not_configured():
-    """A URL without a token must not be enough -- see docs/workbench.md."""
-    wc = WorkbenchClient(base_url="http://bench:8080", token="")
-    assert not wc.is_configured()
-    ok, reason = await wc.is_available()
-    assert not ok and reason == "WORKBENCH_TOKEN not set"
+async def test_url_alone_is_enough():
+    """The stock portal does not authenticate, so requiring a token gated
+    nothing -- anyone able to set the URL can set a token too -- while
+    implying a credential that does not exist. The URL is the gate."""
+    assert WorkbenchClient(base_url="http://bench:8080", token="").is_configured()
+
+
+async def test_token_is_omitted_when_unset():
+    """No Authorization header at all, rather than an empty bearer."""
+    seen = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["auth"] = req.headers.get("authorization")
+        return httpx.Response(200, json={"hostname": "bench"})
+
+    wc = WorkbenchClient(
+        base_url="http://bench:8080", token="", transport=httpx.MockTransport(handler)
+    )
+    ok, _ = await wc.is_available()
+    assert ok
+    assert seen["auth"] is None
 
 
 async def test_bad_token_reports_unauthorized():
@@ -185,7 +200,6 @@ async def test_available_when_configured_and_reachable():
 
 def test_status_reports_reason_and_hint_when_unconfigured(monkeypatch):
     monkeypatch.delenv("WORKBENCH_URL", raising=False)
-    monkeypatch.delenv("WORKBENCH_TOKEN", raising=False)
     body = TestClient(create_app()).get("/workbench/status").json()
     assert body["available"] is False
     assert body["reason"] == "WORKBENCH_URL not set"

--- a/wirestudio/api/workbench.py
+++ b/wirestudio/api/workbench.py
@@ -55,8 +55,9 @@ def router(client_factory: Optional[Callable[[], WorkbenchClient]] = None) -> AP
             "reason": reason,
             "url": wc.base_url or None,
             "configure_hint": (
-                "Export WORKBENCH_URL=http://<pi>:8080 and WORKBENCH_TOKEN=<secret> "
-                "to flash boards on a remote bench."
+                "Export WORKBENCH_URL=http://<pi>:8080 to flash boards on a remote "
+                "bench. WORKBENCH_TOKEN is optional -- set it only if the bench "
+                "sits behind something that authenticates."
                 if not ok
                 else None
             ),
@@ -68,7 +69,7 @@ def router(client_factory: Optional[Callable[[], WorkbenchClient]] = None) -> AP
         if not wc.is_configured():
             raise HTTPException(
                 status_code=503,
-                detail="workbench not configured (set WORKBENCH_URL and WORKBENCH_TOKEN)",
+                detail="workbench not configured (set WORKBENCH_URL)",
             )
         try:
             slots = await wc.slots()
@@ -104,7 +105,7 @@ def router(client_factory: Optional[Callable[[], WorkbenchClient]] = None) -> AP
         if not wc.is_configured():
             raise HTTPException(
                 status_code=503,
-                detail="workbench not configured (set WORKBENCH_URL and WORKBENCH_TOKEN)",
+                detail="workbench not configured (set WORKBENCH_URL)",
             )
 
         slot = body.get("slot")

--- a/wirestudio/targets/lorawan/api.py
+++ b/wirestudio/targets/lorawan/api.py
@@ -204,7 +204,7 @@ def build_router(library: Library, backend: BuildBackend) -> APIRouter:
         if not wb.is_configured():
             raise HTTPException(
                 status_code=503,
-                detail="workbench not configured (set WORKBENCH_URL and WORKBENCH_TOKEN)",
+                detail="workbench not configured (set WORKBENCH_URL)",
             )
         chirp = cs.ChirpStackClient()
         if not chirp.is_configured():

--- a/wirestudio/workbench/client.py
+++ b/wirestudio/workbench/client.py
@@ -1,13 +1,17 @@
 """HTTP client for a Universal Embedded Workbench.
 
   WORKBENCH_URL    base URL of the Pi's portal (e.g. http://10.0.0.44:8080)
-  WORKBENCH_TOKEN  shared secret, sent as a Bearer token
+  WORKBENCH_TOKEN  optional bearer token, sent when set
 
-The token is required even though the stock portal does not check one:
-the studio uploads firmware to whatever host WORKBENCH_URL names, so a
-URL-only gate would let any studio deployment push arbitrary images at
-any reachable bench. Requiring the operator to set both keeps that
-deliberate. See docs/workbench.md.
+The stock portal does not authenticate, so the token is sent only for
+benches fronted by something that does (a reverse proxy, say). It is not
+required, and requiring it bought nothing: anyone able to set the URL can
+set a token too, so it gated nothing while implying a credential that does
+not exist.
+
+WORKBENCH_URL is therefore the gate, and it is a real one -- the server
+uploads firmware to whatever host it names. Point it only at a bench you
+control. See docs/workbench.md.
 """
 from __future__ import annotations
 
@@ -147,13 +151,11 @@ class WorkbenchClient:
     # ------------------------------------------------------------------
 
     def is_configured(self) -> bool:
-        return bool(self.base_url and self.token)
+        return bool(self.base_url)
 
     def unconfigured_reason(self) -> Optional[str]:
         if not self.base_url:
             return "WORKBENCH_URL not set"
-        if not self.token:
-            return "WORKBENCH_TOKEN not set"
         return None
 
     async def is_available(self) -> tuple[bool, Optional[str]]:


### PR DESCRIPTION
Phase 1 required `WORKBENCH_TOKEN`, reasoning that every comparable gate pairs a host with a credential (`FLEET_URL` + `FLEET_TOKEN`, `CHIRPSTACK_API_URL` + `CHIRPSTACK_API_TOKEN`).

That reasoning was wrong. Those tokens authenticate to services that **check** them; this one is checked by nothing. Every request during phase 1 bring-up carried a literal `Bearer dummy` and the bench never looked at it.

So requiring it:

- **gated nothing** — anyone able to set `WORKBENCH_URL` can set a token too
- **implied a credential that does not exist**
- **pushed operators toward sealing a meaningless value into a secret store** just to switch the feature on

That last one is what surfaced it: wiring this into the argocd repo meant either running a dummy value through kubeseal, or putting a plaintext "token" next to real SealedSecrets. Both are worse than being honest that the integration is unauthenticated.

## Change

`WORKBENCH_URL` alone now configures the integration — and it is the real gate, since the server uploads firmware to whatever host it names. The token is still sent when set, for a bench fronted by something that does authenticate (a reverse proxy).

A host allowlist would be a genuine outbound guard; the docs note there's still no existing one to reuse, so that remains new code if wanted.

## Tests

- `test_url_alone_is_enough` replaces `test_url_alone_is_not_configured`
- `test_token_is_omitted_when_unset` — no `Authorization` header at all rather than an empty bearer
- token-carrying paths still covered (`test_bad_token_reports_unauthorized`)

979 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ