### PR TITLE
release 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] — 2026-08-22
+
 ### Changed
 
 - **Migrated to mcp 2.x**, lifting the `mcp<2` pin carried since 0.24.1.

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.27.2"
+__version__ = "0.28.0"


### PR DESCRIPTION
Minor release — the mcp 2.x migration.

## Why minor, not patch

mcp 2.x replaces the server package the entire MCP surface is built on (`mcp.server.fastmcp` → `mcp.server.mcpserver`, `FastMCP` → `MCPServer`) and pulls **httpx2** as a second HTTP stack into the image. The tool contract is unchanged — all 39 tools keep their names and schemas — but a major dependency swap is not a bugfix.

## Changed

**Migrated to mcp 2.x** (#225), lifting the `mcp<2` pin carried since 0.24.1. Three breaks beyond the rename:

- `Settings` dropped `transport_security` — now an argument to `streamable_http_app()`
- `call_tool` returns `CallToolResult`, not a content sequence
- model fields are snake_case (`inputSchema` → `input_schema`, `uriTemplate` → `uri_template`)

Every existing dependency already met 2.0's floors, so nothing else moved.

**Docs** (#226): the mcp 2.x Python SDK client defaults to a five-second `httpx2` timeout that tears down the SSE stream on slower tool calls, with an error naming neither the timeout nor the tool. Documented, along with the client entry-point rename. Claude Code and Claude Desktop speak HTTP directly and are unaffected.

## Verified on staging before tagging

The pin existed because images built against mcp 2.x **crashed at boot** — a failure no unit test catches. So this was checked in a real deployment:

| | |
|---|---|
| Image | `main-full`, mcp 2.0.0, httpx2 2.10.0 |
| Pod | `1/1 Running`, **5+ days uptime, 0 restarts** |
| MCP session | `server=wirestudio protocol=2025-11-25` |
| Surface | 39 tools (17 hardware), 2 resources, 5 templates |
| Hardware tools | workbench, ChirpStack and fleet all reachable |

Full suite: **1017 passed, 12 skipped** (against mcp 2.0.0).

## For anyone driving this server

If you use the **Python SDK**, 2.x needs `streamable_http_client` (was `streamablehttp_client`) with `http_client=httpx2.AsyncClient(..., timeout=60)` instead of `headers=`. See `docs/mcp.md`. HTTP clients — including Claude Code and Desktop — need no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ