### PR TITLE
fix(mcp): register recommend's own function, not library_detail's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `recommend` MCP tool was dead — it ran `library_detail` instead.**
+  Two `@mcp.tool` decorators were stacked on one function. FastMCP's
+  decorator returns `fn` unchanged, so both names bound to
+  `library_detail`, and the real `recommend` body was never registered.
+  MCP clients calling `recommend(query=...)` got a pydantic
+  `ValidationError` for `library_detailArguments`. The existing test
+  asserted the set of tool *names*, which was correct either way — the
+  suite now also asserts no two tools share a function, and that
+  `recommend` takes `query` and returns results.
+
 ## [0.26.3] — 2026-08-01
 
 ### Fixed

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -79,6 +79,34 @@ async def test_all_expected_tools_registered(mcp_server):
     assert names == EXPECTED_TOOLS
 
 
+async def test_every_tool_binds_a_distinct_function(mcp_server):
+    """Stacked @mcp.tool decorators silently alias two names to one function.
+
+    The decorator returns `fn` unchanged, so stacking registers the same
+    callable twice under different names -- the second tool's own function
+    is then never registered at all. A name-only assertion can't see this.
+    """
+    server, _ = mcp_server
+    tools = server._tool_manager.list_tools()
+    by_fn: dict[int, list[str]] = {}
+    for tool in tools:
+        by_fn.setdefault(id(tool.fn), []).append(tool.name)
+    aliased = {tuple(sorted(v)) for v in by_fn.values() if len(v) > 1}
+    assert not aliased, f"tools sharing one function: {aliased}"
+
+
+async def test_recommend_takes_a_query_not_a_library_id(mcp_server):
+    server, _ = mcp_server
+    tools = {t.name: t for t in await server.list_tools()}
+    params = set(tools["recommend"].inputSchema.get("properties", {}))
+    assert "query" in params
+    assert "library_id" not in params
+
+    result = await server.call_tool("recommend", {"query": "temperature"})
+    payload = _content_to_dict(result[0] if isinstance(result, tuple) else result)
+    assert payload.get("ok") is not False, payload
+
+
 async def test_tool_input_schemas_include_design_id_for_mutating_tools(mcp_server):
     server, _ = mcp_server
     tools = {t.name: t for t in await server.list_tools()}

--- a/wirestudio/mcp/server.py
+++ b/wirestudio/mcp/server.py
@@ -110,6 +110,15 @@ def _register_library_tools(mcp: FastMCP, library: Library) -> None:
             "excluded_categories) to filter before ranking."
         ),
     )
+    def recommend(
+        query: str,
+        limit: int = 10,
+        constraints: Optional[dict] = None,
+    ) -> dict:
+        return _run_recommend(
+            {}, library, query=query, limit=limit, constraints=constraints
+        )
+
     @mcp.tool(
         name="library_detail",
         description=(
@@ -122,15 +131,6 @@ def _register_library_tools(mcp: FastMCP, library: Library) -> None:
     )
     def library_detail(library_id: str, kind: str = "component") -> dict:
         return _run_library_detail({}, library, library_id=library_id, kind=kind)
-
-    def recommend(
-        query: str,
-        limit: int = 10,
-        constraints: Optional[dict] = None,
-    ) -> dict:
-        return _run_recommend(
-            {}, library, query=query, limit=limit, constraints=constraints
-        )
 
 
 _DESIGN_ID_HINT = (


### PR DESCRIPTION
Found while surveying the MCP surface to start the hardware-tool work.

Two `@mcp.tool` decorators were stacked on a single function:

```python
@mcp.tool(name="recommend", ...)
@mcp.tool(name="library_detail", ...)
def library_detail(library_id: str, kind: str = "component") -> dict: ...

def recommend(query: str, limit: int = 10, ...) -> dict: ...   # never registered
```

FastMCP's decorator returns `fn` unchanged, so both names bound to `library_detail` and the `recommend` body below was dead code.

Verified against the running server:

```
recommend      -> params=['kind', 'library_id']      # library_detail's signature
library_detail -> params=['kind', 'library_id']
call recommend(query="temperature") -> ValidationError for library_detailArguments
```

So `recommend` has been unusable over MCP: wrong parameters, and any correct call fails validation.

## Why the suite did not catch it

`test_all_expected_tools_registered` asserts the set of tool *names*. Both names were registered, so it passed — the assertion could not distinguish two names bound to one function from two names bound to two.

This is the third bug this week to survive because a test encoded the shape I assumed rather than the behaviour I needed. So the guard added here is the general one, not just a case fix:

- `test_every_tool_binds_a_distinct_function` — no two tools may share a function object, which catches decorator stacking anywhere in the surface, not only this pair.
- `test_recommend_takes_a_query_not_a_library_id` — schema plus a real call.

Both fail against the pre-fix code and pass after:

```
FAILED test_every_tool_binds_a_distinct_function
FAILED test_recommend_takes_a_query_not_a_library_id
2 failed, 13 passed
```

Full suite: 991 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ