### PR TITLE
release 0.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.3] — 2026-08-01
+
 ### Fixed
 
 - **A design could be pushed to fleet once and never updated.** The addon

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.26.2"
+__version__ = "0.26.3"


### PR DESCRIPTION
Patch for the fleet push fix (#203).

**A design could be pushed to fleet once and never updated.** The addon keys its target list by `target`; the client read only `filename`/`name`, so the existence check was always empty, every push took the create branch, and the second push of any device failed:

```
create_target failed: http 400 {"error": "heltec-v4-gnss.yaml already exists"}
```

The first push of every device worked, which is why it survived — it only appears when you push an update.

The test fake returned the assumed shape rather than the addon's, so an existence check that never matched anything still passed. The fake now mirrors a live response, and the new test fails against the old client.

989 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ