### PR TITLE
release 0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1] — 2026-08-22
+
 ### Changed
 
 - **Image builds are now constrained.** `pyproject.toml` carries lower

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.28.0"
+__version__ = "0.28.1"


### PR DESCRIPTION
Patch release that gets **prod onto a constrained image build**.

## What actually changes

The wheel does not. `constraints.txt` lives at the repo root and `pyproject.toml` packages only `wirestudio*` with no `MANIFEST.in`, so **the PyPI artifact is byte-identical to 0.28.0**. Anyone doing `pip install wirestudio` sees no difference.

What moves is the image: both Dockerfile install lines now run under `-c constraints.txt`, so prod stops resolving whatever is current on build day and starts resolving a set someone chose.

Worth stating because it is the opposite of the release we skipped a few days ago — that one changed only CI and would have published an identical image. This one publishes a materially different image while publishing an identical wheel.

## Verified on staging before tagging

The constrained image has been running on staging since #228 merged:

| | |
|---|---|
| Constraints pins | 103 |
| Staging installed | 103 |
| **Mismatches** | **0** |
| Pinned but absent | none |
| Installed but unpinned | none |

Zero mismatches shows the pins are honoured; no unpinned packages shows the file is *complete*. An incomplete constraints file would still let transitive drift through and pass a spot check.

Functionally: all four image jobs built clean, pod `1/1 Running` with 0 restarts, real MCP session at `protocol=2025-11-25` serving 39 tools (17 hardware), `list_boards` returning 26 boards, and workbench / ChirpStack / fleet all reachable.

Full suite: **1017 passed, 12 skipped**.

## After this

Prod becomes reproducible-by-construction. Today its dependency set already matches the pins — they were generated from the 0.28.0 image — so this rebuild should be a no-op in content while changing how that content is arrived at. Any divergence at rollout would itself be the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ