### PR TITLE
feat(web): feedback link to the repo's issue tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Feedback link in the header.** An icon beside the theme and settings
+  buttons opens the repo's new-issue form, prefilled with the running
+  version, the current board, and the browser UA -- the details a bug
+  report otherwise costs a round trip to collect. A plain link rather
+  than an API call: no token, nothing leaves the browser, and GitHub
+  shows the reporter the whole body before they submit. The design is
+  deliberately not included.
+
 ### Changed
 
 - **Regenerated the library coverage matrix.** It still reported 64

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import { UsbDetectDialog } from "./components/UsbDetectDialog";
 import { AgentSidebar } from "./components/AgentSidebar";
 import { SolveResultBanner } from "./components/SolveResultBanner";
 import { NewDesignDialog } from "./components/NewDesignDialog";
+import { FeedbackLink } from "./components/FeedbackLink";
 import { PushToFleetDialog } from "./components/PushToFleetDialog";
 import { CapabilityPickerDialog } from "./components/CapabilityPickerDialog";
 import { EnclosureDialog } from "./components/EnclosureDialog";
@@ -688,6 +689,15 @@ export default function App() {
                 ADVANCED
               </label>
             </div>
+
+            <FeedbackLink
+              version={version}
+              boardId={
+                ((design?.board as Record<string, unknown> | undefined)?.library_id as
+                  | string
+                  | undefined) ?? null
+              }
+            />
 
             <button
               onClick={() => setTheme(theme === "dark" ? "light" : "dark")}

--- a/web/src/components/FeedbackLink.test.tsx
+++ b/web/src/components/FeedbackLink.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FeedbackLink, issueUrl } from "./FeedbackLink";
+
+describe("issueUrl", () => {
+  it("points at the repo's new-issue form", () => {
+    expect(issueUrl("0.25.1")).toContain(
+      "https://github.com/moellere/WireStudio/issues/new",
+    );
+  });
+
+  it("prefills version and board so the reporter isn't asked for them", () => {
+    const body = decodeURIComponent(issueUrl("0.25.1", "ttgo-t-beam").split("body=")[1]);
+    expect(body).toContain("wirestudio v0.25.1");
+    expect(body).toContain("board: ttgo-t-beam");
+  });
+
+  it("still works before /api/health has answered", () => {
+    const body = decodeURIComponent(issueUrl(null).split("body=")[1]);
+    expect(body).toContain("version unknown");
+    expect(body).not.toContain("board:");
+  });
+
+  it("encodes the body, so newlines can't truncate the URL", () => {
+    const url = issueUrl("0.25.1", "esp32-devkitc-v4");
+    expect(url).not.toContain("\n");
+    expect(url).toContain("%0A");
+  });
+});
+
+describe("FeedbackLink", () => {
+  it("opens in a new tab without handing the opener to GitHub", () => {
+    render(<FeedbackLink version="0.25.1" />);
+    const link = screen.getByRole("link", { name: /send feedback/i });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+});

--- a/web/src/components/FeedbackLink.tsx
+++ b/web/src/components/FeedbackLink.tsx
@@ -1,0 +1,44 @@
+import { MessageSquarePlus } from "lucide-react";
+
+const ISSUE_URL = "https://github.com/moellere/WireStudio/issues/new";
+
+/**
+ * Prefills the issue body with the bits that otherwise cost a round trip to
+ * ask for. Everything here is shown in GitHub's form before the reporter
+ * submits, so nothing is sent without them seeing it -- which is also why the
+ * design itself is not included.
+ */
+export function issueUrl(version: string | null, boardId?: string | null): string {
+  const body = [
+    "",
+    "",
+    "---",
+    `wirestudio ${version ? `v${version}` : "(version unknown)"}`,
+    boardId ? `board: ${boardId}` : null,
+    typeof navigator !== "undefined" ? `browser: ${navigator.userAgent}` : null,
+  ]
+    .filter((l) => l !== null)
+    .join("\n");
+  return `${ISSUE_URL}?body=${encodeURIComponent(body)}`;
+}
+
+export function FeedbackLink({
+  version,
+  boardId,
+}: {
+  version: string | null;
+  boardId?: string | null;
+}) {
+  return (
+    <a
+      href={issueUrl(version, boardId)}
+      target="_blank"
+      rel="noreferrer noopener"
+      className="flex items-center gap-1 rounded-md p-1.5 text-ink-faint transition-colors hover:bg-surface-2 hover:text-ink"
+      title="Report a bug or suggest a feature on GitHub"
+      aria-label="Send feedback"
+    >
+      <MessageSquarePlus className="h-4 w-4" />
+    </a>
+  );
+}


### PR DESCRIPTION
Adds an unobtrusive feedback affordance: an icon in the header, beside the theme and settings buttons, that opens `https://github.com/moellere/WireStudio/issues/new`.

Prefills the body with the running version, the current board, and the browser UA — the details a bug report otherwise costs a round trip to collect.

## Design choices

- **A plain `<a>`, not an API call.** No token to configure, no CORS, nothing leaves the browser. GitHub renders the prefilled form and the reporter sees the entire body before submitting.
- **The design is not included.** It could carry anything the user has been working on, and the point is a report they've actually reviewed. Version + board + UA is what's diagnostically useful without being a surprise.
- **`rel="noopener"`** so the new tab can't reach back through `window.opener`.
- The body is URL-encoded, so newlines can't truncate the link.

## Verification

- 5 unit tests: URL target, prefill contents, the `version === null` case before `/api/health` answers, encoding, and the `target`/`rel` attributes
- Full web suite: 213 passed
- `npm run build` clean
- Served the built bundle and confirmed the link and its labels are actually present in it, rather than trusting the test alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ