### PR TITLE
fix(fleet): read the addon's target key when listing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A design could be pushed to fleet once and never updated.** The addon
+  keys its target list by `target`; the client read only `filename`/`name`,
+  so the existence check was always empty, every push took the create
+  branch, and re-pushing an existing device failed with
+  `create_target failed: ... already exists` instead of overwriting.
+  The test fake returned the assumed shape rather than the addon's, which
+  is why nothing caught it -- the fake now mirrors a live response.
+
 ## [0.26.2] — 2026-08-01
 
 ### Fixed

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -58,14 +58,18 @@ class FakeFleetAddon:
             method = req.method
 
             if method == "GET" and path == "/ui/api/targets":
+                # Shape verified against a live addon: a bare list whose
+                # entries key the filename as `target`. The previous fake
+                # returned {"filename", "name"}, which the client happened
+                # to read -- so an existence check that never matched
+                # anything still looked correct here.
                 return httpx.Response(
                     200,
-                    json={
-                        "targets": [
-                            {"filename": f, "name": f}
-                            for f in sorted(self.files.keys())
-                        ],
-                    },
+                    json=[
+                        {"target": f, "device_name": f.removesuffix(".yaml"),
+                         "esp_type": "ESP32", "archived": False}
+                        for f in sorted(self.files.keys())
+                    ],
                 )
 
             if method == "POST" and path == "/ui/api/targets":
@@ -790,3 +794,23 @@ async def test_get_firmware_reports_the_jobs_it_tried():
     fc = addon.make_client()
     with pytest.raises(FleetUnavailable, match="job"):
         await fc.get_firmware("run-1")
+
+
+async def test_push_overwrites_an_existing_target():
+    """The addon keys its target list by `target`. Reading only `filename`
+    made the existence check always empty, so every push took the create
+    branch and re-pushing a device 400'd with 'already exists' -- you could
+    push a design once and never update it."""
+    addon = FakeFleetAddon()
+    addon.files["dev.yaml"] = "esphome:\n  name: dev\n"
+    fc = addon.make_client()
+    await fc.push_device(device_name="dev", yaml="esphome:\n  name: dev2\n")
+    assert addon.files["dev.yaml"] == "esphome:\n  name: dev2\n"
+
+
+async def test_push_creates_when_absent():
+    addon = FakeFleetAddon()
+    fc = addon.make_client()
+    res = await fc.push_device(device_name="fresh", yaml="esphome:\n  name: fresh\n")
+    assert res.created is True
+    assert "fresh.yaml" in addon.files

--- a/wirestudio/fleet/client.py
+++ b/wirestudio/fleet/client.py
@@ -364,15 +364,19 @@ class FleetClient:
                 f"list targets failed: http {resp.status_code} {resp.text}"
             )
         body = resp.json()
-        # The addon returns either {"targets": [...]} with each entry a
-        # dict ({"filename": "..."}) or a bare list -- accept both.
+        # The addon returns a bare list whose entries key the filename as
+        # `target`; older/other shapes use `filename` or `name`, or a plain
+        # string. Missing the real key here is not a cosmetic bug: the set
+        # comes back empty, every push looks like a create, and re-pushing
+        # an existing device fails with "already exists" instead of
+        # overwriting it.
         items = body.get("targets", body) if isinstance(body, dict) else body
         out: set[str] = set()
         for it in items or []:
             if isinstance(it, str):
                 out.add(it)
             elif isinstance(it, dict):
-                f = it.get("filename") or it.get("name")
+                f = it.get("target") or it.get("filename") or it.get("name")
                 if isinstance(f, str):
                     out.add(f)
         return out


### PR DESCRIPTION
A design could be pushed to fleet **once and never updated**.

The addon returns a bare list whose entries key the filename as `target`:

```json
{"target": "heltec-v4-gnss.yaml", "device_name": "Heltec V4 Gnss", "esp_type": "ESP32-S3", ...}
```

`_list_filenames` read only `filename`/`name`, so the set was **always empty**, `push_device` always took the create branch, and the second push of any device failed:

```
create_target failed: http 400 {"error": "heltec-v4-gnss.yaml already exists"}
```

The first push of every device worked, which is why this survived — it only appears when you push an update.

## Why the tests missed it

The fake addon returned `{"filename": f, "name": f}` — the shape I assumed, not the one the addon sends. An existence check that never matched anything still passed every test.

The fake now mirrors a live response (`target`, `device_name`, `esp_type`, `archived`). I verified the new test **fails against the old client** and passes with the fix.

That's the second bug this session where the fake encoded my assumption instead of the real API — the other being artifacts keyed by `job_id` rather than `run_id` (#199).

Found re-pushing a Heltec V4 config after a generator fix. 989 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ