### PR TITLE
fix(fleet): resolve run_id to job_id when fetching firmware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fleet firmware artifacts were unfetchable by run_id.** The addon keys
+  artifacts by `job_id`, while the push response, the status poll and the
+  studio's own route are all keyed by `run_id`. Passing the run_id
+  straight through 404s as "firmware artifact not available", which reads
+  as *the build produced nothing* rather than *wrong key* -- so a compile
+  that had actually succeeded looked broken, and the documented
+  provision -> compile -> flash flow could not complete. `get_firmware`
+  now resolves the run to its jobs and retries; a job_id still works
+  directly. Found fetching a real fleet build for a Heltec V4.
+- **Stale docstrings claimed the fleet artifact endpoint did not exist.**
+  It does, and the comment cost real debugging time.
+
 ## [0.26.0] — 2026-08-01
 
 ### Fixed

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -753,3 +753,40 @@ async def test_fleet_push_lorawan_secrets_no_op_for_non_lorawan_designs(
     # The pushed YAML has no lorawan block at all; the secrets are ignored.
     assert "lorawan:" not in pushed
     assert "dev_eui" not in pushed
+
+
+async def test_get_firmware_resolves_a_run_id_to_its_job_id():
+    """The addon keys artifacts by job_id, while the push response, the
+    status poll and the studio's own route are all keyed by run_id. Passing
+    the run_id straight through 404s, which reads as "the build produced
+    nothing" rather than "wrong key" -- a compile that actually succeeded
+    looks broken."""
+    addon = FakeFleetAddon()
+    addon.queue_jobs = [{
+        "id": "job-abc", "run_id": "run-1", "state": "success",
+        "target": "dev.yaml", "finished_at": "2026-08-01T00:00:00Z",
+    }]
+    # Stored under the job id, as the real addon does.
+    addon.firmware["job-abc"] = {"app": b"FAKE-APP-IMAGE", "factory": None}
+    fc = addon.make_client()
+    assert await fc.get_firmware("run-1") == b"FAKE-APP-IMAGE"
+
+
+async def test_get_firmware_still_accepts_a_job_id_directly():
+    addon = FakeFleetAddon()
+    addon.firmware["job-abc"] = {"app": b"DIRECT", "factory": None}
+    fc = addon.make_client()
+    assert await fc.get_firmware("job-abc") == b"DIRECT"
+
+
+async def test_get_firmware_reports_the_jobs_it_tried():
+    """A genuinely missing artifact should say the run's jobs were checked,
+    so the failure is distinguishable from the key mix-up above."""
+    addon = FakeFleetAddon()
+    addon.queue_jobs = [{
+        "id": "job-abc", "run_id": "run-1", "state": "success",
+        "target": "dev.yaml", "finished_at": "2026-08-01T00:00:00Z",
+    }]
+    fc = addon.make_client()
+    with pytest.raises(FleetUnavailable, match="job"):
+        await fc.get_firmware("run-1")

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -1330,12 +1330,16 @@ def create_app(
         ``/lorawan/firmware/{cache_key}[/factory]`` so the WebSerial flow
         on the external-component path can reuse ``lib/flash.ts`` unchanged.
 
+        Takes a run_id, matching the push response and the status poll.
+        The addon keys artifacts by job_id, so the client resolves the run
+        to its jobs when the id isn't found directly; a job_id also works
+        if you happen to have one.
+
         Returns 404 when the run hasn't finished, has aged out of the
         addon's tracking, or the build didn't produce the requested image
         type; 503 when fleet credentials are missing; 502 when the addon
-        is reachable but the call failed (e.g. the upstream artifact
-        endpoint isn't implemented yet -- see
-        ``docs/lorawan/fleet-firmware-flash.md``).
+        is reachable but the call failed -- see
+        ``docs/lorawan/fleet-firmware-flash.md``.
         """
         fc = make_fleet()
         if not fc.is_configured():

--- a/wirestudio/fleet/client.py
+++ b/wirestudio/fleet/client.py
@@ -291,40 +291,59 @@ class FleetClient:
     ) -> bytes:
         """Fetch the compiled firmware bytes for a finished build.
 
-        Mirrors the addon's artifact endpoint at
-        ``GET /ui/api/jobs/{run_id}/firmware[/factory]`` (the upstream
-        half of the headless-device flash story -- see
-        ``docs/lorawan/fleet-firmware-flash.md``). The browser never holds
-        ``FLEET_TOKEN``; this is the studio-side passthrough that fetches
-        with the server token and re-streams the bytes to the WebSerial
-        flasher via the matching studio route.
+        The addon stores artifacts at ``GET /ui/api/jobs/{job_id}/firmware``
+        keyed by **job_id**, while everything else in this flow -- the push
+        response, the status poll, the studio's own route -- is keyed by
+        run_id. Passing the run_id straight through 404s, which reads as
+        "the build produced nothing" rather than "wrong key", so a compile
+        that actually succeeded looks broken. Accepts either: tries the id
+        as given, then resolves the run's jobs and retries.
+
+        The browser never holds ``FLEET_TOKEN``; this is the studio-side
+        passthrough that fetches with the server token and re-streams the
+        bytes to the WebSerial flasher via the matching studio route.
 
         ``factory=False`` (default) fetches the app image (re-flash that
         preserves NVS); ``factory=True`` fetches the merged factory image
         for blank-board flashing at offset 0x0. 404 -> ``FleetUnavailable``
         the same way ``get_job_log`` handles unknown run_ids, so the UI
         can stop polling.
-
-        The upstream endpoint does not exist yet at the time of writing
-        (it's the scoped fleet half); calls will 502 via the matching
-        studio route until the addon ships it. That gates the dialog's
-        "Flash via WebSerial" button on the upstream rollout without
-        changing this client surface later.
         """
         if not self.is_configured():
             raise FleetUnavailable("FLEET_URL or FLEET_TOKEN missing")
         suffix = "/factory" if factory else ""
+
+        async def _fetch(c: httpx.AsyncClient, ident: str) -> Optional[bytes]:
+            resp = await c.get(f"/ui/api/jobs/{ident}/firmware{suffix}")
+            if resp.status_code == 404:
+                return None
+            if resp.status_code >= 400:
+                raise FleetUnavailable(
+                    f"firmware fetch failed: http {resp.status_code} {resp.text}"
+                )
+            return resp.content
+
         async with self._client() as c:
-            resp = await c.get(f"/ui/api/jobs/{run_id}/firmware{suffix}")
-        if resp.status_code == 404:
-            raise FleetUnavailable(
-                f"firmware artifact not available for run_id {run_id!r}"
-            )
-        if resp.status_code >= 400:
-            raise FleetUnavailable(
-                f"firmware fetch failed: http {resp.status_code} {resp.text}"
-            )
-        return resp.content
+            content = await _fetch(c, run_id)
+            if content is not None:
+                return content
+
+        # Not found under that id. If it was a run_id, the artifact lives
+        # under one of its jobs.
+        try:
+            jobs = (await self.get_run_status(run_id)).jobs
+        except FleetUnavailable:
+            jobs = []
+        async with self._client() as c:
+            for job in jobs:
+                content = await _fetch(c, job.job_id)
+                if content is not None:
+                    return content
+
+        raise FleetUnavailable(
+            f"firmware artifact not available for {run_id!r}"
+            + (f" or its {len(jobs)} job(s)" if jobs else "")
+        )
 
     # ------------------------------------------------------------------
     # Internals


### PR DESCRIPTION
The addon stores artifacts at `/ui/api/jobs/{job_id}/firmware` — keyed by **job_id**. The push response, the status poll, and the studio's own route are all keyed by **run_id**.

So passing the run_id through 404s with *"firmware artifact not available"*, which reads as **the build produced nothing** rather than **wrong key**. A compile that had actually succeeded looked broken, and the documented provision → compile → flash flow couldn't complete.

```
GET /fleet/jobs/bdd60272-…(run_id)/firmware  → 404
GET /fleet/jobs/e4380679-…(job_id)/firmware  → 200, 427728 bytes
```

`get_firmware` now tries the id as given, then resolves the run's jobs and retries — either key works. The not-found message names how many jobs were checked so a genuinely missing artifact stays distinguishable from the mix-up.

Also drops two docstrings asserting the upstream endpoint *"does not exist yet"*. It does — that comment sent me looking in the wrong repo.

## Why the tests missed it

The fake addon keyed its artifact dict by whatever id the request path carried, so `run_id` and `job_id` were indistinguishable and every existing test passed. Three new tests model the real behaviour: artifact stored under the job id, fetched by run id.

Found fetching a real fleet build for a Heltec V4. 987 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ