### PR TITLE
docs(mcp): the 2.x client's 5s default kills slow tool calls

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -319,8 +319,17 @@ state backend so the studio can run as a HA replica; attributing
 `esphome-matrix` failures to specific components for per-release
 support tables.
 
-**Known debt** — `mcp` is pinned to `<2` (0.24.1). mcp 2.0.0 removed
-the `mcp.server.fastmcp` import path the MCP server is built on, so
-images built against it crashed at boot; the pin restores a bootable
-image but freezes the dependency. Migrating to the mcp 2.x API is
-outstanding.
+**Retired debt** — `mcp` was pinned to `<2` from 0.24.1, because mcp
+2.0.0 removed the `mcp.server.fastmcp` import path the server is built
+on and images built against it crashed at boot. Migrated in #225: the
+package became `mcp.server.mcpserver` and the class `MCPServer`, with
+three real breaks beyond the rename — `Settings` dropped
+`transport_security` (now an argument to `streamable_http_app()`),
+`call_tool` returns a `CallToolResult` rather than a content sequence,
+and the model fields are snake_case. Verified on staging, where the
+image has served for days without a restart.
+
+Note mcp 2.x pulls **httpx2**, a distribution separate from httpx. The
+import names differ, so it coexists with the studio's own httpx usage
+rather than replacing it — at the cost of a second HTTP stack in the
+image.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -75,6 +75,46 @@ session, `/mcp` shows the wirestudio tools and resources.
 
 Restart Claude Desktop. The wirestudio tools appear in the tool menu.
 
+**Python SDK** — the studio requires `mcp` 2.x, whose client differs
+from 1.x in two ways that are easy to trip over. The entry point is
+`streamable_http_client` (was `streamablehttp_client`), and it takes an
+`http_client` rather than `headers`:
+
+```python
+import httpx2
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+
+# timeout: httpx2 defaults to 5s, which is too short -- see below.
+http = httpx2.AsyncClient(headers={"Authorization": "Bearer <token>"},
+                          timeout=60)
+
+async with streamable_http_client("http://localhost:8765/mcp",
+                                  http_client=http) as (read, write, *_):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        tools = (await session.list_tools()).tools
+```
+
+**Set the timeout.** `httpx2.AsyncClient()` defaults to
+`Timeout(timeout=5.0)`, and that budget covers the streamed response, so
+any tool call slower than five seconds tears the SSE stream down. The
+error names neither the timeout nor the tool:
+
+```
+MCPError: SSE stream ended without a response
+```
+
+It also fails *intermittently*, because it depends on how slow the call
+happens to be — which reads like a flaky server rather than a client
+setting. Several hardware tools fetch server-side before returning:
+`fleet_firmware_info` downloads the build artifact (a few hundred KB),
+and `workbench_flash` with a `fleet_run_id` does the same before handing
+back a job id. Sixty seconds is a comfortable default.
+
+Note this applies to the Python SDK only. Claude Code and Claude Desktop
+speak HTTP directly and are unaffected.
+
 ### 4. Create a design to edit
 
 The design-editing tools operate on a design that already exists in the
@@ -248,6 +288,11 @@ leaves `running`, and read the log with `job_events` using the returned
 `next_since` cursor.
 
 Jobs live in the server process and are lost on restart.
+
+Returning a handle keeps the *call* short, but a few tools still do real
+work before they answer — fetching an artifact, probing a bench. On the
+Python SDK that runs into the client's five-second default; see
+[Wire up a client](#3-wire-up-a-client).
 
 **A `job_id` and a `run_id` are not interchangeable.** Fleet builds keep
 their own `run_id`, which belongs to the addon's GitHub run, outlives a


### PR DESCRIPTION
Follow-up to #225, from verifying it on staging.

## The trap

`httpx2.AsyncClient()` defaults to `Timeout(timeout=5.0)`, and that budget covers the **streamed** response. Any tool call slower than five seconds tears down the SSE stream:

```
MCPError: SSE stream ended without a response
```

That error names neither the timeout nor the tool. Worse, it fails *intermittently* — it depends on how slow the call happens to be, so it reads like a flaky server rather than a client setting.

It cost me a wrong hypothesis during the staging check: I saw it mid-session and suspected a regression in the async tool path under 2.x. It is not. Individually every tool worked; the session died only when `fleet_status` was briefly slow probing an unreachable fleet. On a later run the same call took 1.8s and passed.

**It bites this server specifically**, because several hardware tools fetch before returning — `fleet_firmware_info` downloads the build artifact (a few hundred KB) and `workbench_flash` with a `fleet_run_id` does the same before handing back a job id.

## What the docs now say

A **Python SDK** subsection under "Wire up a client" covering both 2.x changes: the entry point rename (`streamablehttp_client` → `streamable_http_client`), headers via `http_client`, and the timeout with the failure mode spelled out. Plus a pointer from "Long operations", since that is where someone reading about job handles would reasonably expect their calls to be short.

Scoped explicitly: **Claude Code and Claude Desktop speak HTTP directly and are unaffected.** Only the Python SDK path needs this.

## Verified, not asserted

The snippet was run verbatim against staging before committing:

```
DOC SNIPPET WORKS — 39 tools
```

## Also

Retires the `mcp<2` **Known debt** note in `docs/index.md` — #225 fixed it, and staging has served the migrated image for days without a restart. Replaced with what actually changed, plus a note that mcp 2.x pulls `httpx2` alongside `httpx` (a second HTTP stack in the image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ