### PR TITLE
docs: catch README up to 0.27.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ release factory image for the radio boards), and **CircuitPython**
 (official release image plus a generated starter `code.py` for the
 CIRCUITPY drive).
 
+WebSerial needs the board on the end of a cable. A **remote workbench**
+removes that: point the studio at a
+[SensorsIot Embedded AI Harness](https://github.com/SensorsIot/Embedded-AI-Harness)
+— a Raspberry Pi exposing every USB-attached board as a network
+resource — and flashing, LoRaWAN key provisioning and join verification
+all run against a slot on a bench somewhere else
+([workbench](docs/workbench.md)). The MCP server carries the same
+reach: alongside the design tools it exposes workbench, ChirpStack and
+fleet-build tools, so a headless client can take a design from
+`design.json` to a joined device without dropping to HTTP
+([MCP](docs/mcp.md)).
+
 Not affiliated with the ESPHome project — see
 [`weirded/fleet-for-esphome`](https://github.com/weirded/fleet-for-esphome)
 for the OTA-deploy companion this studio's **Push to fleet** flow
@@ -51,17 +63,18 @@ Detailed docs live in [`docs/`](docs/):
 - [Deployment](docs/deployment.md) — self-host with Docker or Kubernetes.
 - [Integrations](docs/integrations.md) — agent, fleet handoff, enclosure search, KiCad.
 - [MCP server](docs/mcp.md) — drive the studio from Claude Code / Desktop.
+- [Workbench](docs/workbench.md) — flash and provision boards on a remote bench.
 - [Library reference](docs/library.md) — every board and component.
 - [LoRaWAN target](docs/lorawan/) — build + flash LoRaWAN firmware, provision against ChirpStack.
 
 ## Status
 
-`v0.24.0` — on PyPI (`pip install wirestudio`). The studio has wide
+`v0.27.1` — on PyPI (`pip install wirestudio`). The studio has wide
 surface area (YAML, schematic, PCB + fab outputs, enclosure, agent,
-MCP server, fleet handoff, web UI, two LoRaWAN flash/provision paths —
-standalone Arduino and an external-component path that emits ESPHome
-YAML referencing `lorawan-for-esphome`) and a set of things actually
-verified against upstream tools. The YAML, schematic, PCB, and
+MCP server, fleet handoff, remote workbench, web UI, two LoRaWAN
+flash/provision paths — standalone Arduino and an external-component
+path that emits ESPHome YAML referencing `lorawan-for-esphome`) and a
+set of things actually verified against upstream tools. The YAML, schematic, PCB, and
 enclosure paths are gated in CI, and **every library component and
 board is exercised by a bundled example** that passes those gates. This section is honest about which is which, ordered
 by how much it matters that it works.
@@ -78,10 +91,12 @@ Tiers, in priority order:
 | **Verified** | Fab outputs | JLCPCB upload bundle — BOM, CPL, Gerber + drill (`/design/fab/*`) | CPL positions match the `.kicad_pcb` placement; the DRC tier smoke-tests the Gerber export. Boards are unrouted until the Freerouting step, so Gerbers carry pads but no traces (`is_routed` flags it) |
 | **Verified** | Parametric enclosure | OpenSCAD `.scad` from board mount-hole metadata | every enclosure-capable board renders through real OpenSCAD to a non-empty, manifold (closed, printable) solid, every PR ([gate](.github/workflows/enclosure-render.yml)) |
 | **Works (hardware-validated)** | LoRaWAN target | build RadioLib + LoRaWAN_ESP32 firmware for US915 radio boards, flash over WebSerial, provision against ChirpStack | every radio board's firmware builds in CI ([gate](.github/workflows/lorawan-firmware.yml)); validated end-to-end on a TTGO T-Beam and Heltec WiFi LoRa 32 V2 and V3 against live ChirpStack 4.17 — no automated live-device gate |
+| **Works (hardware-validated)** | LoRaWAN external-component path | emit ESPHome YAML referencing `lorawan-for-esphome`, provision keys into `secrets.yaml`, build through fleet | validated end-to-end on a Heltec WiFi LoRa 32 V4 (SX1262 + external PA): joined, uplinked and decoded against live ChirpStack. Payloads over 11 bytes need the data rate asserted per uplink — US915 DR0 caps at 11 and ADR drives to DR0 on a strong link. No automated live-device gate |
+| **Works (hardware-validated)** | Remote workbench | flash a board on a bench slot, and run the whole LoRaWAN bring-up (flash → register → key push → verify) headlessly | wire format verified against a reference bench; flashing and LoRaWAN bring-up exercised repeatedly on a live Pi bench with an ESP32-S3. Transport tests in `tests/test_workbench.py` use wire-level fakes; no automated live-bench gate |
 | **Verified** | Tasmota target | emit a Tasmota device template (`/tasmota/template`) mapping solved pins to Tasmota GPIO function ids | function ids + per-chip layouts sourced from `tasmota_template.h`; unit tests pin the Sonoff S31 template convention for the smart-plug example |
 | **Works (lighter checks)** | Meshtastic flashing | proxy the official release factory image (`/meshtastic/firmware`) for the radio boards and flash it via the unified WebSerial dialog | endpoint tests with mocked upstream; board-to-variant map checked against `meshtastic/firmware` variants; no live-flash gate |
 | **Works (lighter checks)** | CircuitPython flashing | proxy the official release image (`/circuitpython/firmware`) for ESP32/S3/C3/C6 boards, flash via the unified dialog, serve a generated starter `code.py` (`/circuitpython/code`) | endpoint tests with mocked upstream; every board-id mapping verified against downloads.circuitpython.org; generated starters parse as valid Python; no live-flash gate |
-| **Works (lighter checks)** | MCP server | drive the design tools from Claude Code / Desktop over the Model Context Protocol | tool / auth / resource tests in `tests/test_mcp_*.py`; not exercised against a live MCP client in CI |
+| **Works (lighter checks)** | MCP server | 39 tools over the Model Context Protocol: 22 design/library/fab, plus 17 that reach hardware — workbench flash, LoRaWAN compile / provision / activation, fleet push + build status, and job polling for the long ones | tool / auth / resource tests in `tests/test_mcp_*.py`; the hardware tools drive the real clients against wire-level fakes, and were exercised against a live bench, ChirpStack and fleet during bring-up. Not run against a live MCP client in CI |
 | **Experimental** | Thingiverse search relay | rank community models for a board | smoke-tested; depends on a third-party search API that ranks unevenly |
 | **Experimental** | Agent (Claude tool-using) | natural-language design driving | works in practice; tool surface is small; no auto-eval against task list yet |
 | **Verified** | PCB autorouting | Freerouting roundtrip — board → Specctra DSN → routed → SES import; SSE route endpoint, `route_pcb` MCP/agent tool, web-UI Route button, `?route=true` fab exports, `-pcb` image variant | representative examples route with zero unconnected items and pass routed DRC ([gate](.github/workflows/pcb-route.yml)) |
@@ -106,7 +121,7 @@ that pin moves, this line moves with it.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:0.24.0
+  ghcr.io/moellere/wirestudio:0.27.1
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +
@@ -149,7 +164,7 @@ The [User guide](docs/user_guide.md) walks the panes and header actions.
 ## Tests
 
 ```sh
-python -m pytest                          # ~900 cases
+python -m pytest                          # ~1030 cases
 python -m ruff check .                    # lint
 cd web && npx vitest run                  # vitest + jsdom
 pip install 'esphome==2025.12.7'

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,7 +11,7 @@ FastAPI serves the API and the built SPA from one process.
 docker run --rm -p 8765:8765 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -v wirestudio-data:/data \
-  ghcr.io/moellere/wirestudio:0.24.0
+  ghcr.io/moellere/wirestudio:0.27.1
 ```
 
 Open <http://localhost:8765>. The image bundles the FastAPI server +
@@ -23,12 +23,12 @@ Available tags:
 
 | Tag | What it tracks |
 |---|---|
-| `:0.24.0` / `:0.24` / `:latest` | the v0.24.0 release |
+| `:0.27.1` / `:0.27` / `:latest` | the v0.27.1 release |
 | `:main` | latest commit on `main` (rolling) |
 | `:sha-<short>` | a specific commit |
-| `:<tag>-lorawan` (e.g. `:main-lorawan`, `:0.24.0-lorawan`) | same image **plus** the LoRaWAN compile worker (PlatformIO baked in) — see below |
-| `:<tag>-pcb` (e.g. `:main-pcb`, `:0.24.0-pcb`) | the PCB toolchain variant: KiCad 8 (kicad-cli + pcbnew), the pinned symbol/footprint libraries, a JRE, and Freerouting — everything the board/fab/autoroute endpoints gate on — see below |
-| `:<tag>-full` (e.g. `:main-full`, `:0.24.0-full`) | the every-feature image prod runs: `-pcb` **plus** the LoRaWAN compile worker (PlatformIO + prewarmed espressif32) |
+| `:<tag>-lorawan` (e.g. `:main-lorawan`, `:0.27.1-lorawan`) | same image **plus** the LoRaWAN compile worker (PlatformIO baked in) — see below |
+| `:<tag>-pcb` (e.g. `:main-pcb`, `:0.27.1-pcb`) | the PCB toolchain variant: KiCad 8 (kicad-cli + pcbnew), the pinned symbol/footprint libraries, a JRE, and Freerouting — everything the board/fab/autoroute endpoints gate on — see below |
+| `:<tag>-full` (e.g. `:main-full`, `:0.27.1-full`) | the every-feature image prod runs: `-pcb` **plus** the LoRaWAN compile worker (PlatformIO + prewarmed espressif32) |
 
 All feature-gating env vars are optional — the studio runs without any
 of them, just with the corresponding feature turned off. See
@@ -97,7 +97,7 @@ so both run side by side from one source tree with independent PVCs.
 
 | App | Overlay | Image | Upgrades when |
 |---|---|---|---|
-| `wirestudio-prod` | `deploy/overlays/prod` | pinned release, e.g. `:0.24.0-full` | the tag changes in git (bump by hand or via image-updater) |
+| `wirestudio-prod` | `deploy/overlays/prod` | pinned release, e.g. `:0.27.1-full` | the tag changes in git (bump by hand or via image-updater) |
 | `wirestudio-dev` | `deploy/overlays/dev` | rolling `:main-lorawan` | image-updater digest-pins a new `main` build |
 
 ```sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,9 +17,9 @@ under upstream ESPHome.
   in the library.
 - [Library coverage](library-coverage.md) — which library entries are
   exercised by a bundled example.
-- [Workbench integration](workbench.md) — planned hardware-truth layer
-  on a Universal Embedded Workbench: capability map, phases,
-  constraints.
+- [Workbench integration](workbench.md) — hardware-truth layer on an
+  Embedded AI Harness: remote flash and headless LoRaWAN bring-up
+  (shipped), capability map, later phases, constraints.
 
 ## Architecture
 
@@ -218,8 +218,8 @@ anything that can route to the pod. That is survivable while the only
 exposure is a cluster-internal Service, and is the reason the ingress
 publishes `/mcp` alone.
 
-**Workbench featureset (planned).** Integrate a
-[Universal Embedded Workbench](https://github.com/SensorsIot/Universal-Embedded-Workbench)
+**Workbench featureset (phase 1 shipped).** Integrate an
+[Embedded AI Harness](https://github.com/SensorsIot/Embedded-AI-Harness)
 (Raspberry Pi exposing RFC2217 network serial per USB slot, a JSON HTTP
 API, a WiFi AP tester, an MQTT broker, UDP logging, GPIO boot/reset
 control, and an optional RTL-SDR) as the studio's hardware truth layer.
@@ -236,7 +236,11 @@ Phases, each independently shippable. Note the payoff is not evenly
 distributed: phase 1 is what makes a remote bench reachable at all,
 and phase 3 is what retires the "no live-flash gate" caveats above.
 
-1. **Remote flash transport.** `/workbench/status`, `/workbench/slots`
+1. **Remote flash transport — shipped in 0.25.0**, extended in 0.26.0
+   with the headless LoRaWAN bring-up
+   (`/lorawan/workbench/provision`: flash → register → push keys over
+   the slot's serial prompt → verify the join) and in 0.27.0 with the
+   MCP tools that drive both. `/workbench/status`, `/workbench/slots`
    and `/workbench/flash`: the server fetches the framework image
    exactly as today, uploads it to the bench, and streams progress over
    SSE while the Pi runs esptool against its own USB. The flash dialog

--- a/docs/workbench.md
+++ b/docs/workbench.md
@@ -1,13 +1,22 @@
-# Workbench integration (planned)
+# Workbench integration
 
 [← docs index](index.md)
 
-Scoping for integrating a
-[SensorsIot Universal Embedded Workbench](https://github.com/SensorsIot/Universal-Embedded-Workbench)
-— a Raspberry Pi that exposes every USB-attached dev board as a network
-resource — as the studio's hardware truth layer. Roadmap placement and
-phase status live in [index.md](index.md#roadmap); this page carries the
-full capability map and design constraints.
+Integrating a
+[SensorsIot Embedded AI Harness](https://github.com/SensorsIot/Embedded-AI-Harness)
+(formerly Universal Embedded Workbench) — a Raspberry Pi that exposes
+every USB-attached dev board as a network resource — as the studio's
+hardware truth layer. Roadmap placement and phase status live in
+[index.md](index.md#roadmap); this page carries the full capability map
+and design constraints.
+
+**Phase 1 has shipped** (0.25.0): remote flash transport, slot listing
+with pre-flight, and — from 0.26.0 — the whole LoRaWAN bring-up
+(flash → register in ChirpStack → push keys over the slot's serial
+prompt → verify the join) against a bench slot, with no human at the
+bench. 0.27.0 put the same reach behind MCP tools. Later phases
+(continuous serial relay, scheduled flashing, a live-device CI gate)
+are still scoping; the phase table below marks which is which.
 
 ## Why
 


### PR DESCRIPTION
The README last moved at **0.24.0** — nine releases back.

## Stale facts corrected

| Claim | Was | Now |
|---|---|---|
| Version | `v0.24.0` | `v0.27.1` |
| Docker tag | `:0.24.0` | `:0.27.1` |
| Test count | `~900 cases` | `~1030` (1029 collected) |
| MCP server | "drive the design tools" | 39 tools — 22 design, 17 hardware |
| LoRaWAN validation | T-Beam, V2, V3 | + V4 on the external-component path |

`docs/deployment.md` carried seven more `0.24.0` image tags; those are bumped too.

## Two shipped features were missing entirely

**Remote workbench** (0.25.0, extended 0.26.0). It has its own doc page and the README never linked to it. Flashing a board on a bench slot — and running the whole LoRaWAN bring-up headlessly — is arguably the most consequential thing added since 0.24, because it removes the requirement that the developer be in the same room as the board. Now in the intro, the docs list, and the tier table.

**MCP hardware tools** (0.27.0). Took the surface from 22 tools to 39 and let a headless client finish a bring-up without dropping to HTTP.

## The workbench docs still said "planned"

`workbench.md`'s title, its intro paragraph, the `index.md` docs list, and the roadmap entry all described it as future work, three releases after phase 1 shipped and after the bring-up had been run repeatedly against a live bench. Phase 1 is now marked shipped with what extended it; phases 2 and 3 are left as scoping, which is still what they are.

Also picks up the upstream rename: `SensorsIot/Universal-Embedded-Workbench` → `SensorsIot/Embedded-AI-Harness`.

## On the new tier rows

Written to the same bar as the rest of the table — hardware-validated, with the *absence* of an automated live gate stated rather than glossed:

> flashing and LoRaWAN bring-up exercised repeatedly on a live Pi bench with an ESP32-S3. Transport tests in `tests/test_workbench.py` use wire-level fakes; no automated live-bench gate

The external-component row also records the DR0/11-byte payload constraint, since that one cost a day and is invisible until ADR settles.

## Checks

Suite: **1017 passed, 12 skipped**. All 18 README table rows well-formed. No `0.24.x` references remain outside `CHANGELOG.md` and one historical note about the `mcp<2` pin — which I verified is still real (`mcp>=1.27,<2` in `pyproject.toml`, 1.27.1 installed).

Docs-only, so the changelog gate correctly does not fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ