### PR TITLE
docs: record the MCP hardware gap and the REST auth asymmetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Roadmap: MCP tool surface hardware gap.** The 22 MCP tools stop at
+  the artifact -- no compile, flash or provision -- so an MCP client
+  builds a design and then has to hand off to HTTP to reach a board.
+  That matters for exposure, not just ergonomics: `/mcp` authenticates
+  with `WIRESTUDIO_MCP_TOKEN`, while the REST surface authenticates with
+  nothing, so publishing REST instead means publishing unauthenticated
+  firmware-flashing and ChirpStack provisioning.
+
 ### Added
 
 - **Feedback link in the header.** An icon beside the theme and settings

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,6 +190,27 @@ interpreter flash + starter above is the shipped first step).
 Deliberately deferred: generic Arduino/PlatformIO scaffolds (per-driver
 maintenance sinkhole), Zephyr, Zigbee/Thread on the C6.
 
+**MCP tool surface — hardware gap.** The 22 MCP tools cover design,
+KiCad and fab, but stop at the artifact: there is no `compile`, `flash`,
+`provision`, or `workbench_slots` tool. An MCP client can produce a
+design and a schematic and then has to hand off to HTTP to put it on a
+board, which defeats the point of the headless path — and the two are
+not equivalently exposed. A deployment behind SSO can reasonably publish
+`/mcp`, which authenticates with `WIRESTUDIO_MCP_TOKEN`; the REST
+endpoints authenticate with nothing, so publishing those instead means
+publishing unauthenticated firmware-flashing and ChirpStack
+provisioning. Closing the gap in MCP is the only route that does not
+force that trade. Wrapping the existing `/lorawan/compile`,
+`/lorawan/workbench/provision` and `/workbench/*` handlers is most of
+the work; the open question is how a long SSE compile maps onto an MCP
+call that wants to return once.
+
+Related, and worth doing regardless: the REST surface has no auth at
+all. `/workbench/flash` and `/lorawan/provision` are reachable by
+anything that can route to the pod. That is survivable while the only
+exposure is a cluster-internal Service, and is the reason the ingress
+publishes `/mcp` alone.
+
 **Workbench featureset (planned).** Integrate a
 [Universal Embedded Workbench](https://github.com/SensorsIot/Universal-Embedded-Workbench)
 (Raspberry Pi exposing RFC2217 network serial per USB slot, a JSON HTTP


### PR DESCRIPTION
Found while driving a real bring-up against the deployed instance.

The 22 MCP tools cover design, KiCad and fab but stop at the artifact — there's no `compile`, `flash`, `provision` or `workbench_slots`. A headless client can produce a design and a schematic, then has to hand off to HTTP to put it on a board.

The part worth recording is that the two surfaces aren't equivalently exposed:

| Surface | Auth |
|---|---|
| `/api/mcp` | `WIRESTUDIO_MCP_TOKEN` — verified 401 without, 401 wrong, 200 correct |
| `/api/workbench/*`, `/api/lorawan/*`, `/api/designs` | **none** — 200 with no auth |

So a deployment behind SSO can reasonably publish `/mcp`. Publishing the REST endpoints instead — the obvious workaround for the gap — means publishing unauthenticated firmware-flashing and ChirpStack provisioning. Closing the gap in MCP is the only route that doesn't force that trade.

Wrapping the existing handlers is most of the work; the open design question is how a long SSE compile maps onto an MCP call that wants to return once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ