### PR TITLE
release 0.27.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.2] — 2026-08-16
+
 ### Fixed
 
 - **The LoRaWAN battery example sampled the wrong ADC pin.** The
@@ -19,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with a `multiply: 2.0` filter. The board metadata was already correct;
   nothing consulted it, because the design pinned the connection
   explicitly.
+
+### Changed
+
+- `buildModel` in `WiringView.tsx` builds its bus list with a single-pass
+  loop instead of `.map().filter()`, and compares keys with `!==` rather
+  than `Array.includes` (#214). No behaviour change.
 
 ## [0.27.1] — 2026-08-02
 

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.27.1"
+__version__ = "0.27.2"


### PR DESCRIPTION
Patch release — the LoRaWAN battery example fix.

## Fixed

**The `lorawan-battery-uplink` example sampled the wrong ADC pin** (#217). It wired the ADC to `GPIO36` with no scaling, while both `ttgo-lora32-v1` and `-v2` declare:

```yaml
battery_adc: {pin: GPIO35, divider: 2.0}
GPIO35: [..., battery_sense, ...]     # GPIO36 has no such tag
```

Two faults: the wrong pin samples an unconnected input, and the missing multiplier would report half the pack voltage even once the pin was right — while still labelled `V`. Now GPIO35 with `filters: [multiply: 2.0]`.

Not a generator bug — the design pinned the connection explicitly, so the renderer emitted exactly what it was asked for. The board metadata was already correct; nothing consulted it.

Verified through real ESPHome (`Configuration is valid!`), not just the golden.

## Changed

Records #214 (single-pass `buildModel`, `!==` instead of `Array.includes`). It merged under the `Bolt:` title exemption added in #213, so the changelog gate never asked for an entry — same treatment #209 got in 0.27.1.

## Not included

#213 (CI gate scope) and #216 (docs refresh) are on `main` but change no shipped code, so they carry no changelog entries.

## Hardware status

The corresponding fleet config is patched and compiled, but **the device has not been reflashed** — its USB bridge is off the bus and a VBUS power cycle proved the board is powered from elsewhere, i.e. the cable is disconnected. It needs physical access at the remote site. Harmless meanwhile: no battery is attached, so the wrong pin costs nothing.

Full suite: **1017 passed, 12 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ