### PR TITLE
release 0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] — 2026-07-30
+
 ### Changed
 
 - **`WORKBENCH_TOKEN` is optional.** Phase 1 required it, reasoning that

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.25.0"
+__version__ = "0.25.1"


### PR DESCRIPTION
Patch release so the workbench integration can actually be switched on.

0.25.0 required `WORKBENCH_TOKEN`, which meant enabling the feature in a GitOps repo took either running a meaningless value through kubeseal or putting a plaintext "token" next to real SealedSecrets. The stock portal authenticates nothing, so the requirement gated nothing — it only implied a credential that doesn't exist.

`WORKBENCH_URL` alone now configures the integration (#191). The corresponding argocd change is already pushed, so prod and dev pick this up on the next image roll.

979 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ