### PR TITLE
⚡ Bolt: [performance improvement] optimize readConnections and nextInstanceId

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-08-01 - Avoid new Set(arr.map()) for performance
 **Learning:** Constructing a Set by mapping an array via `new Set(arr.map(fn))` causes an unnecessary intermediate array allocation in memory before the Set is built. This can create garbage collection overhead in render loops or frequently called utilities.
 **Action:** Replace `new Set(arr.map(fn))` with a single-pass `for...of` loop to add items to a Set, avoiding the intermediate array entirely.
+
+## 2024-08-01 - Avoid allocating full objects to extract scalar IDs
+**Learning:** Helper functions like `readComponents(d)` allocate a full new object for every item in the array to provide a sanitized/normalized view. When a function only needs to extract primitive fields (like string `id`s for a Set or array), invoking these helpers wastes memory on object creation.
+**Action:** When extracting scalar fields from raw JSON-like structures (e.g. `d.components`), iterate directly over the raw array instead of calling normalizing helper functions, checking types manually to satisfy TypeScript.

--- a/web/src/lib/design.ts
+++ b/web/src/lib/design.ts
@@ -83,20 +83,25 @@ export function readConnections(d: Design | null, componentId?: string): Connect
       locksByCid.set(String(c.id), lp);
     }
   }
-  return (d.connections as Array<Record<string, unknown>>)
-    .map((c, index) => {
-      const cid = String(c.component_id);
-      const role = String(c.pin_role);
-      const locks = locksByCid.get(cid);
-      return {
-        index,
-        component_id: cid,
-        pin_role: role,
-        target: c.target as ConnectionTarget,
-        locked_pin: locks && typeof locks[role] === "string" ? locks[role] : null,
-      };
-    })
-    .filter((c) => !componentId || c.component_id === componentId);
+  // ⚡ Bolt: Use a single-pass loop to avoid intermediate array allocations from .map().filter()
+  const result: ConnectionRow[] = [];
+  const conns = d.connections as Array<Record<string, unknown>>;
+  for (let index = 0; index < conns.length; index++) {
+    const c = conns[index];
+    const cid = String(c.component_id);
+    if (componentId && cid !== componentId) continue;
+
+    const role = String(c.pin_role);
+    const locks = locksByCid.get(cid);
+    result.push({
+      index,
+      component_id: cid,
+      pin_role: role,
+      target: c.target as ConnectionTarget,
+      locked_pin: locks && typeof locks[role] === "string" ? locks[role] : null,
+    });
+  }
+  return result;
 }
 
 /**
@@ -276,7 +281,14 @@ export interface AddComponentOptions {
 /** Generate a unique component id derived from the library id. */
 export function nextInstanceId(d: Design, libraryId: string, hint?: string): string {
   const used = new Set<string>();
-  for (const c of readComponents(d)) used.add(c.id);
+  // ⚡ Bolt: iterate directly over the components array to avoid mapping it to intermediate ComponentInstance objects
+  if (Array.isArray(d.components)) {
+    for (const c of d.components) {
+      if (c && typeof c === "object" && typeof (c as Record<string, unknown>).id === "string") {
+        used.add((c as Record<string, unknown>).id as string);
+      }
+    }
+  }
   const safeHint = hint?.replace(/[^a-zA-Z0-9_]/g, "_");
   if (safeHint && !used.has(safeHint)) return safeHint;
   const base = libraryId.replace(/[^a-z0-9]/gi, "_");


### PR DESCRIPTION
💡 What: Refactored `readConnections` to use a single-pass loop instead of `.map().filter()`, and updated `nextInstanceId` to iterate over raw components instead of allocating new `ComponentInstance` objects via `readComponents(d)`.

🎯 Why: `readConnections` is called frequently (e.g., inside `useMemo` in `Inspector.tsx`) and the chained `.map().filter()` causes unnecessary O(N) array allocations. Similarly, `nextInstanceId` only needs string IDs, so creating full object mappings is wasteful.

📊 Impact: Reduces intermediate array allocations and object instantiation overhead, lowering garbage collection pressure when reading design files.

🔬 Measurement: Verify correctness by running `npm run test -- src/lib/design.test.ts`. Use standard profiling tools on the frontend to observe fewer object allocations when selecting/modifying components.

---
*PR created automatically by Jules for task [8466105509403350761](https://jules.google.com/task/8466105509403350761) started by @moellere*