### PR TITLE
fix(esphome): emit front-end pins and GNSS power for SX1262 boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Bumped the lorawan-for-esphome pin to the SX1262 radio-keys merge.**
+  Its `RADIO_SCHEMA` is strict, so the ref and the emitted keys move
+  together: an older ref rejects `tcxo_voltage`, `dio2_as_rf_switch` and
+  `setup_high` outright rather than ignoring them.
 - **ESPHome LoRaWAN path was unusable on SX1262 boards with a PA.** The
   rendered radio block dropped the board's `setup_high` front-end pins, so
   a Heltec V3/V4 came up deaf -- `begin()` returns OK, uplinks report as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **ESPHome LoRaWAN path was unusable on SX1262 boards with a PA.** The
+  rendered radio block dropped the board's `setup_high` front-end pins, so
+  a Heltec V3/V4 came up deaf -- `begin()` returns OK, uplinks report as
+  sent, and nothing reaches the gateway. They are now emitted alongside
+  `tcxo_voltage` and `dio2_as_rf_switch`, which needs
+  lorawan-for-esphome#8 to accept them.
+- **GNSS stayed unpowered on boards that gate it.** A board carrying a
+  GNSS power-enable (Heltec V4: `GPS_EN` on GPIO34, active low) rendered
+  no way to assert it, so the module sat dark and the UART never produced
+  a sentence -- indistinguishable from "no satellite fix". `uart_gps` now
+  emits a GPIO switch with `restore_mode: ALWAYS_ON` when the component
+  carries an enable pin, matching what the standalone firmware does in
+  `setup()`.
+
+### Fixed
+
 - **LoRaWAN builds still failed in the deployed image.** The 0.25.0 fix
   moved `PLATFORMIO_CORE_DIR` to the writable volume but pointed
   `PLATFORMIO_PLATFORMS_DIR` / `PACKAGES_DIR` straight at the prewarmed

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -17,7 +17,7 @@ sensor:
   lorawan_id: lw
   sensor: battery
 external_components:
-- source: github://moellere/lorawan-for-esphome@1f7ee9a011c09502240fcd77e99afb6c35db375a
+- source: github://moellere/lorawan-for-esphome@df1f6cd7ffe29f5a719ea684c23c26b629d1a5a4
   components:
   - lorawan
 lorawan:

--- a/tests/test_lorawan.py
+++ b/tests/test_lorawan.py
@@ -398,3 +398,65 @@ def test_sx127x_requires_dio0():
                 "pins": {"cs": "GPIO18", "rst": "GPIO23", "busy": "GPIO13"},
             }
         )
+
+
+def _v4_design(**component_params):
+    """Heltec V4: ESP32-S3 + SX1262 behind an external PA, GNSS on the
+    board's built-in port."""
+    return Design.model_validate({
+        "schema_version": "0.1",
+        "id": "v4", "name": "v4", "target": "esphome",
+        "board": {"library_id": "heltec-wifi-lora32-v4", "mcu": "esp32", "framework": "arduino"},
+        "power": {"supply": "usb-5v", "rail_voltage_v": 5.0},
+        "buses": [{"id": "gps_uart", "type": "uart", "rx": "GPIO38", "tx": "GPIO39", "baud_rate": 9600}],
+        "components": [{
+            "id": "gps", "library_id": "uart_gps", "label": "GNSS",
+            "params": {"sensors": {"latitude": {"name": "Lat", "id": "gps_lat"}}, **component_params},
+        }],
+        "connections": [{"component_id": "gps", "pin_role": "BUS",
+                         "target": {"kind": "bus", "bus_id": "gps_uart"}}],
+        "lorawan": {"payload": [{"sensor": "gps_lat"}]},
+    })
+
+
+def test_front_end_pins_reach_the_esphome_radio_block():
+    """A board with an external PA is deaf until its front-end pins are
+    driven, and the failure is silent: begin() returns OK and uplinks report
+    as sent. The standalone path drives them; dropping them here made the
+    ESPHome path quietly unusable on every SX1262 + PA board."""
+    from wirestudio.generate.yaml_gen import build_yaml_dict
+
+    out = build_yaml_dict(_v4_design(), default_library())
+    assert out["lorawan"]["radio"]["setup_high"] == ["GPIO7", "GPIO2", "GPIO5", "GPIO46"]
+
+
+def test_sx1262_radio_keys_are_emitted():
+    from wirestudio.generate.yaml_gen import build_yaml_dict
+
+    radio = build_yaml_dict(_v4_design(), default_library())["lorawan"]["radio"]
+    assert radio["chip"] == "sx1262"
+    assert radio["tcxo_voltage"] == 1.8
+    assert radio["dio2_as_rf_switch"] is True
+
+
+def test_gnss_power_switch_emitted_when_the_board_gates_it():
+    """Boards that gate GNSS power leave the module dark at reset -- the UART
+    just never produces a sentence, which is indistinguishable from no fix."""
+    from wirestudio.generate.yaml_gen import build_yaml_dict
+
+    out = build_yaml_dict(
+        _v4_design(enable_pin="GPIO34", enable_active_low=True), default_library()
+    )
+    sw = [s for s in out.get("switch", []) if s.get("id") == "gps_power"]
+    assert len(sw) == 1
+    assert sw[0]["pin"] == {"number": "GPIO34", "inverted": True}
+    assert sw[0]["restore_mode"] == "ALWAYS_ON"
+
+
+def test_no_gnss_switch_without_an_enable_pin():
+    """Most GPS modules are always-on; emitting a switch for them would
+    invent a pin the board never wired."""
+    from wirestudio.generate.yaml_gen import build_yaml_dict
+
+    out = build_yaml_dict(_v4_design(), default_library())
+    assert not [s for s in out.get("switch", []) if s.get("id") == "gps_power"]

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -447,6 +447,13 @@ def _emit_lorawan_blocks(
         radio_block["tcxo_voltage"] = radio.tcxo_voltage
     if radio.dio2_as_rf_switch:
         radio_block["dio2_as_rf_switch"] = radio.dio2_as_rf_switch
+    # Front-end power / PA-mode pins. The standalone path drives these in
+    # setup() and the board is deaf without them -- begin() still returns OK
+    # and uplinks still report as sent, so the only symptom is that nothing
+    # reaches the gateway. Dropping them here made the ESPHome path silently
+    # unusable on every board with an external PA (Heltec V3/V4).
+    if radio.setup_high:
+        radio_block["setup_high"] = list(radio.setup_high)
 
     overrides = lorawan_secrets or {}
 

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -370,10 +370,13 @@ def _secret_name(ref: str) -> str:
 # the component repo cuts its first stable release post hardware-join
 # validation (decision logged in docs/lorawan/workflow-integration.md).
 _LORAWAN_FOR_ESPHOME_REPO = "moellere/lorawan-for-esphome"
-# Pinned to the SPI-pin schema PR's merge (lorawan-for-esphome#2). Required
-# for the rendered radio: block's sck_pin / miso_pin / mosi_pin keys to
-# validate; `main` doesn't carry those fields until this commit.
-_LORAWAN_FOR_ESPHOME_REF = "1f7ee9a011c09502240fcd77e99afb6c35db375a"
+# Pinned to the SX1262 radio-keys merge (lorawan-for-esphome#8). Its
+# RADIO_SCHEMA is a strict cv.Schema, so the ref and the keys emitted below
+# have to move together: an older ref rejects `tcxo_voltage`,
+# `dio2_as_rf_switch` and `setup_high` outright, and ESPHome refuses the
+# config rather than ignoring them. The previous pin (#2) carried the
+# sck/miso/mosi keys and nothing more.
+_LORAWAN_FOR_ESPHOME_REF = "df1f6cd7ffe29f5a719ea684c23c26b629d1a5a4"
 
 
 def _emit_lorawan_blocks(

--- a/wirestudio/library/components/uart_gps.yaml
+++ b/wirestudio/library/components/uart_gps.yaml
@@ -86,6 +86,21 @@ esphome:
       {{ sensor_key }}: {{ sensor_cfg | tojson }}
     {%- endfor %}
     {%- endif %}
+    {%- if params.enable_pin is defined and params.enable_pin %}
+    switch:
+    - platform: gpio
+      id: {{ id }}_power
+      name: "{{ label | default('GNSS') }} power"
+      pin:
+        number: {{ params.enable_pin }}
+        inverted: {{ 'true' if params.enable_active_low else 'false' }}
+      # Boards that gate GNSS power (Heltec V4: GPS_EN on GPIO34, active low)
+      # leave the module dark at reset. Nothing reports an error -- the UART
+      # simply never produces a sentence, which looks identical to no fix.
+      # ALWAYS_ON powers it at boot, matching what the standalone firmware
+      # does in setup().
+      restore_mode: ALWAYS_ON
+    {%- endif %}
 
 params_schema:
   sensors:


### PR DESCRIPTION
Two board capabilities the **standalone** LoRaWAN path uses and the **ESPHome** path silently dropped. Found generating a config for a real Heltec WiFi LoRa 32 V4.

| Missing | Consequence |
|---|---|
| `radio.setup_high` (front-end power/enable, PA mode) | Board comes up **deaf**. `begin()` returns OK, uplinks report as sent, nothing reaches the gateway. |
| GNSS power-enable (V4: `GPS_EN` GPIO34, active low) | Module stays **dark**. UART never produces a sentence — indistinguishable from sitting indoors with no fix. |

Both were already in the board file and already used by the standalone generator. Neither had any ESPHome expression.

`uart_gps` now emits a GPIO switch with `restore_mode: ALWAYS_ON` when the component carries an enable pin — matching what the standalone firmware does in `setup()`. No switch is emitted without one, so always-on modules don't gain a control for a pin the board never wired.

## Depends on

`setup_high` requires **moellere/lorawan-for-esphome#8** — that component's `RADIO_SCHEMA` is a strict `cv.Schema`, so it currently rejects `tcxo_voltage` and `dio2_as_rf_switch` too. Merging this without #8 renders a config ESPHome will refuse.

## Tests

Four new, each naming the silent failure it guards:
- front-end pins reach the radio block
- SX1262 keys (`chip`/`tcxo_voltage`/`dio2_as_rf_switch`) emitted
- GNSS switch emitted with the right pin, inversion and restore mode
- **no** switch when the board doesn't gate GNSS

980 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ