### PR TITLE
feat(mcp): migrate to mcp 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Migrated to mcp 2.x**, lifting the `mcp<2` pin carried since 0.24.1.
+  2.0 renamed the server package `mcp.server.fastmcp` ->
+  `mcp.server.mcpserver` and the class `FastMCP` -> `MCPServer`; the
+  decorator, resource and transport API is otherwise unchanged, so the
+  39 tools and their registrations move across as-is.
+
+  Three breaks needed real changes rather than a rename:
+  `Settings` no longer carries `transport_security` (it is now an
+  argument to `streamable_http_app()`, which is where it was always
+  used); `call_tool` returns a `CallToolResult` instead of a bare
+  content sequence; and the model fields are snake_case
+  (`inputSchema` -> `input_schema`, `uriTemplate` -> `uri_template`).
+
+  Note mcp 2.x depends on **httpx2**, a separate distribution from
+  httpx. The import names differ, so it coexists with the studio's own
+  httpx usage rather than replacing it -- but it is a second HTTP stack
+  in the image.
+
 ## [0.27.2] — 2026-08-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "anthropic>=0.40",
     "httpx>=0.27",
     "slowapi>=0.1.9",
-    "mcp>=1.27,<2",
+    "mcp>=2.0,<3",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_active_design.py
+++ b/tests/test_active_design.py
@@ -33,8 +33,9 @@ def _seed_design(store: FileDesignStore, design_id: str = "active-test") -> str:
     return design_id
 
 
-def _tool_payload(content: list[Any]) -> dict:
-    """Decode the first TextContent payload as JSON."""
+def _tool_payload(result: Any) -> dict:
+    """Decode the first TextContent payload of a CallToolResult as JSON."""
+    content = result.content
     assert content
     text = getattr(content[0], "text", None)
     assert isinstance(text, str)

--- a/tests/test_mcp_hardware.py
+++ b/tests/test_mcp_hardware.py
@@ -54,10 +54,9 @@ def _seed(store: FileDesignStore, design_id: str = "bench-dut") -> str:
 
 
 def _payload(result: Any) -> dict:
-    """Decode a FastMCP call_tool result into its JSON dict."""
-    content = result[0] if isinstance(result, tuple) else result
-    if isinstance(content, dict):
-        return content
+    """Decode an MCPServer call_tool result into its JSON dict."""
+    content = result.content
+    assert content, "expected at least one content block"
     text = getattr(content[0], "text", None)
     assert isinstance(text, str), f"unexpected content: {content!r}"
     return json.loads(text)

--- a/tests/test_mcp_resources.py
+++ b/tests/test_mcp_resources.py
@@ -79,7 +79,7 @@ async def test_static_resources_registered(mcp_server):
 async def test_template_resources_registered(mcp_server):
     server, _ = mcp_server
     templates = await server.list_resource_templates()
-    uris = {t.uriTemplate for t in templates}
+    uris = {t.uri_template for t in templates}
     assert EXPECTED_TEMPLATE_URIS <= uris
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -77,8 +77,9 @@ def _seed_design(store: FileDesignStore, design_id: str = "test-bench") -> str:
     return design_id
 
 
-def _content_to_dict(content: list[Any]) -> dict:
-    """Decode the first TextContent payload as JSON."""
+def _content_to_dict(result: Any) -> dict:
+    """Decode the first TextContent payload of a CallToolResult as JSON."""
+    content = result.content
     assert content, "expected at least one content block"
     text = getattr(content[0], "text", None)
     assert isinstance(text, str)
@@ -129,12 +130,12 @@ async def test_every_tool_binds_a_distinct_function(mcp_server):
 async def test_recommend_takes_a_query_not_a_library_id(mcp_server):
     server, _ = mcp_server
     tools = {t.name: t for t in await server.list_tools()}
-    params = set(tools["recommend"].inputSchema.get("properties", {}))
+    params = set(tools["recommend"].input_schema.get("properties", {}))
     assert "query" in params
     assert "library_id" not in params
 
     result = await server.call_tool("recommend", {"query": "temperature"})
-    payload = _content_to_dict(result[0] if isinstance(result, tuple) else result)
+    payload = _content_to_dict(result)
     assert payload.get("ok") is not False, payload
 
 
@@ -143,7 +144,7 @@ async def test_tool_input_schemas_include_design_id_for_mutating_tools(mcp_serve
     tools = {t.name: t for t in await server.list_tools()}
     for name in {"set_board", "add_component", "remove_component", "set_param",
                  "set_connection", "add_bus", "solve_pins", "render", "validate"}:
-        schema = tools[name].inputSchema
+        schema = tools[name].input_schema
         assert "design_id" in schema.get("properties", {}), f"{name} missing design_id"
 
 
@@ -236,7 +237,7 @@ async def test_remove_component_persists(mcp_server):
 
 async def test_unknown_design_id_surfaces_as_tool_error(mcp_server):
     server, _ = mcp_server
-    # Unknown design_id triggers FileNotFoundError in the store. FastMCP's
+    # Unknown design_id triggers FileNotFoundError in the store. MCPServer's
     # contract is that tool exceptions become an isError-flagged result;
     # call_tool itself raises ToolError so the model can recover instead
     # of seeing a black-hole response.

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -22,6 +22,7 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 import os
+from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import ValidationError
 
 from wirestudio.mcp import (
@@ -256,7 +257,7 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(_: FastAPI):
-        # FastMCP's session_manager wraps the streamable_http_app; without
+        # MCPServer's session_manager wraps the streamable_http_app; without
         # entering its run() context the /mcp endpoint 500s with "Task group
         # is not initialized." AsyncExitStack lets us no-op when MCP is
         # disabled without a duplicate yield branch.
@@ -1483,11 +1484,17 @@ def create_app(
         # `/mcp` on its own Starlette app; we wrap it in BearerTokenMiddleware
         # and mount at root so the path stays `/mcp`. Mounting at `/mcp` would
         # land the inner route at `/mcp/mcp`, which is wrong.
+        # mcp 2.x dropped `transport_security` from Settings; it is now an
+        # argument to streamable_http_app(), which is where it was always
+        # used. Built here and passed at mount time below.
         allowed_hosts = os.environ.get("WIRESTUDIO_MCP_ALLOWED_HOSTS")
+        transport_security = None
         if allowed_hosts:
-            mcp_server.settings.transport_security.allowed_hosts = [
-                h.strip() for h in allowed_hosts.split(",") if h.strip()
-            ]
+            hosts = [h.strip() for h in allowed_hosts.split(",") if h.strip()]
+            if hosts:
+                transport_security = TransportSecuritySettings(
+                    allowed_hosts=hosts
+                )
         token_path_env = os.environ.get("WIRESTUDIO_MCP_TOKEN_PATH")
         token_store = load_token_store(
             token_path=Path(token_path_env) if token_path_env else None,
@@ -1513,7 +1520,9 @@ def create_app(
                 raise HTTPException(status_code=409, detail=str(e)) from e
             return McpTokenResponse(token=new_token, managed="file")
 
-        mcp_app = mcp_server.streamable_http_app()
+        mcp_app = mcp_server.streamable_http_app(
+            transport_security=transport_security
+        )
         mcp_app.add_middleware(BearerTokenMiddleware, store=token_store)
         app.mount("/", mcp_app)
 

--- a/wirestudio/api/serve.py
+++ b/wirestudio/api/serve.py
@@ -41,7 +41,7 @@ def create_serve_app(static_dir: str | Path) -> FastAPI:
         raise FileNotFoundError(f"static_dir does not exist: {static_path}")
     studio_app = create_app()
     # Mounted sub-apps in FastAPI/Starlette don't get their lifespan run by
-    # the parent. The studio_app uses lifespan to enter the FastMCP session
+    # the parent. The studio_app uses lifespan to enter the MCPServer session
     # manager's run() context; without forwarding it the manager stays
     # uninitialized and /api/mcp returns 500. Re-using studio_app's
     # lifespan_context here runs it once on the parent's startup.

--- a/wirestudio/mcp/hardware.py
+++ b/wirestudio/mcp/hardware.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import base64
 from typing import Any, Callable, Optional
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from wirestudio.designs.active import ActiveDesignTracker
 from wirestudio.designs.store import DesignStore
@@ -108,7 +108,7 @@ def _decode_images(raw: Optional[list[dict]]) -> list[tuple[int, bytes]]:
 
 
 def register_hardware_tools(
-    mcp: FastMCP,
+    mcp: MCPServer,
     library: Library,
     designs: DesignStore,
     active: ActiveDesignTracker,
@@ -162,7 +162,7 @@ def register_hardware_tools(
 # Job polling
 # ---------------------------------------------------------------------------
 
-def _register_job_tools(mcp: FastMCP, jobs: JobRegistry) -> None:
+def _register_job_tools(mcp: MCPServer, jobs: JobRegistry) -> None:
     @mcp.tool(
         name="job_status",
         description=(
@@ -210,7 +210,7 @@ def _register_job_tools(mcp: FastMCP, jobs: JobRegistry) -> None:
 # ---------------------------------------------------------------------------
 
 def _register_workbench_tools(
-    mcp: FastMCP,
+    mcp: MCPServer,
     jobs: JobRegistry,
     workbench: Callable[[], Any],
     fleet: Callable[[], Any],
@@ -359,7 +359,7 @@ def _register_workbench_tools(
 # ---------------------------------------------------------------------------
 
 def _register_lorawan_tools(
-    mcp: FastMCP,
+    mcp: MCPServer,
     library: Library,
     jobs: JobRegistry,
     load_model: Callable[[Optional[str]], tuple[Optional[Design], Optional[dict]]],
@@ -626,7 +626,7 @@ def _register_lorawan_tools(
 # ---------------------------------------------------------------------------
 
 def _register_fleet_tools(
-    mcp: FastMCP,
+    mcp: MCPServer,
     library: Library,
     load_model: Callable[[Optional[str]], tuple[Optional[Design], Optional[dict]]],
     fleet: Callable[[], Any],

--- a/wirestudio/mcp/server.py
+++ b/wirestudio/mcp/server.py
@@ -10,7 +10,7 @@ Resources expose read-only views over the library and stored designs:
 - `library://boards` + `library://boards/{id}` for boards
 - `design://{id}/{format}` for rendered design output (json / yaml / ascii)
 
-The server is a `FastMCP` instance. The caller is responsible for mounting
+The server is an `MCPServer` instance. The caller is responsible for mounting
 its `streamable_http_app()` into the parent FastAPI app and arranging
 `session_manager.run()` in the parent's lifespan.
 """
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from wirestudio.agent.tools import (
     _run_add_bus,
@@ -59,8 +59,8 @@ def build_mcp_server(
     hardware: bool = True,
     workbench_factory: Optional[Callable[[], Any]] = None,
     fleet_factory: Optional[Callable[[], Any]] = None,
-) -> FastMCP:
-    """Build a FastMCP server with all wirestudio tools + resources registered.
+) -> MCPServer:
+    """Build an MCPServer with all wirestudio tools + resources registered.
 
     `active` is the shared active-design tracker (Phase 1.4). When set,
     design-bound tools default their `design_id` argument to the tracker's
@@ -73,7 +73,7 @@ def build_mcp_server(
     factories let a caller inject clients; production passes the same ones
     `create_app` uses for the REST routes.
     """
-    mcp = FastMCP(name=name)
+    mcp = MCPServer(name=name)
     tracker = active or ActiveDesignTracker()
     _register_library_tools(mcp, library)
     _register_design_tools(mcp, library, designs, tracker)
@@ -91,7 +91,7 @@ def build_mcp_server(
     return mcp
 
 
-def _register_library_tools(mcp: FastMCP, library: Library) -> None:
+def _register_library_tools(mcp: MCPServer, library: Library) -> None:
     @mcp.tool(
         name="search_components",
         description=(
@@ -165,7 +165,7 @@ _NO_DESIGN_ERROR = {
 
 
 def _register_design_tools(
-    mcp: FastMCP, library: Library, designs: DesignStore,
+    mcp: MCPServer, library: Library, designs: DesignStore,
     active: ActiveDesignTracker,
 ) -> None:
     def _resolve(design_id: Optional[str]) -> Optional[str]:
@@ -490,7 +490,7 @@ def _register_design_tools(
 
 
 def _register_active_tools(
-    mcp: FastMCP, active: ActiveDesignTracker, designs: DesignStore
+    mcp: MCPServer, active: ActiveDesignTracker, designs: DesignStore
 ) -> None:
     @mcp.tool(
         name="set_active_design",
@@ -527,7 +527,7 @@ def _register_active_tools(
         return {"active_design_id": active.get()}
 
 
-def _register_resources(mcp: FastMCP, library: Library, designs: DesignStore) -> None:
+def _register_resources(mcp: MCPServer, library: Library, designs: DesignStore) -> None:
     """Read-only views of the library and stored designs.
 
     The library catalog resources serve a dual purpose: they let an LLM


### PR DESCRIPTION
Closes #220. Lifts the `mcp<2` pin carried since 0.24.1.

## What the pin was protecting against

mcp 2.0 removed `mcp.server.fastmcp` — the import path the whole server is built on — so images built against it crashed at boot. That is now handled.

## Mostly a rename

`mcp.server.fastmcp` → `mcp.server.mcpserver`, `FastMCP` → `MCPServer`. The `@tool` / `@resource` decorators, `streamable_http_app()`, `session_manager` and `_tool_manager` all survive with compatible signatures, so **all 39 tool registrations move across untouched** — including the `_tool_manager.list_tools()` guard that catches stacked decorators.

## Three real breaks

**1. `Settings` dropped `transport_security`.** It is now an argument to `streamable_http_app()` — which is where it was always consumed, so this is arguably better placed. `WIRESTUDIO_MCP_ALLOWED_HOSTS` handling moved to the mount site:

```python
mcp_app = mcp_server.streamable_http_app(transport_security=transport_security)
```

**2. `call_tool` returns `CallToolResult`,** not a bare content sequence. Four test helpers unwrapped the old shape. They now read `.content`; I removed the 1.x tuple handling rather than keep a compat shim.

**3. Model fields are snake_case:** `inputSchema` → `input_schema`, `uriTemplate` → `uri_template`.

## Dependency note worth knowing

**mcp 2.x depends on `httpx2`**, a separate distribution from `httpx`. I checked before assuming a conflict: it installs as module `httpx2`, so it coexists with the studio's own `httpx` usage (7 source files) rather than replacing it. No migration needed there — but it does mean **two HTTP stacks in the image**, which is worth knowing for size.

Every existing dependency already satisfied 2.0's floors — pydantic 2.13.4 (needs ≥2.12), starlette 0.52.1, anyio 4.13.0, jsonschema 4.26.0 — so nothing else moved.

## Verification

Full suite: **1017 passed, 12 skipped**.

Beyond the suite, because the pin existed for a boot-time crash the suite would not catch:

```
app booted on mcp 2.0.0
  GET  /health        -> 200
  POST /mcp no auth   -> 401
  POST /mcp bad token -> 401
  POST /mcp good tok  -> 400   (empty JSON-RPC body, past auth)
```

And a real Streamable HTTP client session against the running app:

```
MCP SESSION OK: 39 tools (17 hardware)
list_boards -> 26 boards
resources   -> 2
```

## Also changed for clients (not this repo)

The client entry point moved: `streamablehttp_client` → `streamable_http_client`, and it takes `http_client=httpx2.AsyncClient(headers=...)` instead of `headers=`. wirestudio imports no MCP client code, so nothing here depends on it — but anything driving this server with the 1.x client will need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ