### PR TITLE
fix(mcp): detect the flash offset from the artifact, not the endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,16 +35,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`workbench_flash` would have bricked a board when given a
-  `fleet_run_id`.** It fetched the fleet artifact with the client's
-  default `factory=False` -- the bare *app* image -- and wrote it at
-  offset `0x0`, on top of the bootloader. `factory` is now an explicit
-  argument: true (default) fetches the merged image for `0x0`, false
-  fetches the app image for `app_offset` (default `0x10000`), and a
-  build with no factory artifact returns an error saying how to recover.
-  Found by running the tool against the live fleet addon, which reported
-  the app image at 427 KB and no factory image at all; the unit test
-  asserted only the byte count, never the offset.
+- **`workbench_flash` picks its offset by inspecting the artifact.** A
+  merged image (bootloader + partition table + app) goes to `0x0`; a bare
+  app image goes to `0x10000`. The kind is detected from the bytes -- an
+  ESP-IDF partition table at `0x8000` -- because the endpoint that serves
+  them does not reliably say which is which.
+
+  This landed the hard way. `fleet/client.py` documented `/firmware` as
+  the app image and `/firmware/factory` as the merged one, so an earlier
+  attempt at this fix wrote `/firmware` to the app offset. Against the
+  live addon `/firmware` is in fact a *merged* image and
+  `/firmware/factory` 404s, so that put a bootloader in the app partition
+  and boot-looped a Heltec V4 (`No bootable app partitions in the
+  partition table`). Recovered by rewriting the same artifact at `0x0`.
+  The client docstring now records what the addon actually serves.
 
 ### Fixed
 

--- a/tests/test_mcp_hardware.py
+++ b/tests/test_mcp_hardware.py
@@ -266,40 +266,101 @@ async def test_fleet_job_status_reports_the_real_verdict_field(tmp_path):
     }]
 
 
-async def test_fleet_flash_writes_the_app_image_at_the_app_offset(tmp_path):
-    """The artifact kind decides the offset.
+def _merged_image(app_len: int = 4096) -> bytes:
+    """A blob shaped like esptool merge_bin output.
 
-    `get_firmware(factory=False)` returns the *bare app* image. Writing it
-    at 0x0 lands on top of the bootloader and boot-loops the board -- only
-    the merged factory image belongs there.
+    0xE9 image magic at 0, an ESP-IDF partition table (0xAA50) at 0x8000,
+    and another image at 0x10000 -- the layout observed in the fleet
+    addon's real artifact.
+    """
+    blob = bytearray(b"\x00" * (0x10000 + app_len))
+    blob[0] = 0xE9
+    blob[0x8000:0x8002] = b"\xaa\x50"
+    blob[0x10000] = 0xE9
+    return bytes(blob)
+
+
+def _app_image(size: int = 4096) -> bytes:
+    """A bare app image: ESP magic, and nothing at the partition offset."""
+    return b"\xe9" + b"\x11" * (size - 1)
+
+
+def test_merged_and_app_images_are_told_apart():
+    from wirestudio.mcp.hardware import is_merged_image
+
+    assert is_merged_image(_merged_image()) is True
+    assert is_merged_image(_app_image()) is False
+    assert is_merged_image(b"") is False
+    assert is_merged_image(b"\x00" * 0x20000) is False  # no ESP magic
+
+
+async def test_merged_artifact_is_written_at_zero(tmp_path):
+    """A merged image at the app offset boot-loops the board.
+
+    The live addon serves a merged image from `/firmware` despite that
+    endpoint being described as the app image, so the offset has to come
+    from the bytes.
     """
     bench = FakeBench(slots=[_slot("SLOT1")])
     server, _ = _server(
         tmp_path, bench=bench,
-        fleet_handler=_fleet_handler(firmware=b"\xe9app", factory_firmware=None),
+        fleet_handler=_fleet_handler(firmware=_merged_image()),
     )
 
     out = _payload(await server.call_tool("workbench_flash", {
-        "slot": "SLOT1", "fleet_run_id": "run-1", "factory": False,
+        "slot": "SLOT1", "fleet_run_id": "run-1",
     }))
     assert out["ok"] is True, out
     await _wait_job(server, out["job_id"])
 
     body = bench.flashed[0]["body"]
-    assert b"0x10000" in body, "app image must be written at the app offset"
-    assert b'name="bin@0x0"' not in body, "app image must not be written at 0x0"
+    assert b'name="bin@0x0"' in body, "merged image must be written at 0x0"
+    assert b'name="bin@0x10000"' not in body
 
 
-async def test_missing_factory_image_says_how_to_recover(tmp_path):
+async def test_bare_app_artifact_is_written_at_the_app_offset(tmp_path):
+    bench = FakeBench(slots=[_slot("SLOT1")])
+    server, _ = _server(
+        tmp_path, bench=bench,
+        fleet_handler=_fleet_handler(firmware=_app_image()),
+    )
+
+    out = _payload(await server.call_tool("workbench_flash", {
+        "slot": "SLOT1", "fleet_run_id": "run-1",
+    }))
+    assert out["ok"] is True, out
+    await _wait_job(server, out["job_id"])
+
+    body = bench.flashed[0]["body"]
+    assert b'name="bin@0x10000"' in body
+    assert b'name="bin@0x0"' not in body
+
+
+async def test_explicit_offset_overrides_detection(tmp_path):
+    bench = FakeBench(slots=[_slot("SLOT1")])
+    server, _ = _server(
+        tmp_path, bench=bench,
+        fleet_handler=_fleet_handler(firmware=_merged_image()),
+    )
+
+    out = _payload(await server.call_tool("workbench_flash", {
+        "slot": "SLOT1", "fleet_run_id": "run-1", "offset": "0x20000",
+    }))
+    assert out["ok"] is True, out
+    await _wait_job(server, out["job_id"])
+    assert b'name="bin@0x20000"' in bench.flashed[0]["body"]
+
+
+async def test_bad_offset_is_rejected(tmp_path):
     server, _ = _server(
         tmp_path, bench=FakeBench(slots=[_slot("SLOT1")]),
-        fleet_handler=_fleet_handler(factory_firmware=None),
+        fleet_handler=_fleet_handler(),
     )
     out = _payload(await server.call_tool("workbench_flash", {
-        "slot": "SLOT1", "fleet_run_id": "run-1",  # factory=True default
+        "slot": "SLOT1", "fleet_run_id": "run-1", "offset": "banana",
     }))
     assert out["ok"] is False
-    assert "factory=false" in out["error"]
+    assert "not a number" in out["error"]
 
 
 async def test_firmware_is_found_via_the_job_id_not_the_run_id(tmp_path):

--- a/wirestudio/fleet/client.py
+++ b/wirestudio/fleet/client.py
@@ -303,11 +303,18 @@ class FleetClient:
         passthrough that fetches with the server token and re-streams the
         bytes to the WebSerial flasher via the matching studio route.
 
-        ``factory=False`` (default) fetches the app image (re-flash that
-        preserves NVS); ``factory=True`` fetches the merged factory image
-        for blank-board flashing at offset 0x0. 404 -> ``FleetUnavailable``
-        the same way ``get_job_log`` handles unknown run_ids, so the UI
-        can stop polling.
+        ``factory=False`` (default) fetches ``/firmware``; ``factory=True``
+        fetches ``/firmware/factory``. **Do not infer the flash offset from
+        that flag.** Observed against the live addon (2026-08-01): the
+        default ``/firmware`` served a *merged* image -- 0xE9 magic, an
+        ESP-IDF partition table at 0x8000, bootloader entry point -- and
+        ``/firmware/factory`` 404'd entirely. Writing that at the app
+        offset puts a bootloader in the app partition and the board
+        boot-loops ("No bootable app partitions"). Callers must sniff the
+        bytes; see ``wirestudio.mcp.hardware.is_merged_image``.
+
+        404 -> ``FleetUnavailable`` the same way ``get_job_log`` handles
+        unknown run_ids, so the UI can stop polling.
         """
         if not self.is_configured():
             raise FleetUnavailable("FLEET_URL or FLEET_TOKEN missing")

--- a/wirestudio/mcp/hardware.py
+++ b/wirestudio/mcp/hardware.py
@@ -56,6 +56,33 @@ def _valid_eui(dev_eui: str) -> bool:
     return True
 
 
+#: An ESP-IDF partition table lives at 0x8000 inside a *merged* image and
+#: starts with this magic. A bare app image is a single ESP image with
+#: nothing at that offset, so its presence is what distinguishes the two.
+_PARTITION_TABLE_MAGIC = b"\xaa\x50"
+_PARTITION_TABLE_OFFSET = 0x8000
+_ESP_IMAGE_MAGIC = 0xE9
+_DEFAULT_APP_OFFSET = 0x10000
+
+
+def is_merged_image(blob: bytes) -> bool:
+    """Does `blob` carry its own bootloader + partition table?
+
+    Sniffed from the bytes rather than taken on faith from whichever
+    endpoint served them. The fleet addon's ``/firmware`` publishes a
+    merged image even though the client's docstring calls it the app
+    image, and writing a merged image at the app offset puts a
+    bootloader in the app partition -- the board then boot-loops with
+    "Segment 0 ... overlaps bootloader stack / No bootable app
+    partitions". Getting this from the artifact is the only way that
+    stays correct across addon versions.
+    """
+    if len(blob) <= _PARTITION_TABLE_OFFSET + 2 or blob[0] != _ESP_IMAGE_MAGIC:
+        return False
+    at_table = blob[_PARTITION_TABLE_OFFSET:_PARTITION_TABLE_OFFSET + 2]
+    return at_table == _PARTITION_TABLE_MAGIC
+
+
 def _decode_images(raw: Optional[list[dict]]) -> list[tuple[int, bytes]]:
     """[{offset, data}] -> [(int, bytes)]; `data` is base64.
 
@@ -258,13 +285,12 @@ def _register_workbench_tools(
             "`offset` like '0x10000'. Set chip to match the board "
             "(esp32, esp32s3, esp32c3...). erase=true wipes flash first, "
             "which also clears LoRaWAN DevNonce counters.\n\n"
-            "With fleet_run_id, `factory` picks which artifact and therefore "
-            "which offset: factory=true (default) is the merged image "
-            "(bootloader + partition table + app) written at 0x0, correct "
-            "for a blank board; factory=false is the bare app image written "
-            "at `app_offset` (default 0x10000), which preserves NVS but "
-            "requires the board to already hold a matching bootloader and "
-            "partition table."
+            "With fleet_run_id the offset is detected from the artifact: a "
+            "merged image (bootloader + partition table + app) is written "
+            "at 0x0, a bare app image at 0x10000. Pass `offset` only to "
+            "override that, and only if you know which kind the build "
+            "publishes -- a merged image written at the app offset "
+            "boot-loops the board."
         ),
     )
     async def workbench_flash(
@@ -274,8 +300,8 @@ def _register_workbench_tools(
         chip: str = "esp32",
         erase: bool = False,
         baud: int = 921600,
-        factory: bool = True,
-        app_offset: str = "0x10000",
+        factory: bool = False,
+        offset: Optional[str] = None,
     ) -> dict:
         wc = workbench()
         if not wc.is_configured():
@@ -287,29 +313,23 @@ def _register_workbench_tools(
             fc = fleet()
             if not fc.is_configured():
                 return _err("fleet not configured (set FLEET_URL and FLEET_TOKEN)")
-            # The artifact kind decides the offset, and getting this wrong
-            # bricks the board: the bare app image written at 0x0 lands on
-            # top of the bootloader. Only the merged factory image belongs
-            # at 0x0.
-            try:
-                offset = 0x0 if factory else int(app_offset, 0)
-            except ValueError:
-                return _err(f"app_offset is not a number: {app_offset!r}")
-            if offset < 0:
-                return _err("app_offset must not be negative")
             try:
                 blob = await fc.get_firmware(fleet_run_id, factory=factory)
             except Exception as e:
-                hint = (
-                    " -- this build may not publish a merged factory image; "
-                    "retry with factory=false to flash the app image at "
-                    "app_offset, or pass `images` explicitly"
-                    if factory else ""
-                )
-                return _err(
-                    f"could not fetch firmware for run {fleet_run_id}: {e}{hint}"
-                )
-            parsed = [(offset, blob)]
+                return _err(f"could not fetch firmware for run {fleet_run_id}: {e}")
+            # The artifact kind decides the offset and getting it wrong
+            # bricks the board, so read it off the bytes rather than
+            # trusting which endpoint served them.
+            if offset is not None:
+                try:
+                    where = int(offset, 0)
+                except ValueError:
+                    return _err(f"offset is not a number: {offset!r}")
+                if where < 0:
+                    return _err("offset must not be negative")
+            else:
+                where = 0x0 if is_merged_image(blob) else _DEFAULT_APP_OFFSET
+            parsed = [(where, blob)]
         else:
             try:
                 parsed = _decode_images(images)


### PR DESCRIPTION
Corrects #207, which was wrong and boot-looped a real board.

## What happened

#207 changed `workbench_flash` to write the fleet artifact at the *app* offset, on the strength of this docstring in `fleet/client.py`:

> `factory=False` (default) fetches the app image; `factory=True` fetches the merged factory image for blank-board flashing at offset 0x0.

Against the live addon that is not what happens. `/firmware` serves a **merged** image and `/firmware/factory` 404s:

```
size: 427728
byte0: 0xe9                          # ESP image magic
bytes at 0x8000: aa50                # ESP-IDF partition table -> merged
entry point: 0x403c891c              # == bootloader entry in the ROM log
byte at 0x10000: 0xe9                # the app, inside the merged blob
```

So #207 wrote a bootloader into the app partition. The V4:

```
E esp_image: Segment 0 0x3fce2820-0x3fce3d34 invalid: overlaps bootloader stack
E boot: OTA app partition slot 0 is not bootable
E boot: No bootable app partitions in the partition table
```

Recovered by writing the same artifact at `0x0`; the device rejoined and is uplinking again (fCnt 0 → 1). The 2nd-stage bootloader at `0x0` was never touched, which is why it was recoverable.

## The fix

Read the kind off the bytes:

```python
where = 0x0 if is_merged_image(blob) else 0x10000
```

`is_merged_image` looks for the ESP image magic plus an ESP-IDF partition table at `0x8000`. That holds whichever artifact a given addon version serves — which is the property both the old code and its docstring lacked. `offset` overrides it explicitly.

The client docstring is corrected too, so the repo records what the addon actually returns.

## Tests

Fakes now serve realistically-shaped blobs — a merged image with a partition table at `0x8000`, and a bare app image — instead of the same opaque bytes for every path, which is what let both wrong versions pass.

```
FAILED test_merged_artifact_is_written_at_zero      # against #207 behaviour
1 failed, 17 passed
```

Full suite: **1017 passed, 12 skipped**.

## My mistake

I replaced verification with a docstring. The original #206 code had the offset right by accident; I "fixed" it into a brick, and the unit test could not catch either version because the fake served indistinguishable bytes. The check now reads the artifact, and the fakes now differ the way the real artifacts do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ