### PR TITLE
fix(lorawan): bump component to the datarate fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **ESPHome LoRaWAN devices stopped uplinking once the network settled.**
+  A 12-byte payload (three float32 fields) joined fine, uplinked once or
+  twice, then failed with `RADIOLIB_ERR_PACKET_TOO_LONG` (-4) forever.
+  US915 DR0 caps the application payload at 11 bytes and ADR drives the
+  rate to DR0 on a strong link, so the failure appeared only after the
+  network had settled -- which made it look like a radio or provisioning
+  fault. Bumps `lorawan-for-esphome` to a build that re-asserts the
+  payload's minimum data rate before every uplink. The standalone
+  RadioLib path already did this; the ESPHome external-component path
+  never had it.
+
 ## [0.27.0] — 2026-08-02
 
 ### Added

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -18,7 +18,7 @@ sensor:
   lorawan_id: lw
   sensor: battery
 external_components:
-- source: github://moellere/lorawan-for-esphome@df1f6cd7ffe29f5a719ea684c23c26b629d1a5a4
+- source: github://moellere/lorawan-for-esphome@137d06ee47c47c0257b822a6d053870f6ecc021e
   components:
   - lorawan
 lorawan:

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -376,7 +376,7 @@ _LORAWAN_FOR_ESPHOME_REPO = "moellere/lorawan-for-esphome"
 # `dio2_as_rf_switch` and `setup_high` outright, and ESPHome refuses the
 # config rather than ignoring them. The previous pin (#2) carried the
 # sck/miso/mosi keys and nothing more.
-_LORAWAN_FOR_ESPHOME_REF = "df1f6cd7ffe29f5a719ea684c23c26b629d1a5a4"
+_LORAWAN_FOR_ESPHOME_REF = "137d06ee47c47c0257b822a6d053870f6ecc021e"
 
 
 def _emit_lorawan_blocks(


### PR DESCRIPTION
Found chasing the V4's DevAddr churn. The churn turned out to be my own resets — but the device was not uplinking at all, and this is why.

## Symptom

```
[W][lorawan:170]: uplink failed: -4      13:58:32
[W][lorawan:170]: uplink failed: -4      14:09:37
```

DevAddr `005793a1` stable for 25 minutes, `fCntUp` stuck at **0**. Joined, provisioned, decoding profile correct — and never uplinked. The gap between failures matches the 5-minute `uplink_interval` exactly.

## Cause

-4 is `RADIOLIB_ERR_PACKET_TOO_LONG`. The payload is 3 × `float32` = **12 bytes**; US915 **DR0 caps the application payload at 11**. The component never set a data rate, and ADR drives the rate to DR0 on a strong link — the V4 sits at rssi -49 with the gateway in the same building, so ADR went straight to the floor.

That timing is what makes it nasty: the device joins, uplinks a couple of times at the post-join rate, and only starts failing once ADR settles. It reads as a radio or provisioning fault.

## Fix

[lorawan-for-esphome#9](https://github.com/moellere/lorawan-for-esphome/pull/9) re-asserts the rate before **every** `sendReceive`, computed from the payload actually being sent. Once after join is not enough — ADR lowers it again.

The standalone RadioLib path in this repo has done exactly this since it hit the same -4 (`main.cpp.j2` sets it at setup *and* before each uplink). The external-component path never had it. Same bug, two code paths, fixed in one and not the other.

## Verification

Component CI: both `esphome compile` jobs pass, with the CI config now carrying three payload fields so the >11-byte shape stays compiled.

Golden regenerated — the diff is the single pinned-ref line:

```
-- source: github://moellere/lorawan-for-esphome@df1f6cd...
+- source: github://moellere/lorawan-for-esphome@137d06e...
```

Full suite: **1017 passed, 12 skipped**.

Hardware confirmation follows after this deploys and the V4 is reflashed — the -4 is reproducible on demand, so the fix is directly checkable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ