### PR TITLE
feat(mcp): hardware tools with job handles for long operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP hardware tools — a headless client can now finish a bring-up.**
+  The 22 design/library/fab tools stopped at the artifact; putting it on a
+  board meant dropping to HTTP. That was the wrong workaround, because
+  `/api/mcp` is bearer-gated while `/api/workbench/*` and `/api/lorawan/*`
+  carry no auth at all, so "just publish the REST endpoints" meant
+  publishing unauthenticated flashing and ChirpStack provisioning.
+  Seventeen new tools close it: `workbench_status` / `workbench_slots` /
+  `workbench_flash`; `lorawan_chirpstack_status` / `lorawan_compile` /
+  `lorawan_provision` / `lorawan_provision_esphome` /
+  `lorawan_activation` / `lorawan_workbench_provision`; `fleet_status` /
+  `fleet_push` / `fleet_job_status` / `fleet_job_log` /
+  `fleet_firmware_info`; and `job_status` / `job_events` / `job_list`.
+- **Long operations return a job handle instead of blocking.** Compile,
+  flash and workbench-provision stream for minutes, which does not fit a
+  tool call that returns once. They now start the work and hand back a
+  `job_id` to poll. Fleet builds deliberately keep their own `run_id`:
+  that handle belongs to the addon's GitHub run and survives a wirestudio
+  restart, so wrapping it in the in-memory registry would only make it
+  more fragile.
+- Firmware bytes never cross the MCP boundary. `workbench_flash` takes a
+  `fleet_run_id` and fetches the artifact server-side; `fleet_firmware_info`
+  reports size and availability rather than returning megabytes of base64
+  into a context window.
+
 ### Fixed
 
 - **The `recommend` MCP tool was dead — it ran `library_detail` instead.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,22 +190,29 @@ interpreter flash + starter above is the shipped first step).
 Deliberately deferred: generic Arduino/PlatformIO scaffolds (per-driver
 maintenance sinkhole), Zephyr, Zigbee/Thread on the C6.
 
-**MCP tool surface — hardware gap.** The 22 MCP tools cover design,
-KiCad and fab, but stop at the artifact: there is no `compile`, `flash`,
-`provision`, or `workbench_slots` tool. An MCP client can produce a
-design and a schematic and then has to hand off to HTTP to put it on a
-board, which defeats the point of the headless path — and the two are
-not equivalently exposed. A deployment behind SSO can reasonably publish
-`/mcp`, which authenticates with `WIRESTUDIO_MCP_TOKEN`; the REST
-endpoints authenticate with nothing, so publishing those instead means
-publishing unauthenticated firmware-flashing and ChirpStack
-provisioning. Closing the gap in MCP is the only route that does not
-force that trade. Wrapping the existing `/lorawan/compile`,
-`/lorawan/workbench/provision` and `/workbench/*` handlers is most of
-the work; the open question is how a long SSE compile maps onto an MCP
-call that wants to return once.
+**MCP tool surface — hardware gap (closed).** The design/KiCad/fab tools
+used to stop at the artifact: an MCP client could produce a design and a
+schematic, then had to hand off to HTTP to put it on a board. That
+workaround was worse than it looked, because the two surfaces are not
+equivalently exposed — `/mcp` authenticates with `WIRESTUDIO_MCP_TOKEN`
+while the REST endpoints authenticate with nothing, so publishing those
+instead meant publishing unauthenticated flashing and provisioning.
 
-Related, and worth doing regardless: the REST surface has no auth at
+Seventeen tools now cover the rest of the path: `workbench_status` /
+`workbench_slots` / `workbench_flash`, the `lorawan_*` compile,
+provision and activation tools, the `fleet_*` push/status/log tools, and
+`job_status` / `job_events` / `job_list`.
+
+The open question was how a long SSE compile maps onto a call that
+returns once. It doesn't, so the streaming operations return a `job_id`
+and the client polls. Fleet builds are the deliberate exception: their
+`run_id` belongs to the addon's GitHub run and outlives this process, so
+they keep it rather than being wrapped in the in-memory registry — which
+also means a `job_id` and a `run_id` are not interchangeable. Firmware
+bytes stay server-side: `workbench_flash` takes a `fleet_run_id` and
+fetches the artifact itself.
+
+Still open, and worth doing regardless: the REST surface has no auth at
 all. `/workbench/flash` and `/lorawan/provision` are reachable by
 anything that can route to the pod. That is survivable while the only
 exposure is a cluster-internal Service, and is the reason the ingress

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -213,6 +213,55 @@ and persist back to `designs/<id>.json`.
 Every design-bound tool accepts an optional `design_id`; omit it to use
 the active design.
 
+### Hardware tools
+
+These reach real hardware — a bench, a ChirpStack server, the fleet
+addon. They are registered by default; pass `hardware=False` to
+`build_mcp_server` to leave them off.
+
+| Tool | Mutates | Notes |
+|------|---------|-------|
+| `workbench_status` | no | is a bench configured and reachable |
+| `workbench_slots` | no | slot labels, detected chip, and whether each is flashable now |
+| `workbench_flash` | yes | flash a slot → `job_id` |
+| `lorawan_chirpstack_status` | no | ChirpStack token + reachability probe |
+| `lorawan_compile` | no | build standalone RadioLib firmware → `job_id` |
+| `lorawan_provision` | yes | register in ChirpStack, issue AppKey (standalone path) |
+| `lorawan_provision_esphome` | yes | same, formatted for `secrets.yaml` (external-component path) |
+| `lorawan_activation` | no | has the device joined |
+| `lorawan_workbench_provision` | yes | flash + register + key-push + verify → `job_id` |
+| `fleet_status` | no | is the fleet addon configured and reachable |
+| `fleet_push` | yes | render + push to fleet, optionally compile → `run_id` |
+| `fleet_job_status` | no | compile verdict for a run |
+| `fleet_job_log` | no | incremental build log |
+| `fleet_firmware_info` | no | artifact size + availability (never the bytes) |
+| `job_status` | no | poll a `job_id` |
+| `job_events` | no | incremental event log for a `job_id` |
+| `job_list` | no | jobs this process is holding |
+
+#### Long operations
+
+A tool call returns once; a compile or flash streams for minutes. So
+`workbench_flash`, `lorawan_compile` and `lorawan_workbench_provision`
+start the work and return a `job_id` — poll `job_status` until `state`
+leaves `running`, and read the log with `job_events` using the returned
+`next_since` cursor.
+
+Jobs live in the server process and are lost on restart.
+
+**A `job_id` and a `run_id` are not interchangeable.** Fleet builds keep
+their own `run_id`, which belongs to the addon's GitHub run, outlives a
+wirestudio restart, and is polled with `fleet_job_status` — not
+`job_status`.
+
+#### Firmware never crosses the boundary
+
+`workbench_flash` takes either `images` (base64, for firmware you already
+hold) or `fleet_run_id`, in which case the server fetches that build's
+artifact itself. `fleet_firmware_info` reports size and availability
+rather than returning the image, because an agent needs the bytes on the
+board, not in its context window.
+
 ## Resources
 
 Seven read-only resources. Compact indexes for discovery, `{id}`

--- a/tests/test_mcp_hardware.py
+++ b/tests/test_mcp_hardware.py
@@ -1,0 +1,300 @@
+"""Tests for the MCP hardware tool surface (workbench / ChirpStack / fleet).
+
+These drive the *real* clients against wire-level fakes -- `FakeBench`
+speaks the Pi portal's HTTP shapes and the fleet handler speaks the
+addon's -- rather than substituting a fake client. A fake client would
+only prove the tools call the methods I think exist; three bugs this
+month survived exactly that.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from wirestudio.designs.store import FileDesignStore
+from wirestudio.fleet import FleetClient
+from wirestudio.library import default_library
+from wirestudio.mcp.server import build_mcp_server
+from wirestudio.workbench import WorkbenchClient
+
+from tests.test_workbench import FakeBench, _slot
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _seed(store: FileDesignStore, design_id: str = "bench-dut") -> str:
+    store.save(
+        {
+            "schema_version": "0.1",
+            "id": design_id,
+            "name": "Bench DUT",
+            "board": {
+                "library_id": "esp32-devkitc-v4",
+                "mcu": "esp32",
+                "framework": "arduino",
+            },
+            "power": {"supply": "usb-5v", "rail_voltage_v": 5.0, "budget_ma": 500},
+            "components": [],
+            "buses": [],
+            "connections": [],
+        },
+        design_id=design_id,
+    )
+    return design_id
+
+
+def _payload(result: Any) -> dict:
+    """Decode a FastMCP call_tool result into its JSON dict."""
+    content = result[0] if isinstance(result, tuple) else result
+    if isinstance(content, dict):
+        return content
+    text = getattr(content[0], "text", None)
+    assert isinstance(text, str), f"unexpected content: {content!r}"
+    return json.loads(text)
+
+
+def _server(tmp_path: Path, *, bench: FakeBench | None = None, fleet_handler=None):
+    store = FileDesignStore(root=tmp_path / "designs")
+    _seed(store)
+
+    def wb_factory():
+        if bench is None:
+            return WorkbenchClient(base_url="", token="")
+        # FakeBench requires a bearer by default, so the token path is
+        # exercised too even though WORKBENCH_TOKEN is optional in prod.
+        return WorkbenchClient(
+            base_url="http://bench:8080", token=bench.require_token or "",
+            transport=httpx.MockTransport(bench.handler),
+        )
+
+    def fleet_factory():
+        if fleet_handler is None:
+            return FleetClient(base_url="", token="")
+        return FleetClient(
+            base_url="http://fleet:8080", token="tok",
+            transport=httpx.MockTransport(fleet_handler),
+        )
+
+    server = build_mcp_server(
+        default_library(), store,
+        workbench_factory=wb_factory, fleet_factory=fleet_factory,
+    )
+    return server, store
+
+
+async def _wait_job(server, job_id: str, timeout: float = 10.0) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        snap = _payload(await server.call_tool("job_status", {"job_id": job_id}))
+        if snap["state"] != "running":
+            return snap
+        time.sleep(0.02)
+    raise AssertionError(f"job {job_id} never finished")
+
+
+# ---------------------------------------------------------------------------
+# Workbench
+# ---------------------------------------------------------------------------
+
+async def test_workbench_slots_reports_flashability(tmp_path):
+    bench = FakeBench(slots=[_slot("SLOT1"), _slot("SLOT2", flapping=True)])
+    server, _ = _server(tmp_path, bench=bench)
+
+    out = _payload(await server.call_tool("workbench_slots", {}))
+    assert out["ok"] is True
+    by_label = {s["label"]: s for s in out["slots"]}
+    assert by_label["SLOT1"]["flashable"] is True
+    assert by_label["SLOT2"]["flashable"] is False
+    assert by_label["SLOT2"]["blocked_reason"]
+
+
+async def test_workbench_slots_without_config_is_an_error_not_a_crash(tmp_path):
+    server, _ = _server(tmp_path)  # no bench -> unconfigured client
+    out = _payload(await server.call_tool("workbench_slots", {}))
+    assert out["ok"] is False
+    assert "WORKBENCH_URL" in out["error"]
+
+
+async def test_workbench_flash_returns_a_job_that_completes(tmp_path):
+    bench = FakeBench(slots=[_slot("SLOT1")])
+    server, _ = _server(tmp_path, bench=bench)
+
+    out = _payload(await server.call_tool("workbench_flash", {
+        "slot": "SLOT1",
+        "images": [{"offset": "0x10000", "data": "aGVsbG8="}],
+        "chip": "esp32",
+    }))
+    assert out["ok"] is True, out
+    assert out["bytes"] == 5
+
+    snap = await _wait_job(server, out["job_id"])
+    assert snap["state"] == "done", snap
+    assert snap["event_count"] > 0
+    assert bench.flashed, "the bench was never asked to flash"
+
+
+async def test_workbench_flash_refuses_a_flapping_slot(tmp_path):
+    bench = FakeBench(slots=[_slot("SLOT1", flapping=True)])
+    server, _ = _server(tmp_path, bench=bench)
+
+    out = _payload(await server.call_tool("workbench_flash", {
+        "slot": "SLOT1",
+        "images": [{"offset": "0x0", "data": "aGVsbG8="}],
+    }))
+    assert out["ok"] is False
+    assert "not flashable" in out["error"]
+    assert not bench.flashed
+
+
+async def test_workbench_flash_requires_exactly_one_firmware_source(tmp_path):
+    bench = FakeBench(slots=[_slot("SLOT1")])
+    server, _ = _server(tmp_path, bench=bench)
+
+    neither = _payload(await server.call_tool("workbench_flash", {"slot": "SLOT1"}))
+    assert neither["ok"] is False
+    assert "exactly one" in neither["error"]
+
+    both = _payload(await server.call_tool("workbench_flash", {
+        "slot": "SLOT1",
+        "fleet_run_id": "123",
+        "images": [{"offset": "0x0", "data": "aGVsbG8="}],
+    }))
+    assert both["ok"] is False
+    assert "exactly one" in both["error"]
+
+
+async def test_workbench_flash_rejects_a_bad_image_payload(tmp_path):
+    bench = FakeBench(slots=[_slot("SLOT1")])
+    server, _ = _server(tmp_path, bench=bench)
+
+    out = _payload(await server.call_tool("workbench_flash", {
+        "slot": "SLOT1",
+        "images": [{"offset": "0x0", "data": "not!base64!"}],
+    }))
+    assert out["ok"] is False
+    assert "image 0" in out["error"]
+    assert not bench.flashed
+
+
+async def test_flash_failure_surfaces_as_job_error(tmp_path):
+    """A non-zero esptool return arrives under HTTP 200 -- the job must not
+    report done."""
+    bench = FakeBench(slots=[_slot("SLOT1")], returncode=1)
+    server, _ = _server(tmp_path, bench=bench)
+
+    out = _payload(await server.call_tool("workbench_flash", {
+        "slot": "SLOT1",
+        "images": [{"offset": "0x0", "data": "aGVsbG8="}],
+    }))
+    assert out["ok"] is True
+    snap = await _wait_job(server, out["job_id"])
+    assert snap["state"] == "error", snap
+
+
+# ---------------------------------------------------------------------------
+# Fleet
+# ---------------------------------------------------------------------------
+
+def _fleet_handler(
+    *, existing: list[dict] | None = None, firmware: bytes = b"\xe9firmware",
+):
+    """Speaks the addon's actual shapes.
+
+    Two field names here are the ones the client really reads, and both
+    have burned us: the target list is keyed by ``target`` (not
+    ``filename``), and a queue row's id is ``id`` with state in ``state``
+    (not ``job_id``/``status``). Artifacts hang off the **job** id, not
+    the run id -- so a fetch by run_id must 404 and fall through.
+    """
+    targets = existing if existing is not None else []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        path = req.url.path
+        if path == "/ui/api/targets":
+            if req.method == "GET":
+                return httpx.Response(200, json=targets)
+            return httpx.Response(200, json={"ok": True, "run_id": "run-1"})
+        if path.startswith("/ui/api/targets/"):
+            return httpx.Response(200, json={"ok": True, "run_id": "run-1"})
+        if path == "/ui/api/queue":
+            return httpx.Response(200, json=[
+                {"run_id": "run-1", "id": "job-9", "target": "dut.yaml",
+                 "state": "success", "finished_at": "2026-08-01T00:00:00Z"},
+            ])
+        if path == "/ui/api/jobs/job-9/firmware":
+            return httpx.Response(200, content=firmware)
+        if path.endswith("/log"):
+            return httpx.Response(200, json={"log": "Linking .pio\n", "offset": 14,
+                                             "finished": True})
+        if path in ("/ui/api/status", "/health"):
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(404, json={"error": f"no route {path}"})
+
+    return handler
+
+
+async def test_fleet_job_status_reports_the_real_verdict_field(tmp_path):
+    """RunStatus carries `verdict` and JobStatus carries `job_id`/`state` --
+    reading any other attribute yields silent Nones."""
+    server, _ = _server(tmp_path, fleet_handler=_fleet_handler())
+    out = _payload(await server.call_tool("fleet_job_status", {"run_id": "run-1"}))
+    assert out["ok"] is True, out
+    assert out["verdict"] == "passed"
+    assert out["jobs"] == [{
+        "job_id": "job-9", "target": "dut.yaml", "state": "success",
+        "finished_at": "2026-08-01T00:00:00Z",
+    }]
+
+
+async def test_firmware_is_found_via_the_job_id_not_the_run_id(tmp_path):
+    """The artifact is keyed by job_id; a run_id fetch must fall through."""
+    server, _ = _server(tmp_path, fleet_handler=_fleet_handler(firmware=b"y" * 32))
+    out = _payload(await server.call_tool("fleet_firmware_info", {"run_id": "run-1"}))
+    assert out["ok"] is True, out
+    assert out["bytes"] == 32
+
+
+async def test_fleet_firmware_info_reports_size_not_bytes(tmp_path):
+    """The image must not cross the MCP boundary."""
+    server, _ = _server(tmp_path, fleet_handler=_fleet_handler(firmware=b"x" * 4096))
+    out = _payload(await server.call_tool("fleet_firmware_info", {"run_id": "run-1"}))
+    assert out["ok"] is True, out
+    assert out["bytes"] == 4096
+    assert "data" not in out and "firmware" not in out
+
+
+async def test_fleet_tools_without_config_are_errors(tmp_path):
+    server, _ = _server(tmp_path)
+    out = _payload(await server.call_tool("fleet_push", {"design_id": "bench-dut"}))
+    assert out["ok"] is False
+    assert "fleet not configured" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# Design resolution
+# ---------------------------------------------------------------------------
+
+async def test_design_bound_tool_without_a_design_says_so(tmp_path):
+    store = FileDesignStore(root=tmp_path / "designs")  # empty, no active
+    server = build_mcp_server(default_library(), store)
+    out = _payload(await server.call_tool("lorawan_compile", {}))
+    assert out["ok"] is False
+    assert "design_id" in out["error"]
+
+
+async def test_eui_validation_rejects_non_hex(tmp_path):
+    server, _ = _server(tmp_path)
+    for bad in ("zzzzzzzzzzzzzzzz", "0011223344556677889900", "short"):
+        out = _payload(await server.call_tool("lorawan_activation", {"dev_eui": bad}))
+        assert out["ok"] is False, bad
+        assert "16 hex" in out["error"]

--- a/tests/test_mcp_jobs.py
+++ b/tests/test_mcp_jobs.py
@@ -1,0 +1,104 @@
+"""Tests for the MCP long-running-job registry."""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from wirestudio.mcp.jobs import JobNotFound, JobRegistry
+
+
+def _wait(reg: JobRegistry, job_id: str, timeout: float = 5.0) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        snap = reg.status(job_id)
+        if snap["state"] != "running":
+            return snap
+        time.sleep(0.01)
+    raise AssertionError(f"job {job_id} still running after {timeout}s")
+
+
+def test_sync_generator_events_are_collected():
+    reg = JobRegistry()
+    job_id = reg.start("compile", lambda: iter(
+        [{"step": 1}, {"step": 2}, {"step": 3}]
+    ))
+    snap = _wait(reg, job_id)
+    assert snap["state"] == "done"
+    assert snap["event_count"] == 3
+    assert snap["last_event"] == {"step": 3}
+    assert reg.events(job_id)["events"] == [{"step": 1}, {"step": 2}, {"step": 3}]
+
+
+def test_async_generator_is_driven_on_the_worker():
+    async def produce():
+        for i in range(3):
+            yield {"step": i}
+
+    reg = JobRegistry()
+    job_id = reg.start("flash", produce)
+    snap = _wait(reg, job_id)
+    assert snap["state"] == "done"
+    assert snap["event_count"] == 3
+
+
+def test_producer_exception_becomes_error_state():
+    def produce():
+        yield {"step": 1}
+        raise RuntimeError("bench went away")
+
+    reg = JobRegistry()
+    job_id = reg.start("flash", produce)
+    snap = _wait(reg, job_id)
+    assert snap["state"] == "error"
+    assert "bench went away" in snap["error"]
+    # Events emitted before the failure are still readable.
+    assert reg.events(job_id)["events"] == [{"step": 1}]
+
+
+def test_events_paginate_with_a_cursor():
+    reg = JobRegistry()
+    job_id = reg.start("compile", lambda: iter([{"n": i} for i in range(10)]))
+    _wait(reg, job_id)
+
+    first = reg.events(job_id, since=0, limit=4)
+    assert first["events"] == [{"n": i} for i in range(4)]
+    assert first["next_since"] == 4
+    assert first["done"] is False
+
+    rest = reg.events(job_id, since=first["next_since"], limit=100)
+    assert rest["events"] == [{"n": i} for i in range(4, 10)]
+    assert rest["done"] is True
+
+
+def test_unknown_job_raises():
+    with pytest.raises(JobNotFound):
+        JobRegistry().status("nope")
+
+
+def test_running_jobs_are_never_evicted():
+    """A full registry must not drop work still in flight."""
+    reg = JobRegistry(max_jobs=2)
+    release = []
+
+    def blocker():
+        while not release:
+            time.sleep(0.005)
+        yield {"done": True}
+
+    live = reg.start("flash", blocker)
+    for _ in range(5):
+        finished = reg.start("compile", lambda: iter([{"x": 1}]))
+        _wait(reg, finished)
+
+    # The blocked job survived five evictions of finished jobs.
+    assert reg.status(live)["state"] == "running"
+    release.append(True)
+    assert _wait(reg, live)["state"] == "done"
+
+
+def test_non_dict_events_are_wrapped_not_dropped():
+    reg = JobRegistry()
+    job_id = reg.start("compile", lambda: iter(["plain line"]))
+    _wait(reg, job_id)
+    assert reg.events(job_id)["events"] == [{"message": "plain line"}]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -41,6 +41,26 @@ EXPECTED_TOOLS = {
     "get_active_design",
 }
 
+HARDWARE_TOOLS = {
+    "job_status",
+    "job_events",
+    "job_list",
+    "workbench_status",
+    "workbench_slots",
+    "workbench_flash",
+    "lorawan_chirpstack_status",
+    "lorawan_compile",
+    "lorawan_provision",
+    "lorawan_provision_esphome",
+    "lorawan_activation",
+    "lorawan_workbench_provision",
+    "fleet_status",
+    "fleet_push",
+    "fleet_job_status",
+    "fleet_job_log",
+    "fleet_firmware_info",
+}
+
 
 def _seed_design(store: FileDesignStore, design_id: str = "test-bench") -> str:
     design = {
@@ -76,6 +96,17 @@ async def test_all_expected_tools_registered(mcp_server):
     server, _ = mcp_server
     tools = await server.list_tools()
     names = {t.name for t in tools}
+    assert names == EXPECTED_TOOLS | HARDWARE_TOOLS
+
+
+async def test_hardware_tools_can_be_left_off(tmp_path: Path):
+    """A build without hardware access registers only the design surface."""
+    server = build_mcp_server(
+        default_library(),
+        FileDesignStore(root=tmp_path / "designs"),
+        hardware=False,
+    )
+    names = {t.name for t in await server.list_tools()}
     assert names == EXPECTED_TOOLS
 
 

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -242,7 +242,17 @@ def create_app(
 
 
     mcp_enabled = os.environ.get("WIRESTUDIO_MCP_ENABLED", "true").lower() != "false"
-    mcp_server = build_mcp_server(lib, designs_store, active=active) if mcp_enabled else None
+    # The hardware tools get the same client factories the REST routes use,
+    # so a test that mocks the transport mocks both surfaces at once.
+    mcp_server = (
+        build_mcp_server(
+            lib, designs_store, active=active,
+            workbench_factory=workbench_client_factory,
+            fleet_factory=make_fleet,
+        )
+        if mcp_enabled
+        else None
+    )
 
     @asynccontextmanager
     async def lifespan(_: FastAPI):

--- a/wirestudio/mcp/hardware.py
+++ b/wirestudio/mcp/hardware.py
@@ -1,0 +1,726 @@
+"""MCP tools that reach hardware: workbench, ChirpStack, fleet builds.
+
+The design/library tools stop at the artifact. These carry it the rest of
+the way -- compile it, put it on a slot, register it with ChirpStack --
+so a headless client can finish a bring-up without dropping to HTTP.
+That mattered because the REST endpoints these wrap carry no auth of
+their own: publishing them to close the gap would publish unauthenticated
+flashing and provisioning, while `/mcp` is bearer-gated.
+
+Long operations return a `job_id` rather than blocking. Compile, flash
+and workbench-provision stream for minutes; the tool starts the work and
+the client polls `job_status` / `job_events`. Fleet builds keep their own
+`run_id` from the addon's GitHub run and are polled with
+`fleet_job_status` -- that handle outlives this process, so wrapping it in
+the in-memory registry would only make it more fragile.
+
+Firmware bytes never cross the MCP boundary. `workbench_flash` takes a
+`fleet_run_id` and fetches the artifact server-side, because an agent
+needs the image *on the board*, not in its context window.
+"""
+from __future__ import annotations
+
+import base64
+from typing import Any, Callable, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from wirestudio.designs.active import ActiveDesignTracker
+from wirestudio.designs.store import DesignStore
+from wirestudio.library import Library
+from wirestudio.mcp.jobs import JobNotFound, JobRegistry
+from wirestudio.model import Design
+
+_EUI_LEN = 16
+
+_NO_DESIGN = {
+    "ok": False,
+    "error": (
+        "design_id was not provided and no active design is set. "
+        "Either pass design_id explicitly or call set_active_design first."
+    ),
+}
+
+
+def _err(message: str, **extra: Any) -> dict:
+    return {"ok": False, "error": message, **extra}
+
+
+def _valid_eui(dev_eui: str) -> bool:
+    if len(dev_eui) != _EUI_LEN:
+        return False
+    try:
+        int(dev_eui, 16)
+    except ValueError:
+        return False
+    return True
+
+
+def _decode_images(raw: Optional[list[dict]]) -> list[tuple[int, bytes]]:
+    """[{offset, data}] -> [(int, bytes)]; `data` is base64.
+
+    Offsets arrive as strings like "0x10000", so base=0 rather than
+    assumed decimal -- an ESP32-S3 bootloader at 0x0 and an app at
+    0x10000 both have to parse correctly.
+    """
+    if not raw:
+        raise ValueError("no images supplied")
+    out: list[tuple[int, bytes]] = []
+    for i, img in enumerate(raw):
+        try:
+            offset = int(str(img["offset"]), 0)
+            data = base64.b64decode(img["data"], validate=True)
+        except (KeyError, ValueError, TypeError) as e:
+            raise ValueError(f"image {i}: {e}") from e
+        if offset < 0:
+            raise ValueError(f"image {i}: negative offset")
+        if not data:
+            raise ValueError(f"image {i}: empty payload")
+        out.append((offset, data))
+    return out
+
+
+def register_hardware_tools(
+    mcp: FastMCP,
+    library: Library,
+    designs: DesignStore,
+    active: ActiveDesignTracker,
+    jobs: JobRegistry,
+    *,
+    workbench_factory: Optional[Callable[[], Any]] = None,
+    fleet_factory: Optional[Callable[[], Any]] = None,
+) -> None:
+    """Register the hardware tool surface on `mcp`.
+
+    The factories exist so tests can inject fakes; production passes the
+    same ones `create_app` already uses for the REST routes.
+    """
+    def _load(design_id: Optional[str]) -> tuple[Optional[str], Optional[dict]]:
+        rid = design_id or active.get()
+        if not rid:
+            return None, None
+        return rid, designs.load(rid)
+
+    def _load_model(design_id: Optional[str]) -> tuple[Optional[Design], Optional[dict]]:
+        """Load and validate; returns (design, error_dict) with one side None."""
+        rid, raw = _load(design_id)
+        if raw is None:
+            return None, _NO_DESIGN
+        try:
+            return Design.model_validate(raw), None
+        except Exception as e:
+            return None, _err(f"design '{rid}' failed validation: {e}")
+
+    def _workbench() -> Any:
+        if workbench_factory is not None:
+            return workbench_factory()
+        from wirestudio.workbench import WorkbenchClient
+
+        return WorkbenchClient()
+
+    def _fleet() -> Any:
+        if fleet_factory is not None:
+            return fleet_factory()
+        from wirestudio.fleet import FleetClient
+
+        return FleetClient()
+
+    _register_job_tools(mcp, jobs)
+    _register_workbench_tools(mcp, jobs, _workbench, _fleet)
+    _register_lorawan_tools(mcp, library, jobs, _load_model, _workbench)
+    _register_fleet_tools(mcp, library, _load_model, _fleet)
+
+
+# ---------------------------------------------------------------------------
+# Job polling
+# ---------------------------------------------------------------------------
+
+def _register_job_tools(mcp: FastMCP, jobs: JobRegistry) -> None:
+    @mcp.tool(
+        name="job_status",
+        description=(
+            "Check a long-running job started by lorawan_compile, "
+            "workbench_flash or lorawan_workbench_provision. Returns state "
+            "('running' | 'done' | 'error'), event_count, the most recent "
+            "event, and elapsed_s. Poll this until state leaves 'running'; "
+            "use job_events for the full log. Note fleet builds are NOT "
+            "these jobs -- poll a fleet run with fleet_job_status."
+        ),
+    )
+    def job_status(job_id: str) -> dict:
+        try:
+            return {"ok": True, **jobs.status(job_id)}
+        except JobNotFound:
+            return _err(f"no such job: {job_id}")
+
+    @mcp.tool(
+        name="job_events",
+        description=(
+            "Read a job's event log incrementally. Pass since=0 first, then "
+            "the returned next_since to get only what is new. `done` is true "
+            "once the job has finished AND you have read every event."
+        ),
+    )
+    def job_events(job_id: str, since: int = 0, limit: int = 200) -> dict:
+        try:
+            return {"ok": True, **jobs.events(job_id, since=since, limit=limit)}
+        except JobNotFound:
+            return _err(f"no such job: {job_id}")
+
+    @mcp.tool(
+        name="job_list",
+        description=(
+            "List jobs this server currently holds, newest last. Jobs are "
+            "in-memory and are lost on restart."
+        ),
+    )
+    def job_list() -> dict:
+        return {"ok": True, "jobs": jobs.list()}
+
+
+# ---------------------------------------------------------------------------
+# Workbench
+# ---------------------------------------------------------------------------
+
+def _register_workbench_tools(
+    mcp: FastMCP,
+    jobs: JobRegistry,
+    workbench: Callable[[], Any],
+    fleet: Callable[[], Any],
+) -> None:
+    @mcp.tool(
+        name="workbench_status",
+        description=(
+            "Is a remote workbench configured and reachable? Returns "
+            "available, reason and url. Check this before workbench_slots "
+            "or workbench_flash."
+        ),
+    )
+    async def workbench_status() -> dict:
+        wc = workbench()
+        ok, reason = await wc.is_available()
+        return {
+            "ok": True,
+            "available": ok,
+            "reason": reason,
+            "url": wc.base_url or None,
+            "configure_hint": (
+                None if ok else
+                "Set WORKBENCH_URL=http://<pi>:8080. WORKBENCH_TOKEN is "
+                "optional -- only needed if the bench sits behind an "
+                "authenticating proxy."
+            ),
+        }
+
+    @mcp.tool(
+        name="workbench_slots",
+        description=(
+            "List the bench's USB slots: label, state, present, detected "
+            "chip, product string, and whether the slot is flashable right "
+            "now (with blocked_reason when it isn't). Use the label as the "
+            "`slot` argument to workbench_flash."
+        ),
+    )
+    async def workbench_slots() -> dict:
+        wc = workbench()
+        if not wc.is_configured():
+            return _err("workbench not configured (set WORKBENCH_URL)")
+        try:
+            slots = await wc.slots()
+        except Exception as e:
+            return _err(f"workbench unreachable: {e}")
+        return {
+            "ok": True,
+            "slots": [
+                {
+                    "label": s.label,
+                    "state": s.state,
+                    "present": s.present,
+                    "chip": s.chip,
+                    "product": s.product,
+                    "serial_url": s.serial_url,
+                    "flapping": s.flapping,
+                    "last_error": s.last_error,
+                    "flashable": s.flashable[0],
+                    "blocked_reason": s.flashable[1],
+                }
+                for s in slots
+            ],
+        }
+
+    @mcp.tool(
+        name="workbench_flash",
+        description=(
+            "Flash a bench slot and return a job_id; poll it with "
+            "job_status. Supply the firmware either as `fleet_run_id` (the "
+            "server fetches that build's artifact itself -- preferred) or "
+            "as `images`, a list of {offset, data} with base64 `data` and "
+            "`offset` like '0x10000'. Set chip to match the board "
+            "(esp32, esp32s3, esp32c3...); an ESP32-S3 bootloader belongs "
+            "at 0x0, not 0x1000. erase=true wipes flash first, which also "
+            "clears LoRaWAN DevNonce counters."
+        ),
+    )
+    async def workbench_flash(
+        slot: str,
+        fleet_run_id: Optional[str] = None,
+        images: Optional[list[dict]] = None,
+        chip: str = "esp32",
+        erase: bool = False,
+        baud: int = 921600,
+    ) -> dict:
+        wc = workbench()
+        if not wc.is_configured():
+            return _err("workbench not configured (set WORKBENCH_URL)")
+        if bool(fleet_run_id) == bool(images):
+            return _err("supply exactly one of fleet_run_id or images")
+
+        if fleet_run_id:
+            fc = fleet()
+            if not fc.is_configured():
+                return _err("fleet not configured (set FLEET_URL and FLEET_TOKEN)")
+            try:
+                blob = await fc.get_firmware(fleet_run_id)
+            except Exception as e:
+                return _err(f"could not fetch firmware for run {fleet_run_id}: {e}")
+            # A fleet artifact is a merged factory image -- one blob at 0x0.
+            parsed = [(0x0, blob)]
+        else:
+            try:
+                parsed = _decode_images(images)
+            except ValueError as e:
+                return _err(str(e))
+
+        try:
+            ok, reason = (await wc.slot(slot)).flashable
+        except Exception as e:
+            return _err(f"workbench unreachable: {e}")
+        if not ok:
+            return _err(f"slot {slot} is not flashable: {reason}")
+
+        total = sum(len(d) for _, d in parsed)
+        job_id = jobs.start(
+            "flash",
+            lambda: wc.flash(
+                slot=slot, images=parsed, chip=chip, erase=erase, baud=baud,
+            ),
+            label=f"{slot} {chip} ({total} bytes)",
+        )
+        return {"ok": True, "job_id": job_id, "slot": slot, "bytes": total}
+
+
+# ---------------------------------------------------------------------------
+# LoRaWAN / ChirpStack
+# ---------------------------------------------------------------------------
+
+def _register_lorawan_tools(
+    mcp: FastMCP,
+    library: Library,
+    jobs: JobRegistry,
+    load_model: Callable[[Optional[str]], tuple[Optional[Design], Optional[dict]]],
+    workbench: Callable[[], Any],
+) -> None:
+    @mcp.tool(
+        name="lorawan_chirpstack_status",
+        description=(
+            "Is ChirpStack configured and reachable? Read-only probe of the "
+            "API token and endpoint. Check before any provision call."
+        ),
+    )
+    def lorawan_chirpstack_status() -> dict:
+        from wirestudio.targets.lorawan import chirpstack as cs
+
+        return {"ok": True, **cs.chirpstack_status()}
+
+    @mcp.tool(
+        name="lorawan_compile",
+        description=(
+            "Build standalone LoRaWAN firmware for a design and return a "
+            "job_id; poll it with job_status. This is the RadioLib "
+            "standalone path, not the ESPHome external-component path. "
+            "Validates the design and its board's radio block eagerly, so a "
+            "bad design fails here rather than inside the job."
+        ),
+    )
+    def lorawan_compile(design_id: Optional[str] = None) -> dict:
+        design, err = load_model(design_id)
+        if err:
+            return err
+        from wirestudio.targets import get_target
+        from wirestudio.targets.lorawan.firmware import generate_firmware
+
+        try:
+            generate_firmware(design, library)  # eager: board + radio block
+        except (FileNotFoundError, ValueError) as e:
+            return _err(str(e))
+
+        backend = get_target("lorawan").build_backend()
+        build_id = backend.enqueue(design, library)
+        job_id = jobs.start(
+            "compile",
+            lambda: backend.stream(build_id, design, library),
+            label=design.id,
+        )
+        return {"ok": True, "job_id": job_id, "design_id": design.id}
+
+    @mcp.tool(
+        name="lorawan_provision",
+        description=(
+            "Register a device in ChirpStack for the standalone RadioLib "
+            "path and issue its AppKey. Returns the DevEUI/JoinEUI/AppKey "
+            "to type into the device's serial provisioning prompt. The "
+            "AppKey is generated server-side, returned once, and never "
+            "written to design.json. Use lorawan_provision_esphome instead "
+            "for the ESPHome external-component path."
+        ),
+    )
+    def lorawan_provision(
+        dev_eui: str,
+        design_id: Optional[str] = None,
+        application_name: str = "wirestudio",
+    ) -> dict:
+        import secrets as _secrets
+
+        dev_eui = dev_eui.lower()
+        if not _valid_eui(dev_eui):
+            return _err("dev_eui must be 16 hex characters")
+        design, err = load_model(design_id)
+        if err:
+            return err
+
+        from wirestudio.targets.lorawan import chirpstack as cs
+        from wirestudio.targets.lorawan.codec import generate_codec, profile_name
+
+        client = cs.ChirpStackClient()
+        if not client.is_configured():
+            return _err(
+                "ChirpStack not configured "
+                "(set CHIRPSTACK_API_TOKEN / CHIRPSTACK_API_URL)"
+            )
+        join_eui = (
+            design.lorawan.join_eui
+            if design.lorawan and design.lorawan.join_eui else None
+        )
+        app_key = _secrets.token_hex(16)
+        try:
+            result = client.provision_device(
+                dev_eui=dev_eui,
+                app_key=app_key,
+                application_name=application_name,
+                device_profile_name=profile_name(design, library),
+                join_eui=join_eui,
+                codec=generate_codec(design, library),
+            )
+        except cs.ChirpStackUnavailable as e:
+            return _err(str(e))
+        return {
+            "ok": True,
+            "dev_eui": dev_eui,
+            "join_eui": join_eui or "0000000000000000",
+            "band": "US915",
+            "sub_band": 2,
+            "app_key": app_key,
+            "application_id": result["application_id"],
+            "device_profile_id": result["device_profile_id"],
+        }
+
+    @mcp.tool(
+        name="lorawan_provision_esphome",
+        description=(
+            "Register a device in ChirpStack for the ESPHome "
+            "external-component path (lorawan-for-esphome). Returns keys "
+            "formatted for secrets.yaml rather than a serial prompt. "
+            "Requires design.lorawan.payload to be non-empty. The profile "
+            "is created without a codec; set one afterwards once the "
+            "payload format has settled."
+        ),
+    )
+    def lorawan_provision_esphome(
+        dev_eui: str,
+        design_id: Optional[str] = None,
+        application_name: str = "wirestudio-esphome",
+    ) -> dict:
+        import secrets as _secrets
+
+        dev_eui = dev_eui.lower()
+        if not _valid_eui(dev_eui):
+            return _err("dev_eui must be 16 hex characters")
+        design, err = load_model(design_id)
+        if err:
+            return err
+        if design.lorawan is None or not design.lorawan.payload:
+            return _err(
+                "design.lorawan.payload must be non-empty for the ESPHome "
+                "external-component path"
+            )
+
+        from wirestudio.targets.lorawan import chirpstack as cs
+
+        zero = "0000000000000000"
+        join_eui = design.lorawan.join_eui or zero
+        client = cs.ChirpStackClient()
+        if not client.is_configured():
+            return _err(
+                "ChirpStack not configured "
+                "(set CHIRPSTACK_API_TOKEN / CHIRPSTACK_API_URL)"
+            )
+        app_key = _secrets.token_hex(16)
+        try:
+            result = client.provision_device(
+                dev_eui=dev_eui,
+                app_key=app_key,
+                application_name=application_name,
+                device_profile_name=(
+                    f"wirestudio-esphome-{design.lorawan.region.lower()}"
+                    f"-sub{design.lorawan.sub_band}"
+                ),
+                join_eui=join_eui if join_eui != zero else None,
+                codec=None,
+            )
+        except cs.ChirpStackUnavailable as e:
+            return _err(str(e))
+        return {
+            "ok": True,
+            "secrets": {
+                "dev_eui": dev_eui,
+                "join_eui": join_eui,
+                "app_key": app_key,
+            },
+            "chirpstack": {
+                "application_id": result["application_id"],
+                "device_profile_id": result["device_profile_id"],
+            },
+            "band": design.lorawan.region,
+            "sub_band": design.lorawan.sub_band,
+        }
+
+    @mcp.tool(
+        name="lorawan_activation",
+        description=(
+            "Has the device joined the network? Reads ChirpStack's "
+            "activation record. Returns joined=false until the OTAA join "
+            "lands -- a freshly flashed device typically waits one full "
+            "uplink interval before its first join attempt, so poll rather "
+            "than concluding failure from one call."
+        ),
+    )
+    def lorawan_activation(dev_eui: str) -> dict:
+        dev_eui = dev_eui.lower()
+        if not _valid_eui(dev_eui):
+            return _err("dev_eui must be 16 hex characters")
+        from wirestudio.targets.lorawan import chirpstack as cs
+
+        client = cs.ChirpStackClient()
+        if not client.is_configured():
+            return _err("ChirpStack not configured")
+        try:
+            act = client.get_activation(dev_eui)
+        except cs.ChirpStackUnavailable as e:
+            return _err(str(e))
+        return {"ok": True, "dev_eui": dev_eui, "joined": act is not None, **(act or {})}
+
+    @mcp.tool(
+        name="lorawan_workbench_provision",
+        description=(
+            "The whole bring-up on one slot: flash, register in ChirpStack, "
+            "push keys over the device's serial prompt, and verify. Returns "
+            "a job_id; poll it with job_status. Supply `images` as "
+            "{offset, data} with base64 `data`. erase defaults to true "
+            "because a re-provisioned device must restart its DevNonce "
+            "counter or the network rejects its joins as replays."
+        ),
+    )
+    def lorawan_workbench_provision(
+        slot: str,
+        images: list[dict],
+        design_id: Optional[str] = None,
+        erase: bool = True,
+        application_name: str = "wirestudio",
+    ) -> dict:
+        design, err = load_model(design_id)
+        if err:
+            return err
+        try:
+            parsed = _decode_images(images)
+        except ValueError as e:
+            return _err(str(e))
+
+        from wirestudio.targets.lorawan import chirpstack as cs
+        from wirestudio.targets.lorawan.workbench_provision import provision_events
+
+        wb = workbench()
+        if not wb.is_configured():
+            return _err("workbench not configured (set WORKBENCH_URL)")
+        chirp = cs.ChirpStackClient()
+        if not chirp.is_configured():
+            return _err(
+                "ChirpStack not configured "
+                "(set CHIRPSTACK_API_TOKEN / CHIRPSTACK_API_URL)"
+            )
+        try:
+            ok, reason = wb.slot_sync(slot).flashable
+        except Exception as e:
+            return _err(f"workbench unreachable: {e}")
+        if not ok:
+            return _err(f"slot {slot} is not flashable: {reason}")
+
+        job_id = jobs.start(
+            "provision",
+            lambda: provision_events(
+                design, library,
+                slot=slot, workbench=wb, chirpstack=chirp,
+                images=parsed, erase=erase, application_name=application_name,
+            ),
+            label=f"{slot} {design.id}",
+        )
+        return {"ok": True, "job_id": job_id, "slot": slot, "design_id": design.id}
+
+
+# ---------------------------------------------------------------------------
+# Fleet
+# ---------------------------------------------------------------------------
+
+def _register_fleet_tools(
+    mcp: FastMCP,
+    library: Library,
+    load_model: Callable[[Optional[str]], tuple[Optional[Design], Optional[dict]]],
+    fleet: Callable[[], Any],
+) -> None:
+    @mcp.tool(
+        name="fleet_status",
+        description=(
+            "Is the ESPHome fleet addon configured and reachable? Check "
+            "before fleet_push."
+        ),
+    )
+    async def fleet_status() -> dict:
+        fc = fleet()
+        if not fc.is_configured():
+            return {
+                "ok": True, "available": False,
+                "reason": "FLEET_URL not set" if not fc.base_url else "FLEET_TOKEN not set",
+                "url": fc.base_url or None,
+            }
+        ok, reason = await fc.is_available()
+        return {"ok": True, "available": ok, "reason": reason, "url": fc.base_url or None}
+
+    @mcp.tool(
+        name="fleet_push",
+        description=(
+            "Render a design to ESPHome YAML and push it to the fleet "
+            "addon, optionally starting a compile. Returns run_id -- poll "
+            "it with fleet_job_status, then pass it to workbench_flash as "
+            "fleet_run_id. This is a fleet run handle, not a job_id: it "
+            "belongs to the addon and survives a wirestudio restart."
+        ),
+    )
+    async def fleet_push(
+        design_id: Optional[str] = None,
+        device_name: Optional[str] = None,
+        compile: bool = True,
+    ) -> dict:
+        design, err = load_model(design_id)
+        if err:
+            return err
+        from wirestudio.targets import get_target
+
+        try:
+            artifacts = get_target(design.target).generate(design, library)
+            yaml_text = artifacts.get("firmware.yaml")
+        except (FileNotFoundError, ValueError, KeyError) as e:
+            return _err(str(e))
+        if not yaml_text:
+            return _err(f"target '{design.target}' does not produce firmware.yaml")
+
+        name = (
+            device_name
+            or (design.fleet.device_name if design.fleet and design.fleet.device_name else None)
+            or design.id
+        )
+        fc = fleet()
+        if not fc.is_configured():
+            return _err("fleet not configured (set FLEET_URL and FLEET_TOKEN)")
+        try:
+            result = await fc.push_device(name, yaml_text, compile=compile)
+        except ValueError as e:
+            return _err(str(e))
+        except Exception as e:
+            return _err(f"fleet unreachable: {e}")
+        return {
+            "ok": True,
+            "filename": result.filename,
+            "created": result.created,
+            "run_id": result.run_id,
+            "enqueued": result.enqueued,
+        }
+
+    @mcp.tool(
+        name="fleet_job_status",
+        description=(
+            "Compile verdict for a fleet run: running | passed | failed | "
+            "cancelled | unknown. A run that has aged out of the addon's "
+            "queue comes back 'unknown', which means 'no longer tracked', "
+            "not 'failed'."
+        ),
+    )
+    async def fleet_job_status(run_id: str) -> dict:
+        fc = fleet()
+        if not fc.is_configured():
+            return _err("fleet not configured (set FLEET_URL and FLEET_TOKEN)")
+        try:
+            status = await fc.get_run_status(run_id)
+        except Exception as e:
+            return _err(f"fleet unreachable: {e}")
+        return {
+            "ok": True,
+            "run_id": status.run_id,
+            "verdict": status.verdict,
+            "jobs": [
+                {
+                    "job_id": j.job_id,
+                    "target": j.target,
+                    "state": j.state,
+                    "finished_at": j.finished_at,
+                }
+                for j in status.jobs
+            ],
+        }
+
+    @mcp.tool(
+        name="fleet_job_log",
+        description=(
+            "Read a fleet build log incrementally. Pass offset=0 first, "
+            "then the returned offset to fetch only what is new."
+        ),
+    )
+    async def fleet_job_log(run_id: str, offset: int = 0) -> dict:
+        fc = fleet()
+        if not fc.is_configured():
+            return _err("fleet not configured (set FLEET_URL and FLEET_TOKEN)")
+        try:
+            chunk = await fc.get_job_log(run_id, offset=offset)
+        except Exception as e:
+            return _err(f"fleet unreachable: {e}")
+        return {
+            "ok": True, "run_id": run_id,
+            "log": chunk.log, "offset": chunk.offset, "finished": chunk.finished,
+        }
+
+    @mcp.tool(
+        name="fleet_firmware_info",
+        description=(
+            "Report whether a fleet run's compiled firmware is available "
+            "and how large it is. Deliberately does NOT return the bytes -- "
+            "pass the run_id to workbench_flash as fleet_run_id and the "
+            "server moves the image to the board directly."
+        ),
+    )
+    async def fleet_firmware_info(run_id: str, factory: bool = False) -> dict:
+        fc = fleet()
+        if not fc.is_configured():
+            return _err("fleet not configured (set FLEET_URL and FLEET_TOKEN)")
+        try:
+            blob = await fc.get_firmware(run_id, factory=factory)
+        except Exception as e:
+            return _err(f"firmware not available for run {run_id}: {e}")
+        return {"ok": True, "run_id": run_id, "factory": factory, "bytes": len(blob)}

--- a/wirestudio/mcp/jobs.py
+++ b/wirestudio/mcp/jobs.py
@@ -1,0 +1,197 @@
+"""In-process job registry for long-running MCP operations.
+
+An MCP tool call returns once. Compile, flash and provision stream events
+for minutes, so those tools start the work, hand back a `job_id`, and let
+the client poll `job_status` / `job_events` until the state leaves
+"running".
+
+Jobs live in this process and die with it -- a restart loses them. Fleet
+builds are the exception and deliberately stay outside this registry:
+their `run_id` belongs to the fleet addon's GitHub run, survives a
+wirestudio restart, and is polled through `fleet_job_status` instead.
+
+Producers come in both flavours -- `backend.stream()` and
+`provision_events()` are sync generators, `WorkbenchClient.flash()` is an
+async one -- so `start()` accepts a zero-arg factory returning either and
+drives it on a worker thread.
+"""
+from __future__ import annotations
+
+import inspect
+import itertools
+import threading
+import time
+import uuid
+from collections import OrderedDict
+from typing import Any, Callable, Optional
+
+# Events are held per job so a client that polls slowly still sees the whole
+# log. A compile emits a line per PlatformIO step; this bounds a runaway
+# producer without truncating any build we have actually seen.
+MAX_EVENTS_PER_JOB = 5000
+
+# Completed jobs are evicted oldest-first once this many accumulate, so a
+# long-lived server doesn't retain every build log it ever ran.
+MAX_JOBS = 64
+
+
+class JobNotFound(KeyError):
+    """Raised when a job_id is unknown -- expired, or never existed."""
+
+
+class _Job:
+    __slots__ = ("id", "kind", "state", "events", "error", "started_at",
+                 "finished_at", "label", "_lock")
+
+    def __init__(self, job_id: str, kind: str, label: Optional[str]) -> None:
+        self.id = job_id
+        self.kind = kind
+        self.label = label
+        self.state = "running"
+        self.events: list[dict] = []
+        self.error: Optional[str] = None
+        self.started_at = time.time()
+        self.finished_at: Optional[float] = None
+        self._lock = threading.Lock()
+
+    def append(self, event: dict) -> None:
+        with self._lock:
+            if len(self.events) < MAX_EVENTS_PER_JOB:
+                self.events.append(event)
+
+    def finish(self, state: str, error: Optional[str] = None) -> None:
+        with self._lock:
+            self.state = state
+            self.error = error
+            self.finished_at = time.time()
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            last = self.events[-1] if self.events else None
+            return {
+                "job_id": self.id,
+                "kind": self.kind,
+                "label": self.label,
+                "state": self.state,
+                "event_count": len(self.events),
+                "last_event": last,
+                "error": self.error,
+                "started_at": self.started_at,
+                "finished_at": self.finished_at,
+                "elapsed_s": round(
+                    (self.finished_at or time.time()) - self.started_at, 1
+                ),
+            }
+
+    def slice(self, since: int, limit: int) -> dict:
+        with self._lock:
+            total = len(self.events)
+            start = max(0, since)
+            chunk = self.events[start:start + limit]
+            return {
+                "job_id": self.id,
+                "state": self.state,
+                "events": chunk,
+                "since": start,
+                "next_since": start + len(chunk),
+                "event_count": total,
+                "done": self.state != "running" and start + len(chunk) >= total,
+                "error": self.error,
+            }
+
+
+class JobRegistry:
+    """Thread-safe registry of running and recently-finished jobs."""
+
+    def __init__(self, max_jobs: int = MAX_JOBS) -> None:
+        self._jobs: OrderedDict[str, _Job] = OrderedDict()
+        self._lock = threading.Lock()
+        self._max_jobs = max_jobs
+        self._counter = itertools.count(1)
+
+    def start(
+        self,
+        kind: str,
+        produce: Callable[[], Any],
+        *,
+        label: Optional[str] = None,
+    ) -> str:
+        """Run `produce()` on a worker thread, collecting its events.
+
+        `produce` is a zero-arg callable returning a sync iterator or an
+        async iterator of event dicts. It is called on the worker, not
+        here, so a producer that blocks while starting doesn't stall the
+        tool call that created the job.
+        """
+        job_id = f"{kind}-{next(self._counter)}-{uuid.uuid4().hex[:8]}"
+        job = _Job(job_id, kind, label)
+        with self._lock:
+            self._jobs[job_id] = job
+            self._evict_locked()
+
+        threading.Thread(
+            target=self._run, args=(job, produce), daemon=True,
+            name=f"mcp-job-{job_id}",
+        ).start()
+        return job_id
+
+    def _run(self, job: _Job, produce: Callable[[], Any]) -> None:
+        try:
+            source = produce()
+            if inspect.isasyncgen(source) or inspect.isawaitable(source):
+                self._drain_async(job, source)
+            else:
+                for event in source:
+                    job.append(_as_event(event))
+        except Exception as exc:  # producer failures become job state
+            job.finish("error", f"{type(exc).__name__}: {exc}")
+            return
+        job.finish("done")
+
+    def _drain_async(self, job: _Job, source: Any) -> None:
+        import asyncio
+
+        async def pump() -> None:
+            agen = await source if inspect.isawaitable(source) else source
+            async for event in agen:
+                job.append(_as_event(event))
+
+        asyncio.run(pump())
+
+    def status(self, job_id: str) -> dict:
+        return self._get(job_id).snapshot()
+
+    def events(self, job_id: str, since: int = 0, limit: int = 200) -> dict:
+        return self._get(job_id).slice(since, max(1, limit))
+
+    def list(self) -> list[dict]:
+        with self._lock:
+            return [j.snapshot() for j in self._jobs.values()]
+
+    def _get(self, job_id: str) -> _Job:
+        with self._lock:
+            job = self._jobs.get(job_id)
+        if job is None:
+            raise JobNotFound(job_id)
+        return job
+
+    def _evict_locked(self) -> None:
+        """Drop the oldest *finished* jobs past the cap.
+
+        Running jobs are never evicted -- losing the handle to work still
+        in flight would strand a client polling for it.
+        """
+        while len(self._jobs) > self._max_jobs:
+            for jid, job in self._jobs.items():
+                if job.state != "running":
+                    del self._jobs[jid]
+                    break
+            else:
+                return
+
+
+def _as_event(event: Any) -> dict:
+    """Producers yield dicts; anything else is wrapped rather than dropped."""
+    if isinstance(event, dict):
+        return event
+    return {"message": str(event)}

--- a/wirestudio/mcp/server.py
+++ b/wirestudio/mcp/server.py
@@ -16,7 +16,7 @@ its `streamable_http_app()` into the parent FastAPI app and arranging
 """
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from mcp.server.fastmcp import FastMCP
 
@@ -56,6 +56,9 @@ def build_mcp_server(
     *,
     name: str = "wirestudio",
     active: Optional[ActiveDesignTracker] = None,
+    hardware: bool = True,
+    workbench_factory: Optional[Callable[[], Any]] = None,
+    fleet_factory: Optional[Callable[[], Any]] = None,
 ) -> FastMCP:
     """Build a FastMCP server with all wirestudio tools + resources registered.
 
@@ -65,6 +68,10 @@ def build_mcp_server(
     whatever the browser is showing. A fresh tracker is built if the
     caller doesn't supply one (test-only path -- production wires through
     `create_app`).
+
+    `hardware` registers the workbench / ChirpStack / fleet tools. The
+    factories let a caller inject clients; production passes the same ones
+    `create_app` uses for the REST routes.
     """
     mcp = FastMCP(name=name)
     tracker = active or ActiveDesignTracker()
@@ -72,6 +79,15 @@ def build_mcp_server(
     _register_design_tools(mcp, library, designs, tracker)
     _register_active_tools(mcp, tracker, designs)
     _register_resources(mcp, library, designs)
+    if hardware:
+        from wirestudio.mcp.hardware import register_hardware_tools
+        from wirestudio.mcp.jobs import JobRegistry
+
+        register_hardware_tools(
+            mcp, library, designs, tracker, JobRegistry(),
+            workbench_factory=workbench_factory,
+            fleet_factory=fleet_factory,
+        )
     return mcp
 
 


### PR DESCRIPTION
Closes the gap recorded in #195.

The design/library/fab tools stopped at the artifact. An MCP client could produce a design and a schematic, then had to drop to HTTP to put it on a board.

The obvious workaround — publish the REST endpoints too — is worse than it looks:

| Surface | Auth |
|---|---|
| `/api/mcp` | `WIRESTUDIO_MCP_TOKEN` |
| `/api/workbench/*`, `/api/lorawan/*` | **none** |

So closing it in MCP was the only route that does not mean publishing unauthenticated firmware-flashing and ChirpStack provisioning.

## Tools (17)

**Workbench** — `workbench_status`, `workbench_slots`, `workbench_flash`
**LoRaWAN** — `lorawan_chirpstack_status`, `lorawan_compile`, `lorawan_provision`, `lorawan_provision_esphome`, `lorawan_activation`, `lorawan_workbench_provision`
**Fleet** — `fleet_status`, `fleet_push`, `fleet_job_status`, `fleet_job_log`, `fleet_firmware_info`
**Jobs** — `job_status`, `job_events`, `job_list`

## The design question from #195

"How does a long SSE compile map onto an MCP call that wants to return once?" It doesn't — so it doesn't try. `lorawan_compile`, `workbench_flash` and `lorawan_workbench_provision` start the work and return a `job_id`; the client polls `job_status` and reads the log through `job_events` with a cursor.

`wirestudio/mcp/jobs.py` runs each producer on a worker thread. Producers come in both flavours — `backend.stream()` and `provision_events()` are sync generators, `WorkbenchClient.flash()` is async — so the registry detects and drives either.

**Fleet builds stay outside the registry.** Their `run_id` belongs to the addon's GitHub run and survives a wirestudio restart; putting it behind an in-memory handle would make it *more* fragile, not less. A `job_id` and a `run_id` are therefore not interchangeable, and the tool descriptions and docs both say so explicitly.

## Firmware does not cross the boundary

`workbench_flash` takes either `images` (base64) or `fleet_run_id`, and in the latter case fetches the artifact server-side. `fleet_firmware_info` returns size and availability, not bytes — an agent needs the image on the board, not in its context window.

## Testing

21 new tests. They drive the **real** `WorkbenchClient` and `FleetClient` against wire-level fakes — reusing `FakeBench`, which is already verified against the reference bench — rather than substituting fake clients.

That choice paid immediately. It caught a bug in this PR before it shipped: `fleet_job_status` read `.state` and `.passed` off `RunStatus`, which has `run_id` / `verdict` / `jobs` and neither of the others. Every field would have come back `null`, with no error. A fake client would have returned whatever I asked it for; the real client parsing a real-shaped queue row did not.

It also corrected my own fake mid-write — I had queue rows as `{job_id, status}` when the addon sends `{id, state}`, which is the same class of mistake that caused #199 and #203.

Verified the new test fails against the bug:

```
>       assert out["verdict"] == "passed"
FAILED tests/test_mcp_hardware.py::test_fleet_job_status_reports_the_real_verdict_field
1 failed, 12 passed
```

Full suite: **1012 passed, 12 skipped** (was 991).

## Not covered

No hardware-in-the-loop run — these are exercised against fakes only. The REST paths they wrap are the ones the V4 bring-up used live, but the MCP wrappers themselves have not yet driven a real board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ