### PR TITLE
ci: fail when a dependency reaches the image unpinned

### DIFF
--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -1,0 +1,51 @@
+name: constraints
+
+# constraints.txt caps the versions the runtime image resolves, and only
+# stays true while it names every package pip pulls in. Add a dependency
+# to pyproject.toml and it is simply not pinned -- nothing fails, and the
+# file silently stops being complete. That is exactly the drift it exists
+# to prevent, so it would go unnoticed for as long as it did last time.
+#
+# The install here is *constrained* on purpose. Resolving unconstrained
+# and diffing would also flag upstream releases that add a transitive
+# dependency -- drift nobody in this repo caused. A gate that goes red
+# for reasons no one can act on gets ignored, and then it catches
+# nothing. Under the pins each package's dependency list is fixed, so the
+# resolved set only moves when pyproject.toml does, which is the defect
+# worth failing on.
+#
+# The comparison is one-directional: every installed package must be
+# pinned, but not every pin must be installed. The file is generated from
+# the -full image, so it carries pins for platformio and the extras that
+# a base install never touches; a constraint on a package pip is not
+# installing is inert.
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  constraints:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          # Must match the Dockerfile's runtime base (python:3.11-slim).
+          # A resolve on a newer interpreter can pick wheels that do not
+          # exist for 3.11, and the resolved set can differ.
+          python-version: '3.11'
+
+      - name: Install under constraints
+        run: |
+          python -m pip install --upgrade pip
+          pip install -c constraints.txt .
+
+      - name: Every installed package must be pinned
+        run: python scripts/check_constraints.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A gate that keeps `constraints.txt` honest.** The pins added in
+  0.28.1 only hold while the file names every package pip installs; add
+  a dependency to `pyproject.toml` and it is simply not pinned, nothing
+  fails, and builds can drift again. The `constraints` workflow installs
+  under the pins on Python 3.11 (the image's) and fails if anything
+  arrived unpinned. Runnable locally via
+  `scripts/check_constraints.py`.
+
 ## [0.28.1] — 2026-08-22
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,22 @@ change inside a diff nobody is reading for that.
 Generate it against the image's Python (3.11), not whatever is on your
 machine — pins that resolve on 3.13 may have no 3.11 wheel.
 
+The [`constraints`](.github/workflows/constraints.yml) gate installs
+under the pins on 3.11 and fails if anything reached the environment
+unpinned — which is what happens when a dependency is added to
+`pyproject.toml` and the file is not refreshed. Run it yourself with:
+
+```sh
+pip install -c constraints.txt .
+python scripts/check_constraints.py
+```
+
+It checks one direction only. Every installed package must be pinned;
+the reverse is not required, because the file is generated from the
+`-full` image and carries pins for `platformio` and the extras that a
+base install never touches. A constraint on a package pip is not
+installing is inert.
+
 ### Nightly compile smoke
 
 `.github/workflows/esphome-compile.yml` runs `esphome compile`

--- a/scripts/check_constraints.py
+++ b/scripts/check_constraints.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Assert constraints.txt still pins everything the image installs.
+
+`constraints.txt` caps the versions the runtime image resolves. It only
+stays true while it names every package pip pulls in -- a dependency
+added to pyproject.toml is *not* pinned, nothing fails, and the file
+quietly stops being complete. That is the drift the file exists to
+prevent, so it would go unnoticed for as long as it did last time.
+
+The check is one-directional: every **installed** package must be
+pinned. The reverse is not required and would be wrong -- the file is
+generated from the `-full` image, so it carries pins for platformio and
+the lorawan/pcb extras that a base install never touches. A constraint
+on a package pip is not installing is inert.
+
+Run against an environment built *with* the constraints applied:
+
+    pip install -c constraints.txt .
+    python scripts/check_constraints.py
+
+Use the image's Python (3.11). A freeze from a newer interpreter can
+name wheels that do not exist for 3.11, and the resolved set can differ.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# pip normalises distribution names for comparison: case-insensitive,
+# with runs of -_. collapsed to a single dash (PEP 503).
+_NORMALISE = re.compile(r"[-_.]+")
+
+# Always present in a venv, never a project dependency, and not worth
+# pinning -- pip upgrades itself and setuptools ships with the venv.
+IGNORE = {"pip", "setuptools", "wheel", "wirestudio"}
+
+
+def normalise(name: str) -> str:
+    return _NORMALISE.sub("-", name).lower()
+
+
+def pinned_names(path: Path) -> set[str]:
+    names = set()
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "==" not in line:
+            continue
+        names.add(normalise(line.split("==", 1)[0]))
+    return names
+
+
+def installed_names() -> set[str]:
+    out = subprocess.run(
+        [sys.executable, "-m", "pip", "freeze", "--exclude-editable"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    names = set()
+    for line in out.splitlines():
+        line = line.strip()
+        if not line or line.startswith("-") or " @ " in line:
+            continue
+        if "==" not in line:
+            continue
+        names.add(normalise(line.split("==", 1)[0]))
+    return names
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--constraints", type=Path,
+                    default=REPO_ROOT / "constraints.txt")
+    args = ap.parse_args()
+
+    pinned = pinned_names(args.constraints)
+    installed = installed_names() - IGNORE
+    unpinned = sorted(installed - pinned)
+
+    print(f"python      : {sys.version.split()[0]}")
+    print(f"pinned      : {len(pinned)}")
+    print(f"installed   : {len(installed)}")
+    print(f"unpinned    : {len(unpinned)}")
+
+    if not unpinned:
+        print("\nOK: every installed package is pinned.")
+        return 0
+
+    # Flush first: the summary above is on stdout and the failure below on
+    # stderr, and unflushed stdout lands after it in a CI log.
+    sys.stdout.flush()
+    print("\nInstalled but not pinned in constraints.txt:", file=sys.stderr)
+    for name in unpinned:
+        print(f"  {name}", file=sys.stderr)
+    print(
+        "\nA dependency reached the image without a pin, so builds can "
+        "drift again.\nRefresh constraints.txt -- see 'Refreshing the image "
+        "constraints' in CONTRIBUTING.md.\nGenerate it against Python 3.11, "
+        "the image's interpreter.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #230.

`constraints.txt` only stays true while it names every package pip installs. Add a dependency to `pyproject.toml` and it is simply **not pinned** — nothing fails, the file quietly stops being complete, and builds drift again. That is the same failure the file was added to prevent, which is why it would go unnoticed for as long as it did last time.

## Two choices differ from what I filed in #230

Both are about the gate staying worth reading.

**Install *under* the constraints, not unconstrained.** #230 proposed `pip install .` and diffing the resolved set. That would also flag upstream releases that add a transitive dependency — drift nobody in this repo caused. A gate that goes red for reasons no one can act on gets ignored, and then it catches nothing. Under the pins, each package's dependency list is fixed, so the resolved set moves only when `pyproject.toml` does, which is the defect worth failing on.

**Compare one direction only.** Every installed package must be pinned; *not* every pin must be installed. `constraints.txt` is generated from the `-full` image, so it carries `platformio` and the lorawan/pcb extras a base install never touches — a constraint on a package pip is not installing is inert. Failing on unused pins would be wrong, and it is a mistake the naive `comm -3` in the issue would have made.

## Verified it fails, not just passes

Synthesising a complete file from the current environment, then dropping two pins:

```
=== positive case: complete file ===
pinned: 90  installed: 90  unpinned: 0
OK: every installed package is pinned.          exit=0

=== negative case: drop two pins ===
Installed but not pinned in constraints.txt:
  anthropic
  httpx2
exit=1
```

The failure message names the packages and points at the refresh procedure in `CONTRIBUTING.md`, including the Python 3.11 requirement.

## Details worth noting

- **Python 3.11**, matching `python:3.11-slim` in the Dockerfile. A resolve on a newer interpreter can pick wheels that do not exist for 3.11, and the set can differ.
- **PEP 503 name normalisation** — not theoretical: `constraints.txt` really does carry `pydantic_core`, `pyasn1_modules`, `docstring_parser`, which pip can report with either separator.
- `pip`/`setuptools`/`wheel` are ignored; they are venv furniture, not project dependencies.

Runnable locally:

```sh
pip install -c constraints.txt .
python scripts/check_constraints.py
```

Suite: **1017 passed, 12 skipped**. The gate itself gets its first real run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ