### PR TITLE
fix(lorawan): PlatformIO lock cannot live on the read-only image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **LoRaWAN builds still failed in the deployed image.** The 0.25.0 fix
+  moved `PLATFORMIO_CORE_DIR` to the writable volume but pointed
+  `PLATFORMIO_PLATFORMS_DIR` / `PACKAGES_DIR` straight at the prewarmed
+  tree baked into the image. PlatformIO takes its lock at `<dir>.lock` --
+  a *sibling* of the managed directory, not a child -- so every build died
+  with `OSError: [Errno 30] Read-only file system:
+  '/opt/pio/platforms.lock'`. The core dir now holds symlinks to the
+  prewarmed trees (created by a new entrypoint, since /data is a volume
+  and masks anything written at build time), so locks land on the writable
+  volume while the content still resolves to the read-only baked copy --
+  no re-download, nothing duplicated onto the volume.
+- **`platformio_status()` reported available for that install.** The probe
+  checked core-dir writability and platform-tree readability, which is
+  exactly what this failure slips past. It now also verifies the lock path
+  beside each managed directory is writable. Found by running a real build
+  against the deployed image: status said available, the build failed.
+
 ### Added
 
 - **Feedback link in the header.** An icon beside the theme and settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,9 +102,12 @@ EOF
 # invocation, so a baked-in core dir cannot work under a read-only root
 # filesystem. Split it: state on the writable volume, the prewarmed
 # toolchain read-only where the build stage left it.
+# Only the core dir and cache are set. platforms/packages are NOT pointed at
+# /opt/pio directly: PlatformIO locks at `<dir>.lock`, a sibling of the managed
+# directory, so that would leave the lock on the read-only image filesystem and
+# every build would fail. docker-entrypoint.sh symlinks the prewarmed trees in
+# from the writable core dir instead.
 ENV PLATFORMIO_CORE_DIR=/data/pio \
-    PLATFORMIO_PLATFORMS_DIR=/opt/pio/platforms \
-    PLATFORMIO_PACKAGES_DIR=/opt/pio/packages \
     PLATFORMIO_CACHE_DIR=/tmp/pio-cache
 
 ENV PYTHONUNBUFFERED=1 \
@@ -120,5 +123,6 @@ VOLUME ["/data"]
 USER appuser
 
 # tini reaps zombies + forwards SIGTERM cleanly so docker stop is fast.
-ENTRYPOINT ["/usr/bin/tini", "--"]
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["python", "-m", "wirestudio.api", "--host", "0.0.0.0", "--port", "8765", "--static-dir", "/app/web-dist"]

--- a/Dockerfile.pcb
+++ b/Dockerfile.pcb
@@ -96,9 +96,12 @@ EOF
 # invocation, so a baked-in core dir cannot work under a read-only root
 # filesystem. Split it: state on the writable volume, the prewarmed
 # toolchain read-only where the build stage left it.
+# Only the core dir and cache are set. platforms/packages are NOT pointed at
+# /opt/pio directly: PlatformIO locks at `<dir>.lock`, a sibling of the managed
+# directory, so that would leave the lock on the read-only image filesystem and
+# every build would fail. docker-entrypoint.sh symlinks the prewarmed trees in
+# from the writable core dir instead.
 ENV PLATFORMIO_CORE_DIR=/data/pio \
-    PLATFORMIO_PLATFORMS_DIR=/opt/pio/platforms \
-    PLATFORMIO_PACKAGES_DIR=/opt/pio/packages \
     PLATFORMIO_CACHE_DIR=/tmp/pio-cache
 
 ENV PYTHONUNBUFFERED=1 \
@@ -120,5 +123,6 @@ VOLUME ["/data"]
 
 USER appuser
 
-ENTRYPOINT ["/usr/bin/tini", "--"]
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["python", "-m", "wirestudio.api", "--host", "0.0.0.0", "--port", "8765", "--static-dir", "/app/web-dist"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# PlatformIO takes its lock at `<dir>.lock` -- a sibling of the managed
+# directory, not a child. So pointing PLATFORMIO_PLATFORMS_DIR straight at the
+# prewarmed tree baked into the image puts the lock on the image filesystem,
+# and every build dies with:
+#
+#   OSError: [Errno 30] Read-only file system: '/opt/pio/platforms.lock'
+#
+# Keep the core dir on the writable volume and link the prewarmed trees in from
+# there, so the locks land next to the links (writable) while the content still
+# resolves to the read-only baked copy. No re-download, no 7 GB duplicated onto
+# the volume.
+#
+# Done here rather than in the Dockerfile because /data is a volume: anything
+# written to that path at build time is masked once it is mounted.
+set -e
+
+CORE_DIR="${PLATFORMIO_CORE_DIR:-/data/pio}"
+if [ -d /opt/pio ]; then
+    mkdir -p "$CORE_DIR" 2>/dev/null || true
+    for d in platforms packages; do
+        if [ -d "/opt/pio/$d" ] && [ ! -e "$CORE_DIR/$d" ]; then
+            ln -sfn "/opt/pio/$d" "$CORE_DIR/$d" 2>/dev/null || true
+        fi
+    done
+fi
+
+exec "$@"

--- a/tests/test_lorawan_api.py
+++ b/tests/test_lorawan_api.py
@@ -425,3 +425,29 @@ def test_platformio_status_available_when_core_dir_usable(monkeypatch, tmp_path)
     status = compile_mod.platformio_status()
     assert status["available"] is True
     assert status["reason"] is None
+
+
+def test_platformio_status_flags_unwritable_lock(monkeypatch, tmp_path):
+    """PlatformIO locks at `<dir>.lock` -- a sibling of the managed directory.
+    Pointing platforms at a read-only prewarmed tree leaves that lock
+    unwritable, so every build dies with "Read-only file system:
+    .../platforms.lock" while a core-dir-only probe still reports available."""
+    from wirestudio.targets.lorawan import compile as compile_mod
+
+    monkeypatch.setattr(compile_mod, "_pio_cmd", lambda: ["pio"])
+    monkeypatch.setattr(
+        compile_mod.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="PlatformIO Core 6.1", stderr=""),
+    )
+    baked = tmp_path / "baked"
+    (baked / "platforms").mkdir(parents=True)
+    baked.chmod(0o500)  # readable, not writable -- the image filesystem
+    monkeypatch.setenv("PLATFORMIO_CORE_DIR", str(tmp_path / "core"))
+    monkeypatch.setenv("PLATFORMIO_PLATFORMS_DIR", str(baked / "platforms"))
+    try:
+        status = compile_mod.platformio_status()
+    finally:
+        baked.chmod(0o700)
+    assert status["available"] is False
+    assert "lock" in status["reason"]

--- a/wirestudio/targets/lorawan/compile.py
+++ b/wirestudio/targets/lorawan/compile.py
@@ -176,6 +176,9 @@ def _core_dir_problem() -> Optional[str]:
     platforms = Path(
         os.environ.get("PLATFORMIO_PLATFORMS_DIR") or (core / "platforms")
     )
+    packages = Path(
+        os.environ.get("PLATFORMIO_PACKAGES_DIR") or (core / "packages")
+    )
     if platforms.is_dir():
         try:
             for entry in platforms.iterdir():
@@ -183,6 +186,25 @@ def _core_dir_problem() -> Optional[str]:
                     os.listdir(entry)
         except OSError as exc:
             return f"PlatformIO platform tree {platforms} is not readable: {exc}"
+
+    # PlatformIO takes a lock at `<dir>.lock` -- a sibling of the managed
+    # directory, not a child -- so pointing platforms/packages at a read-only
+    # tree leaves the lock unwritable even when the core dir is fine. Every
+    # build then dies with "Read-only file system: /.../platforms.lock", while
+    # a probe that only checked core-dir writability reported available.
+    for managed in (platforms, packages):
+        lock = managed.with_name(managed.name + ".lock")
+        if lock.exists():
+            continue
+        try:
+            lock.touch()
+            lock.unlink()
+        except OSError as exc:
+            return (
+                f"PlatformIO cannot take its lock at {lock}: {exc} -- point "
+                f"PLATFORMIO_{'PLATFORMS' if managed is platforms else 'PACKAGES'}_DIR "
+                "at a writable location, or symlink it from inside the core dir"
+            )
     return None
 
 


### PR DESCRIPTION
Follow-up to #188. That fix moved `PLATFORMIO_CORE_DIR` onto the writable volume, but pointed `PLATFORMIO_PLATFORMS_DIR`/`PACKAGES_DIR` straight at the prewarmed tree baked into the image.

PlatformIO takes its lock at **`<dir>.lock` — a sibling of the managed directory, not a child**. So the lock landed on the read-only image filesystem and every build died:

```
OSError: [Errno 30] Read-only file system: '/opt/pio/platforms.lock'
```

Found the honest way: running a real LoRaWAN build against the deployed pod for a Heltec V4.

## Fix

The core dir now holds symlinks to the prewarmed trees, so locks land on the writable volume while the content still resolves to the read-only baked copy — no re-download, nothing duplicated onto the PVC.

Created by an entrypoint rather than in the Dockerfile because `/data` is a volume: anything written to that path at build time is masked once mounted.

**Verified against the deployed pod** — the same project that failed builds in 52 s with the symlinked layout.

## The probe was wrong too

`platformio_status()` reported `available: true` for that install. It checked core-dir writability and platform-tree readability — precisely the two things this failure slips past.

That's the third time this probe has claimed more than it verified (`pio --version` only → core dir → now the lock). The regression test names the specific failure so the next change has to keep covering it.

980 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ