### PR TITLE
⚡ Bolt: [performance improvement] Replace .includes with strict equality in WiringView buildModel loop

### DIFF
--- a/web/src/components/WiringView.tsx
+++ b/web/src/components/WiringView.tsx
@@ -237,7 +237,7 @@ function buildModel(design: Design) {
     id: String(b.id ?? ""),
     type: String(b.type ?? ""),
     pins: Object.entries(b).filter(
-      ([k, v]) => !["id", "type", "frequency_hz"].includes(k) && typeof v === "string" && /^(GPIO|D|A)\d/i.test(String(v)),
+      ([k, v]) => k !== "id" && k !== "type" && k !== "frequency_hz" && typeof v === "string" && /^(GPIO|D|A)\d/i.test(String(v)),
     ) as Array<[string, string]>,
   }));
 


### PR DESCRIPTION
What: Replaced `!["id", "type", "frequency_hz"].includes(k)` with `k !== "id" && k !== "type" && k !== "frequency_hz"` in the `.filter` callback inside `buildModel` for `buses` parsing.
Why: The `.includes` method executes an O(N) array traversal per iteration. Inside a tight rendering loop like `buildModel` filtering through object keys, this can cause unnecessary overhead and garbage collection from the static array allocation.
Impact: Eliminates O(N) array traversals per iteration, converting them to direct O(1) strict inequality comparisons.
Measurement: This micro-optimization reduces render time by saving allocations and iterations, which can be measured through React DevTools profiler during intensive graph manipulation.

---
*PR created automatically by Jules for task [16801871774839372403](https://jules.google.com/task/16801871774839372403) started by @moellere*