### PR TITLE
ci: extend the changelog gate to web/src, exempt the Bolt stream

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,9 +1,21 @@
 name: changelog
 
-# Nudge, not a wall: if a PR changes shipped code under wirestudio/ but
-# leaves CHANGELOG.md untouched, fail with a hint. The point is to make
-# "does this need a changelog entry?" a conscious choice, not to block
-# refactors or test-only changes.
+# Nudge, not a wall: if a PR changes shipped code but leaves CHANGELOG.md
+# untouched, fail with a hint. The point is to make "does this need a
+# changelog entry?" a conscious choice, not to block refactors or
+# test-only changes.
+#
+# Shipped code is wirestudio/ *and* web/src/ -- the Dockerfile builds the
+# SPA and copies web/dist into the image, so a UI change reaches users the
+# same way a Python one does. web/ was outside this check for a long time,
+# which is why a dozen web-only PRs merged without an entry.
+#
+# The Bolt perf stream is exempt by title. Those PRs are machine-generated
+# single-pass-loop refactors with no behaviour change, and they are frequent
+# enough that requiring a label on each would just train people to bypass
+# the gate. Note the exemption cannot key on the author: Bolt PRs are opened
+# by a human account with the bot only as a commit co-author, so
+# `user.type == 'Bot'` never matches.
 #
 # Escape hatches (either one):
 #   - put [skip changelog] anywhere in the PR title, or
@@ -22,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       !contains(github.event.pull_request.title, '[skip changelog]') &&
+      !contains(github.event.pull_request.title, 'Bolt:') &&
       !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
     steps:
       - uses: actions/checkout@v4
@@ -35,10 +48,10 @@ jobs:
           changed=$(git diff --name-only "$BASE" "$HEAD")
           echo "Changed files:"
           echo "$changed"
-          code=$(echo "$changed" | grep -E '^wirestudio/' || true)
+          code=$(echo "$changed" | grep -E '^(wirestudio/|web/src/)' || true)
           changelog=$(echo "$changed" | grep -E '^CHANGELOG\.md$' || true)
           if [ -n "$code" ] && [ -z "$changelog" ]; then
-            echo "::error::Code under wirestudio/ changed but CHANGELOG.md was not updated."
+            echo "::error::Shipped code changed but CHANGELOG.md was not updated."
             echo "Add an entry under [Unreleased], or use [skip changelog] in the PR title / the skip-changelog label."
             exit 1
           fi


### PR DESCRIPTION
Follow-up to checking why #209 merged without a changelog entry.

## What I found

Nothing to do with bot authorship — my initial guess was wrong. The gate matched only `^wirestudio/`:

```bash
code=$(echo "$changed" | grep -E "^wirestudio/" || true)
```

#209 touched `.jules/bolt.md` and `web/src/lib/design.ts`. Neither matched, so the check passed exactly as written; it never evaluated the author at all.

**`web/` is shipped code.** The Dockerfile runs `npm run build` and copies `/web/dist` into the image, so a UI change reaches users the same way a Python one does. It was simply outside the gate — a dozen web-only PRs merged without an entry.

None were material: all perf refactors, which the gate's own comment says it does not want to block. But the feedback link (#194) was a **user-visible, web-only** feature, and its changelog entry existed only because the author chose to write one.

## The author check does not work

Worth recording, because it is the obvious thing to reach for:

```
$ gh api repos/moellere/WireStudio/pulls/209 -q .user.type
User
```

Bolt PRs are opened by a **human account** with the bot only as a commit co-author. `user.type == 'Bot'` never matches, so an author-based exemption would have failed open and made every Bolt PR trip the widened gate. The exemption is keyed on the `Bolt:` title prefix instead, which is consistent across the stream (verified on 5 of them) and matches how the existing `[skip changelog]` hatch already works.

## Backtest

Replayed both rule sets over the last 120 first-parent commits. Four verdicts change, all human-authored web refactors that would now need `[skip changelog]`:

```
1bf6af9   WOULD NOW FAIL   refactor(web): single-pass loops for ConnectionForm
81f98af   WOULD NOW FAIL   perf(ui): avoid O(N) traversal in InventoryDialog search
9dfb263   WOULD NOW FAIL   refactor(inspector): memoize category grouping
2809dd4   WOULD NOW FAIL   perf(inspector): memoize compatibility warnings
```

Every `⚡ Bolt:` PR is exempt. That ~3% friction is the deliberate cost of the wider scope; the escape hatches are unchanged.

Note this PR touches neither `wirestudio/` nor `web/src/`, so the gate does not fire on it — CI-only changes are not product changelog material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ