### PR TITLE
build: constrain image dependency resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Image builds are now constrained.** `pyproject.toml` carries lower
+  bounds only and the Dockerfile installed with a bare
+  `pip install .`, so two images built weeks apart resolved different
+  versions of everything -- including transitive packages nothing
+  declares. `constraints.txt` caps the whole set (103 pins, taken from
+  the 0.28.0-full image serving prod) and both install lines now use
+  `-c constraints.txt`. Refresh procedure in `CONTRIBUTING.md`.
+
+  The prompt was staging and prod landing on different `httpx2` minors,
+  a dependency that arrived with mcp 2.x and that no wirestudio code
+  imports. They happened to reconverge on the next build, which is the
+  actual problem: they agreed by coincidence of timing rather than by
+  construction.
+
 ## [0.28.0] — 2026-08-22
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,35 @@ board *before* bumping. When it does, bump the pin (and add the new
 version to the matrix list); when it's red, the failing examples show
 what upstream changed.
 
+### Refreshing the image constraints
+
+`constraints.txt` pins every package the runtime image resolves, and the
+Dockerfile installs with `pip install -c constraints.txt .`. Without it
+`pyproject.toml` carries lower bounds only, so two images built weeks
+apart get different versions of everything — including transitive
+packages nothing in `pyproject.toml` names. That is how staging and prod
+ended up on different `httpx2` minors, a dependency that arrived with
+mcp 2.x and that no wirestudio code imports.
+
+It is *not* a lockfile: it caps versions, it does not resolve or install
+them. Constraints only apply to packages pip is already pulling in, so
+entries for the `lorawan` extra sit inert in the base image.
+
+To move it:
+
+```sh
+# from a clean venv built off pyproject, or an image you trust
+python -m pip freeze | grep -viE '^wirestudio==|^-e |@ file://' | sort
+```
+
+Paste the result under the header, run the suite, and commit it on its
+own. The point of the file is that it moves when someone decides it
+should — bundling a refresh into an unrelated PR hides a dependency
+change inside a diff nobody is reading for that.
+
+Generate it against the image's Python (3.11), not whatever is on your
+machine — pins that resolve on 3.13 may have no 3.11 wheel.
+
 ### Nightly compile smoke
 
 `.github/workflows/esphome-compile.yml` runs `esphome compile`

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,11 @@ WORKDIR /app
 COPY pyproject.toml ./
 COPY wirestudio/ ./wirestudio/
 COPY README.md ./
+# Caps what pip resolves so two images built weeks apart get the same
+# dependency set. See the header in constraints.txt for how to refresh.
+COPY constraints.txt ./
 
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir -c constraints.txt .
 
 # Drop the built SPA into a stable path. WIRESTUDIO_STATIC_DIR points
 # uvicorn at it through wirestudio.api.serve.
@@ -86,7 +89,7 @@ ENV PLATFORMIO_CORE_DIR=/opt/pio
 RUN <<'EOF'
 set -eu
 if [ "$WITH_LORAWAN" = "true" ]; then
-    pip install --no-cache-dir platformio ".[lorawan]"
+    pip install --no-cache-dir -c constraints.txt platformio ".[lorawan]"
     mkdir -p "$PLATFORMIO_CORE_DIR"
     python -c "from wirestudio.library import default_library; from wirestudio.model import Design; from wirestudio.targets import get_target; from wirestudio.targets.lorawan.compile import compile_firmware; lib=default_library(); [compile_firmware(Design(schema_version='0.1', id='prewarm-'+b, name=b, target='lorawan', lorawan={}, board={'library_id': b, 'mcu': 'esp32'}, power={'supply':'usb','rail_voltage_v':3.3}), lib, use_cache=False) for b in get_target('lorawan').board_ids(lib)]"
     chown -R appuser:appuser "$PLATFORMIO_CORE_DIR"

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,124 @@
+# Reproducible image builds.
+#
+# pyproject.toml carries lower bounds only, and the Dockerfile installs
+# with plain `pip install .`, so two images built a week apart resolve
+# different versions of everything -- including transitive packages
+# nothing here declares. That is how staging and prod ended up on
+# different httpx2 minors (an mcp 2.x dependency) in August 2026.
+#
+# This file caps what the image resolves. It does not *cause* anything
+# to be installed: a constraint only applies to a package pip is already
+# pulling in, so entries for extras (platformio, the lorawan set) are
+# inert in the base image.
+#
+# Refresh deliberately, not casually -- the point is that it only moves
+# when someone decides it should:
+#
+#   1. build/run an image you trust, or a clean venv from pyproject
+#   2. python -m pip freeze | grep -viE '^wirestudio==|^-e |@ file://' | sort
+#   3. paste below, run the suite, commit in its own change
+#
+# Generated 2026-08-22 from the wirestudio 0.28.0-full image serving prod.
+ajsonrpc==1.2.0
+annotated-doc==0.0.5
+annotated-types==0.8.0
+anthropic==1.0.0
+anyio==4.14.2
+attrs==26.1.0
+bottle==0.13.4
+cairocffi==1.7.1
+CairoSVG==2.9.0
+certifi==2026.7.22
+cffi==2.1.1
+charset-normalizer==3.5.1
+chirpstack-api==4.19.0
+click==8.3.3
+colorama==0.4.6
+contourpy==1.3.3
+cryptography==50.0.0
+cssselect2==0.9.0
+cycler==0.12.1
+defusedxml==0.7.1
+Deprecated==1.3.1
+deprecation==2.1.0
+diskcache==5.6.3
+docstring_parser==0.18.0
+fastapi==0.141.1
+fonttools==4.63.0
+google-api-core==2.34.0
+googleapis-common-protos==1.75.1
+google-auth==2.56.3
+graphviz==0.21
+grpcio==1.83.0
+h11==0.16.0
+h5py==3.16.0
+hierplace==1.1.0
+httpcore==1.0.9
+httpcore2==2.12.0
+httptools==0.8.0
+httpx==0.28.1
+httpx2==2.12.0
+idna==3.19
+InSpice==1.6.3.3
+Jinja2==3.1.6
+jiter==0.16.0
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+kinet2pcb==1.1.4
+kiwisolver==1.5.0
+limits==5.8.0
+markdown-it-py==4.2.0
+MarkupSafe==3.0.3
+marshmallow==3.26.2
+matplotlib==3.11.1
+mcp==2.0.0
+mcp-types==2.0.0
+mdurl==0.1.2
+numpy==2.4.6
+opentelemetry-api==1.44.0
+packaging==26.3
+paho-mqtt==2.1.0
+pillow==12.3.0
+platformio==6.1.19
+ply==3.11
+protobuf==7.36.0
+proto-plus==1.28.3
+pyasn1==0.6.4
+pyasn1_modules==0.4.2
+pycparser==3.0
+pydantic==2.13.4
+pydantic_core==2.46.4
+pyelftools==0.33
+Pygments==2.21.0
+PyJWT==2.13.0
+pyparsing==3.3.2
+pyserial==3.5
+python-dateutil==2.9.0.post0
+python-dotenv==1.2.3
+python-multipart==0.0.32
+PyYAML==6.0.3
+referencing==0.37.0
+requests==2.34.2
+rich==15.0.0
+rpds-py==2026.6.3
+semantic-version==2.10.0
+simp_sexp==0.3.1
+six==1.17.0
+skidl==2.3.0
+slowapi==0.1.10
+sniffio==1.3.1
+sse-starlette==3.4.8
+starlette==0.52.1
+tabulate==0.10.0
+tinycss2==1.5.1
+truststore==0.10.4
+typing_extensions==4.16.0
+typing-inspection==0.4.4
+urllib3==2.7.0
+uvicorn==0.40.0
+uvloop==0.22.1
+watchfiles==1.2.0
+webencodings==0.6.1
+websockets==17.0.1
+wrapt==2.3.0
+wsproto==1.3.2


### PR DESCRIPTION
You asked to pin `httpx2` so staging and prod match. Checking first: **they already match** — both on httpx2 2.12.0, and identical on every other package.

The difference I reported earlier was a build-timing artifact. Staging was still on the `main-full` image from the migration commit while prod had just been built from `v0.28.0`; the release also pushed `main`, staging rebuilt minutes later, and they converged.

That convergence is the actual problem — they agree by coincidence of build timing, not by construction.

## Why pinning httpx2 alone would not have helped

```toml
dependencies = [
    "pydantic>=2.6", "fastapi>=0.110", "anthropic>=0.40",
    "httpx>=0.27", "mcp>=2.0,<3", ...
]
```

Lower bounds only, `pip install .` in the Dockerfile, no lockfile. **Everything** floats. Staging tracks `main-full` and rebuilds every merge; prod sits on a release tag until one is cut. Any gap between those builds picks up whatever released in between — `anthropic` is at 1.0.0, a major, which is the kind of thing that arrives unannounced.

httpx2 was just the one I happened to notice, and it is not even a package we import — it arrived with mcp 2.x.

## What this does

`constraints.txt`: 103 pins taken from **the 0.28.0-full image currently serving prod**, so the baseline is a build known to work rather than whatever resolves today. Both Dockerfile install lines use `-c constraints.txt`.

Not a lockfile — a constraint only applies to a package pip is already pulling in, so entries for the `lorawan` extra sit inert in the base image and nothing extra gets installed by their presence.

## Verified

- `pip install --dry-run -c constraints.txt .` resolves with no conflicts, and would install exactly the pinned set (httpx2-2.12.0, anthropic-1.0.0, fastapi-0.141.1 …)
- `.dockerignore` does not exclude `constraints.txt` — a silent `COPY` failure would have broken the build
- 103 pins, no duplicates, no `wirestudio==` self-reference
- Suite: **1017 passed, 12 skipped**

The image build itself is exercised by CI's `build` job on this PR.

## Refresh

Documented in `CONTRIBUTING.md` next to the ESPHome pin-bump section, including the trap that pins must be generated against the image's Python (3.11) — pins resolving on 3.13 may have no 3.11 wheel — and that a refresh belongs in its own commit rather than buried in an unrelated diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ