### PR TITLE
fix(esphome): emit flash_size from the board file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **ESPHome configs declared 4 MB regardless of the board.** ESPHome
+  defaults to 4 MB, so a 16 MB board silently got a 4 MB partition table --
+  three quarters of the flash unused and OTA slots smaller than the chip
+  allows. Nothing errors, which is why it went unnoticed; found reading
+  `SPI Flash Size : 4MB` out of a Heltec V4 whose chip reports 16 MB by
+  JEDEC ID. The `esp32:` block now carries `flash_size` from the board
+  file, matching what the standalone path already pins via
+  `board_build.flash_size`.
+
+  This makes `flash_size_mb` load-bearing for every ESP32 design. Only
+  five boards claim more than 4 MB, and over-declaring is the direction
+  that boot-loops (see the V2 fix in 0.25.0) -- of those, only
+  `heltec-wifi-lora32-v4` is verified against real silicon here. ESP8266
+  boards are unaffected; the key is emitted inside the `esp32:` branch.
+
 ## [0.26.1] — 2026-08-01
 
 ### Fixed

--- a/tests/golden/analog-node.yaml
+++ b/tests/golden/analog-node.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/atom-lite.yaml
+++ b/tests/golden/atom-lite.yaml
@@ -4,6 +4,7 @@ esp32:
   board: m5stack-atom
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/atoms3-lcd.yaml
+++ b/tests/golden/atoms3-lcd.yaml
@@ -5,6 +5,7 @@ esp32:
   framework:
     type: arduino
   variant: ESP32S3
+  flash_size: 8MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/atoms3-onboard.yaml
+++ b/tests/golden/atoms3-onboard.yaml
@@ -5,6 +5,7 @@ esp32:
   framework:
     type: arduino
   variant: ESP32S3
+  flash_size: 8MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/atomu-onboard.yaml
+++ b/tests/golden/atomu-onboard.yaml
@@ -4,6 +4,7 @@ esp32:
   board: m5stack-atom
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/bl0906-mainmeter.yaml
+++ b/tests/golden/bl0906-mainmeter.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/c3-supermini.yaml
+++ b/tests/golden/c3-supermini.yaml
@@ -5,6 +5,7 @@ esp32:
   framework:
     type: arduino
   variant: ESP32C3
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/c6-supermini.yaml
+++ b/tests/golden/c6-supermini.yaml
@@ -5,6 +5,7 @@ esp32:
   framework:
     type: esp-idf
   variant: ESP32C6
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/desk-climate.yaml
+++ b/tests/golden/desk-climate.yaml
@@ -5,6 +5,7 @@ esp32:
   framework:
     type: arduino
   variant: ESP32C3
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/desk-matrix.yaml
+++ b/tests/golden/desk-matrix.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/encoder-drives-stepper.yaml
+++ b/tests/golden/encoder-drives-stepper.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/esp32-audio.yaml
+++ b/tests/golden/esp32-audio.yaml
@@ -4,6 +4,7 @@ esp32:
   board: nodemcu-32s
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/esp32cam-wrover.yaml
+++ b/tests/golden/esp32cam-wrover.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp-wrover-kit
   framework:
     type: esp-idf
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/esp32cam.yaml
+++ b/tests/golden/esp32cam.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32cam
   framework:
     type: esp-idf
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/flow-meter.yaml
+++ b/tests/golden/flow-meter.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/garage-motion.yaml
+++ b/tests/golden/garage-motion.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger:
   level: INFO
 api:

--- a/tests/golden/grill-probe.yaml
+++ b/tests/golden/grill-probe.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/led-display.yaml
+++ b/tests/golden/led-display.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -4,6 +4,7 @@ esp32:
   board: ttgo-lora32-v1
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 sensor:
 - platform: adc

--- a/tests/golden/nextion-thermostat.yaml
+++ b/tests/golden/nextion-thermostat.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/presence-rf.yaml
+++ b/tests/golden/presence-rf.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger:
   baud_rate: 0
 api:

--- a/tests/golden/rs485-energy.yaml
+++ b/tests/golden/rs485-energy.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/s3-devkitc.yaml
+++ b/tests/golden/s3-devkitc.yaml
@@ -5,6 +5,7 @@ esp32:
   framework:
     type: arduino
   variant: ESP32S3
+  flash_size: 8MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/s3-supermini.yaml
+++ b/tests/golden/s3-supermini.yaml
@@ -5,6 +5,7 @@ esp32:
   framework:
     type: arduino
   variant: ESP32S3
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/subghz-rfid.yaml
+++ b/tests/golden/subghz-rfid.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/t-beam.yaml
+++ b/tests/golden/t-beam.yaml
@@ -4,6 +4,7 @@ esp32:
   board: ttgo-t-beam
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/tft-touch.yaml
+++ b/tests/golden/tft-touch.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/ttgo-lora32.yaml
+++ b/tests/golden/ttgo-lora32.yaml
@@ -4,6 +4,7 @@ esp32:
   board: ttgo-lora32-v1
   framework:
     type: esp-idf
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/tests/golden/weather-station.yaml
+++ b/tests/golden/weather-station.yaml
@@ -4,6 +4,7 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+  flash_size: 4MB
 logger: {}
 api:
   encryption:

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -504,6 +504,14 @@ def build_yaml_dict(
         chip_block["framework"] = {"type": design.board.framework}
         if board.chip_variant != "esp32":
             chip_block["variant"] = board.chip_variant.upper()
+        # ESPHome defaults to 4 MB regardless of the PlatformIO board, so a
+        # 16 MB board silently gets a 4 MB partition table -- three quarters
+        # of the flash unused and OTA slots smaller than the chip allows.
+        # Nothing errors, which is why it goes unnoticed. Under-declaring is
+        # the safe direction (over-declaring boot-loops the bootloader on a
+        # size mismatch), so emit what the board file says.
+        if board.flash_size_mb:
+            chip_block["flash_size"] = f"{board.flash_size_mb}MB"
         out["esp32"] = chip_block
     else:
         out[board.chip_variant] = chip_block


### PR DESCRIPTION
ESPHome defaults to **4 MB** whatever the PlatformIO board says. So a 16 MB board silently gets a 4 MB partition table — three quarters of the flash unused, OTA slots smaller than the chip allows. Nothing errors, which is why it went unnoticed.

Found by reading the boot log of a running Heltec V4:

```
I (33) boot.esp32s3: SPI Flash Size : 4MB     ← the image
Manufacturer: 68  Device: 4018 → 16MB          ← the chip, by JEDEC ID
```

The **standalone** path already pins `board_build.flash_size` from the same board field (added after the V2 boot loops). This makes the two paths agree.

## The consequence, stated plainly

This makes `flash_size_mb` **load-bearing for every ESP32 design**, where before ESPHome's safe-but-wasteful 4 MB default applied universally.

Over-declaring is the direction that boot-loops — that's exactly what bricked a Heltec V2 earlier in this work, when the library claimed 8 MB on a 4 MB chip. Five boards claim more than 4 MB:

| Board | Claims | Verified? |
|---|---|---|
| `heltec-wifi-lora32-v4` | 16 MB | ✅ JEDEC ID on real hardware |
| `esp32-s3-devkitc-1` | 8 MB | ⚠️ vendor spec only (N8/N16 variants exist) |
| `heltec-wifi-lora32-v3` | 8 MB | ⚠️ vendor spec only |
| `m5stack-atoms3` | 8 MB | ⚠️ vendor spec only |
| `m5stack-atoms3-lite` | 8 MB | ⚠️ vendor spec only |

If any of those is wrong, devices built for them will boot-loop. I'd treat the four unverified rows as worth checking against hardware before trusting them. ESP8266 boards are unaffected — the key is emitted inside the `esp32:` branch only.

## Goldens

29 regenerated. The diff is exactly one `flash_size` line each (26× `4MB`, 3× `8MB`) and nothing else.

987 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ