### PR TITLE
fix(examples): battery sense on GPIO35 with the 1:2 divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The LoRaWAN battery example sampled the wrong ADC pin.** The
+  `lorawan-battery-uplink` design wired its ADC to `GPIO36` and applied
+  no scaling, while both `ttgo-lora32-v1` and `-v2` carry
+  `battery_adc: {pin: GPIO35, divider: 2.0}` -- GPIO35 is the pin tagged
+  `battery_sense`, and the pack is read through a 1:2 divider. So the
+  example sampled an unconnected pin and, even on the right one, would
+  have reported half the pack voltage while labelled `V`. Now GPIO35
+  with a `multiply: 2.0` filter. The board metadata was already correct;
+  nothing consulted it, because the design pinned the connection
+  explicitly.
+
 ## [0.27.1] — 2026-08-02
 
 ### Changed

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -8,12 +8,14 @@ esp32:
 logger: {}
 sensor:
 - platform: adc
-  pin: GPIO36
+  pin: GPIO35
   name: Battery
   id: battery
   attenuation: 12db
   update_interval: 30s
   unit_of_measurement: V
+  filters:
+  - multiply: 2.0
 - platform: lorawan
   lorawan_id: lw
   sensor: battery

--- a/wirestudio/examples/lorawan-battery-uplink.json
+++ b/wirestudio/examples/lorawan-battery-uplink.json
@@ -30,7 +30,8 @@
       "params": {
         "attenuation": "12db",
         "update_interval": "30s",
-        "unit_of_measurement": "V"
+        "unit_of_measurement": "V",
+        "filters": [{ "multiply": 2.0 }]
       }
     }
   ],
@@ -38,7 +39,7 @@
   "buses": [],
 
   "connections": [
-    { "component_id": "battery", "pin_role": "IN", "target": { "kind": "gpio", "pin": "GPIO36" } }
+    { "component_id": "battery", "pin_role": "IN", "target": { "kind": "gpio", "pin": "GPIO35" } }
   ],
 
   "passives": [],


### PR DESCRIPTION
The `lorawan-battery-uplink` design wired its ADC to `GPIO36` with no scaling. Both `ttgo-lora32-v1` and `-v2` declare:

```yaml
battery_adc:  {pin: GPIO35, divider: 2.0}
GPIO35: [gpio, adc, adc1, input_only, battery_sense, ...]
GPIO36: [gpio, adc, adc1, input_only, ...]          # no battery_sense tag
```

Two faults, either one enough on its own:

- **Wrong pin** — GPIO36 has nothing attached, so it samples an unconnected input.
- **No divider** — the pack is read through 1:2, so even on the right pin the value would be *half* the battery voltage, while still labelled `V`.

## Not a generator bug

The board metadata was already right. Nothing consulted it, because the design pins the connection explicitly:

```json
{"component_id": "battery", "pin_role": "IN",
 "target": {"kind": "gpio", "pin": "GPIO36"}}
```

The generator emitted exactly what it was asked for. This is a bad example, not a bad renderer — worth saying, because the obvious next move would have been to go hunting in `yaml_gen`.

## Golden

```diff
 - platform: adc
-  pin: GPIO36
+  pin: GPIO35
   name: Battery
   ...
   unit_of_measurement: V
+  filters:
+  - multiply: 2.0
```

Verified through real ESPHome, not just the goldens: `INFO Configuration is valid!`

Full suite: **1017 passed, 12 skipped**.

## How it surfaced, and what it did not show

Checking decoded uplinks across all ChirpStack devices, this one reported `{"battery": 0.142}`. I initially called that a floating pin — wrong inference: the device has **no battery attached**, so a correctly-wired GPIO35 would read low too. That number never discriminated between the two. The config discrepancy is real and confirmed against the board files; the uplink value simply was not the evidence for it.

Also noting a divergence this turned up, not addressed here: the bundled example declares `ttgo-lora32-v1` while the deployed fleet config for the same DevEUI says `ttgo-lora32-v2`. The battery pin is GPIO35 on both, so the fix holds either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ