### PR TITLE
release 0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.2] — 2026-08-01
+
 ### Fixed
 
 - **ESPHome configs declared 4 MB regardless of the board.** ESPHome

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.26.1"
+__version__ = "0.26.2"


### PR DESCRIPTION
ESPHome configs now declare the board's real flash size instead of ESPHome's 4 MB default (#201), so a 16 MB board stops being used as a 4 MB one.

Makes `flash_size_mb` load-bearing for every ESP32 design — see #201 for which boards claim >4 MB and which are actually verified against silicon. Over-declaring is the direction that boot-loops.

987 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ