### PR TITLE
release 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] — 2026-08-01
+
 ### Fixed
 
 - **Bumped the lorawan-for-esphome pin to the SX1262 radio-keys merge.**

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.25.1"
+__version__ = "0.26.0"


### PR DESCRIPTION
Minor rather than patch: the rendered ESPHome config changes for every SX1262 board, and the pinned `lorawan-for-esphome` ref moves with it. Regenerating a config produces materially different output — more than a bugfix, even though each change fixes something broken.

## Highlights

**SX1262 boards with an external PA now work on the ESPHome path.** Three things were missing and every one failed silently:

- `setup_high` front-end pins never reached the radio block — board comes up **deaf** while `begin()` returns OK and uplinks report as sent
- `tcxo_voltage` / `dio2_as_rf_switch` were emitted but rejected by the component's strict schema
- GNSS power-enable had no ESPHome expression — module stays **dark**, UART never produces a sentence, indistinguishable from no fix

Paired with lorawan-for-esphome#8, which adds the schema and C++ support. The pinned ref moves with the emitted keys because `RADIO_SCHEMA` is strict — an older ref rejects the config outright rather than ignoring unknown keys.

**LoRaWAN builds work in the deployed image again.** 0.25.0 moved `PLATFORMIO_CORE_DIR` to the writable volume but left platforms/packages on the read-only image. PlatformIO locks at `<dir>.lock`, a *sibling* of the managed directory, so every build died on `Read-only file system: '/opt/pio/platforms.lock'`. And `platformio_status()` reported available for that install — now checks the lock path too.

**Feedback link** in the header, opening the issue tracker prefilled with version, board and browser.

## Verification

984 passed, 12 skipped. `main-full` image built clean.

Honest limitation: CI proves these configs *compile*. It cannot prove the front-end pins actually wake the PA — that needs a device that joins, and the Heltec V4 that motivated this is flashed and registered but not yet joined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ