### PR TITLE
fix(mcp): pick the flash offset from the artifact kind, not a guess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`workbench_flash` would have bricked a board when given a
+  `fleet_run_id`.** It fetched the fleet artifact with the client's
+  default `factory=False` -- the bare *app* image -- and wrote it at
+  offset `0x0`, on top of the bootloader. `factory` is now an explicit
+  argument: true (default) fetches the merged image for `0x0`, false
+  fetches the app image for `app_offset` (default `0x10000`), and a
+  build with no factory artifact returns an error saying how to recover.
+  Found by running the tool against the live fleet addon, which reported
+  the app image at 427 KB and no factory image at all; the unit test
+  asserted only the byte count, never the offset.
+
+### Fixed
+
 - **The `recommend` MCP tool was dead — it ran `library_detail` instead.**
   Two `@mcp.tool` decorators were stacked on one function. FastMCP's
   decorator returns `fn` unchanged, so both names bound to

--- a/tests/test_mcp_hardware.py
+++ b/tests/test_mcp_hardware.py
@@ -206,7 +206,10 @@ async def test_flash_failure_surfaces_as_job_error(tmp_path):
 # ---------------------------------------------------------------------------
 
 def _fleet_handler(
-    *, existing: list[dict] | None = None, firmware: bytes = b"\xe9firmware",
+    *,
+    existing: list[dict] | None = None,
+    firmware: bytes = b"\xe9firmware",
+    factory_firmware: bytes | None = b"\xe9factory-merged",
 ):
     """Speaks the addon's actual shapes.
 
@@ -231,6 +234,13 @@ def _fleet_handler(
                 {"run_id": "run-1", "id": "job-9", "target": "dut.yaml",
                  "state": "success", "finished_at": "2026-08-01T00:00:00Z"},
             ])
+        # Two distinct artifacts: /firmware is the bare app image,
+        # /firmware/factory is the merged bootloader+table+app. A build
+        # may publish the first without the second.
+        if path == "/ui/api/jobs/job-9/firmware/factory":
+            if factory_firmware is None:
+                return httpx.Response(404, json={"error": "no factory image"})
+            return httpx.Response(200, content=factory_firmware)
         if path == "/ui/api/jobs/job-9/firmware":
             return httpx.Response(200, content=firmware)
         if path.endswith("/log"):
@@ -254,6 +264,42 @@ async def test_fleet_job_status_reports_the_real_verdict_field(tmp_path):
         "job_id": "job-9", "target": "dut.yaml", "state": "success",
         "finished_at": "2026-08-01T00:00:00Z",
     }]
+
+
+async def test_fleet_flash_writes_the_app_image_at_the_app_offset(tmp_path):
+    """The artifact kind decides the offset.
+
+    `get_firmware(factory=False)` returns the *bare app* image. Writing it
+    at 0x0 lands on top of the bootloader and boot-loops the board -- only
+    the merged factory image belongs there.
+    """
+    bench = FakeBench(slots=[_slot("SLOT1")])
+    server, _ = _server(
+        tmp_path, bench=bench,
+        fleet_handler=_fleet_handler(firmware=b"\xe9app", factory_firmware=None),
+    )
+
+    out = _payload(await server.call_tool("workbench_flash", {
+        "slot": "SLOT1", "fleet_run_id": "run-1", "factory": False,
+    }))
+    assert out["ok"] is True, out
+    await _wait_job(server, out["job_id"])
+
+    body = bench.flashed[0]["body"]
+    assert b"0x10000" in body, "app image must be written at the app offset"
+    assert b'name="bin@0x0"' not in body, "app image must not be written at 0x0"
+
+
+async def test_missing_factory_image_says_how_to_recover(tmp_path):
+    server, _ = _server(
+        tmp_path, bench=FakeBench(slots=[_slot("SLOT1")]),
+        fleet_handler=_fleet_handler(factory_firmware=None),
+    )
+    out = _payload(await server.call_tool("workbench_flash", {
+        "slot": "SLOT1", "fleet_run_id": "run-1",  # factory=True default
+    }))
+    assert out["ok"] is False
+    assert "factory=false" in out["error"]
 
 
 async def test_firmware_is_found_via_the_job_id_not_the_run_id(tmp_path):

--- a/wirestudio/mcp/hardware.py
+++ b/wirestudio/mcp/hardware.py
@@ -256,9 +256,15 @@ def _register_workbench_tools(
             "server fetches that build's artifact itself -- preferred) or "
             "as `images`, a list of {offset, data} with base64 `data` and "
             "`offset` like '0x10000'. Set chip to match the board "
-            "(esp32, esp32s3, esp32c3...); an ESP32-S3 bootloader belongs "
-            "at 0x0, not 0x1000. erase=true wipes flash first, which also "
-            "clears LoRaWAN DevNonce counters."
+            "(esp32, esp32s3, esp32c3...). erase=true wipes flash first, "
+            "which also clears LoRaWAN DevNonce counters.\n\n"
+            "With fleet_run_id, `factory` picks which artifact and therefore "
+            "which offset: factory=true (default) is the merged image "
+            "(bootloader + partition table + app) written at 0x0, correct "
+            "for a blank board; factory=false is the bare app image written "
+            "at `app_offset` (default 0x10000), which preserves NVS but "
+            "requires the board to already hold a matching bootloader and "
+            "partition table."
         ),
     )
     async def workbench_flash(
@@ -268,6 +274,8 @@ def _register_workbench_tools(
         chip: str = "esp32",
         erase: bool = False,
         baud: int = 921600,
+        factory: bool = True,
+        app_offset: str = "0x10000",
     ) -> dict:
         wc = workbench()
         if not wc.is_configured():
@@ -279,12 +287,29 @@ def _register_workbench_tools(
             fc = fleet()
             if not fc.is_configured():
                 return _err("fleet not configured (set FLEET_URL and FLEET_TOKEN)")
+            # The artifact kind decides the offset, and getting this wrong
+            # bricks the board: the bare app image written at 0x0 lands on
+            # top of the bootloader. Only the merged factory image belongs
+            # at 0x0.
             try:
-                blob = await fc.get_firmware(fleet_run_id)
+                offset = 0x0 if factory else int(app_offset, 0)
+            except ValueError:
+                return _err(f"app_offset is not a number: {app_offset!r}")
+            if offset < 0:
+                return _err("app_offset must not be negative")
+            try:
+                blob = await fc.get_firmware(fleet_run_id, factory=factory)
             except Exception as e:
-                return _err(f"could not fetch firmware for run {fleet_run_id}: {e}")
-            # A fleet artifact is a merged factory image -- one blob at 0x0.
-            parsed = [(0x0, blob)]
+                hint = (
+                    " -- this build may not publish a merged factory image; "
+                    "retry with factory=false to flash the app image at "
+                    "app_offset, or pass `images` explicitly"
+                    if factory else ""
+                )
+                return _err(
+                    f"could not fetch firmware for run {fleet_run_id}: {e}{hint}"
+                )
+            parsed = [(offset, blob)]
         else:
             try:
                 parsed = _decode_images(images)


### PR DESCRIPTION
Found while testing #206's tools against the live bench and fleet addon, before flashing anything.

`workbench_flash(fleet_run_id=...)` fetched the artifact and wrote it at `0x0`:

```python
blob = await fc.get_firmware(fleet_run_id)   # factory=False default -> app image
parsed = [(0x0, blob)]                       # 0x0 is the bootloader
```

The fleet client's own contract says what that returns:

> `factory=False` (default) fetches the app image (re-flash that preserves NVS); `factory=True` fetches the merged factory image for blank-board flashing at offset 0x0.

So the first real call would have written a bare app image over the bootloader and boot-looped the board.

## How it surfaced

`fleet_firmware_info` against the V4's actual build:

```
factory=false -> {"ok": true,  "bytes": 427728}
factory=true  -> {"ok": false, "error": "firmware artifact not available ..."}
```

An app image, 427 KB, and no factory image at all — the exact input that would have triggered it.

## Fix

`factory` is now an explicit argument that decides the offset:

| `factory` | artifact | offset |
|---|---|---|
| `true` (default) | merged bootloader + partition table + app | `0x0` |
| `false` | bare app image | `app_offset`, default `0x10000` |

A build with no factory artifact now errors with the recovery spelled out rather than silently flashing the wrong thing.

## Why the tests missed it

`test_fleet_firmware_info_reports_size_not_bytes` asserted `bytes == 4096` and nothing about placement, and the fake served the same blob for every path — so it could not tell the two artifacts apart. It now serves `/firmware` and `/firmware/factory` separately, and can be told to publish no factory image.

Two new tests, both failing against the old code:

```
FAILED test_fleet_flash_writes_the_app_image_at_the_app_offset
FAILED test_missing_factory_image_says_how_to_recover
2 failed, 13 passed
```

Full suite: **1014 passed, 12 skipped**.

## Verified live (staging, real infrastructure)

`workbench_status`, `workbench_slots` (SLOT29 → `esp32s3`, flashable), `lorawan_chirpstack_status`, `fleet_status`, `fleet_job_status` (real run → `verdict: passed`, job id resolved), `fleet_firmware_info`, `lorawan_activation`, and the `job_*` error contracts — all against the live bench, ChirpStack and fleet addon over a real MCP client session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ