### PR TITLE
release 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.1] — 2026-08-01
+
 ### Fixed
 
 - **Fleet firmware artifacts were unfetchable by run_id.** The addon keys

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.26.0"
+__version__ = "0.26.1"


### PR DESCRIPTION
Patch release for the fleet artifact fix (#199). No generated output changes — unlike 0.26.0 this only makes a documented flow actually work.

**Fleet firmware artifacts were unfetchable by run_id.** The addon keys artifacts by `job_id`, while the push response, status poll and studio route are all keyed by `run_id`. The resulting 404 said *"firmware artifact not available"*, which reads as the build having produced nothing rather than the key being wrong — so a successful compile looked broken and the provision → compile → flash flow couldn't complete.

Also removes two docstrings asserting the upstream endpoint "does not exist yet". It does.

Found fetching a real fleet build for a Heltec V4, which is now joined and uplinking on this path.

987 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ