### PR TITLE
release 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] — 2026-08-02
+
 ### Added
 
 - **MCP hardware tools — a headless client can now finish a bring-up.**
@@ -49,8 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and boot-looped a Heltec V4 (`No bootable app partitions in the
   partition table`). Recovered by rewriting the same artifact at `0x0`.
   The client docstring now records what the addon actually serves.
-
-### Fixed
 
 - **The `recommend` MCP tool was dead — it ran `library_detail` instead.**
   Two `@mcp.tool` decorators were stacked on one function. FastMCP's

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.26.3"
+__version__ = "0.27.0"


### PR DESCRIPTION
Cuts 0.27.0 — minor bump for the new MCP hardware tool surface.

## Added

**17 MCP hardware tools.** The design/library/fab tools stopped at the artifact; a headless client had to drop to HTTP to put firmware on a board. That workaround published unauthenticated flashing and provisioning, since `/api/mcp` is bearer-gated and the REST endpoints are not. Closes the gap recorded in #195.

- workbench: `workbench_status`, `workbench_slots`, `workbench_flash`
- LoRaWAN: `lorawan_chirpstack_status`, `lorawan_compile`, `lorawan_provision`, `lorawan_provision_esphome`, `lorawan_activation`, `lorawan_workbench_provision`
- fleet: `fleet_status`, `fleet_push`, `fleet_job_status`, `fleet_job_log`, `fleet_firmware_info`
- jobs: `job_status`, `job_events`, `job_list`

Long operations return a `job_id` and the client polls; fleet builds keep their own `run_id`, which outlives the process.

## Fixed

- `recommend` had been dead — two stacked `@mcp.tool` decorators bound both names to `library_detail` (#205)
- flash offset is now read from the artifact bytes rather than the endpoint that served them (#208)

## Verified on hardware

Driven as a real MCP client against staging with the live bench, ChirpStack and fleet addon: SLOT29 flashed (427728 bytes, hash verified, 44 job events, 16.7 s), fleet run status and firmware info resolved against a real build, `lorawan_activation` returned a live join.

The offset fix was found the hard way — an earlier attempt boot-looped a Heltec V4 by writing a merged image at the app offset. Recovered; device rejoined and is uplinking. The changelog records it.

Full suite: **1017 passed, 12 skipped**.

Also merges the two duplicate `### Fixed` sections that had accumulated under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ