### PR TITLE
release 0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1] — 2026-08-02
+
+### Changed
+
+- `readConnections` uses a single-pass loop instead of a chained
+  `.map().filter()`, and `nextInstanceId` iterates the raw components
+  array rather than building throw-away `ComponentInstance` objects to
+  read their ids (#209).
+
 ### Fixed
 
 - **ESPHome LoRaWAN devices stopped uplinking once the network settled.**

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.27.0"
+__version__ = "0.27.1"


### PR DESCRIPTION
Patch release — ships the LoRaWAN datarate fix.

## Fixed

**ESPHome LoRaWAN devices stopped uplinking once the network settled** (#211). A payload over 11 bytes joined fine, uplinked once or twice, then failed with `RADIOLIB_ERR_PACKET_TOO_LONG` (-4) indefinitely. US915 DR0 caps the application payload at 11 bytes and ADR drives the rate to DR0 on a strong link, so the failure only appeared *after* the network settled — which made it read as a radio or provisioning fault rather than a payload-size one.

Bumps `lorawan-for-esphome` to [#9](https://github.com/moellere/lorawan-for-esphome/pull/9), which re-asserts the payload's minimum data rate before every uplink. Setting it once after join is not enough because ADR lowers it again. The standalone RadioLib path has done this since it hit the same error; the external-component path never had it.

### Verified on hardware

Heltec V4, SX1262, rssi -49 (gateway in the same building, so ADR went straight to DR0):

| | before | after |
|---|---|---|
| serial | `uplink failed: -4` every interval | `uplink sent (12 bytes)` ×4, **zero failures** |
| `fCntUp` | stuck at 0 for 25 min | 1 → 5 on 5-minute spacing |
| DevAddr | stable | stable |

## Changed

Records #209 (single-pass `readConnections`, `nextInstanceId` over the raw components array), which merged without a changelog entry.

Full suite: **1017 passed, 12 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ