### PR TITLE
docs(library): record where each flash_size_mb came from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Board `flash_size_mb` now records where its value came from.** The
+  field drives the ESPHome partition table, and the failure is
+  asymmetric: under-declaring wastes flash, over-declaring boot-loops
+  the board. Six boards now carry provenance -- two verified against
+  silicon, three from vendor docs and marked unverified, and
+  `esp32-s3-devkitc-1` marked as a floor that must not be raised,
+  because Espressif sells it as both an 8MB and a 32MB part under one
+  name. `docs/integration_spec.md` explains the asymmetry and how to
+  read the real size off an ESP-IDF bootloader.
+
 ### Added
 
 - **A gate that keeps `constraints.txt` honest.** The pins added in

--- a/docs/integration_spec.md
+++ b/docs/integration_spec.md
@@ -159,7 +159,7 @@ mcu: esp32                    # esp8266 | esp32 today; any ESPHome-supported MCU
 chip_variant: esp32c3         # PlatformIO chip variant
 framework: arduino            # arduino | esp-idf
 platformio_board: example_devkit
-flash_size_mb: 4
+flash_size_mb: 4              # see "Flash size" below -- get this wrong upward and the board boot-loops
 image: https://example.com/img/devkit.png
 
 # --- power (required; current budget validation) ---
@@ -224,6 +224,38 @@ radio:
   tcxo_voltage: 1.8
   dio2_as_rf_switch: true
 ```
+
+### Flash size
+
+`flash_size_mb` is emitted into the ESPHome config and drives the
+partition table, so it is the one field where a wrong value bricks
+rather than degrades. The asymmetry matters:
+
+- **Under-declaring wastes flash.** A 16MB board declared as 8MB loses
+  half its OTA slots and nothing else.
+- **Over-declaring boot-loops the board.** Declaring 8MB on a 4MB
+  PICO-D4 is how a Heltec V2 was bricked in 0.26.x.
+
+So when in doubt, declare the smallest size the board ships with, and
+say so in a comment. Several bundled boards carry exactly that note.
+
+**Boards sold in multiple flash sizes under one name are the trap.** The
+ESP32-S3-DevKitC-1 ships as N8/N8R2/N8R8 (8MB) *and* N32R16V (32MB); no
+static value is right for every unit. Pin the floor and comment that it
+must not be raised.
+
+To verify against silicon, the reliable route is the ESP-IDF bootloader,
+which prints the real size at boot:
+
+```
+I (33) boot.esp32s3: SPI Flash Size : 16MB
+```
+
+That line only appears on ESP-IDF builds — an Arduino-framework board
+prints ROM output and nothing about flash. `esptool flash-id` reads it
+directly, but needs the chip in download mode, which auto-reset over a
+network RFC2217 link does not reliably achieve; drive the board's
+boot/reset pins, or run esptool locally over USB.
 
 ## Validation tiers
 

--- a/wirestudio/library/boards/esp32-s3-devkitc-1.yaml
+++ b/wirestudio/library/boards/esp32-s3-devkitc-1.yaml
@@ -4,6 +4,13 @@ mcu: esp32
 chip_variant: esp32s3
 framework: arduino
 platformio_board: esp32-s3-devkitc-1
+# FLOOR -- do not raise. Espressif sells this one board name across
+# several modules: N8 / N8R2 / N8R8 (8MB, WROOM-1) and N32R16V (32MB,
+# WROOM-2). No single value is correct for every unit, so this is the
+# smallest. Under-declaring only wastes flash; over-declaring boot-loops
+# the board, which is how a Heltec V2 was bricked in 0.26.x by an 8MB
+# declaration on a 4MB part. Unverified against silicon.
+# https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/user_guide_v1.1.html
 flash_size_mb: 8
 
 rails:

--- a/wirestudio/library/boards/heltec-wifi-lora32-v2.yaml
+++ b/wirestudio/library/boards/heltec-wifi-lora32-v2.yaml
@@ -8,6 +8,8 @@ platformio_board: heltec_wifi_lora_32_V2
 # definition claims 8 MB; building against that makes the bootloader assert on
 # the size mismatch and boot-loop. Verified on hardware: esptool reports
 # "Detected size(4096k)" and the 8 MB image never reaches setup().
+# Verified on silicon the hard way: declaring 8MB here in 0.26.x
+# boot-looped the bench unit, whose PICO-D4 carries 4MB. Do not raise.
 flash_size_mb: 4
 
 rails:

--- a/wirestudio/library/boards/heltec-wifi-lora32-v3.yaml
+++ b/wirestudio/library/boards/heltec-wifi-lora32-v3.yaml
@@ -4,6 +4,10 @@ mcu: esp32
 chip_variant: esp32s3
 framework: arduino
 platformio_board: heltec_wifi_lora_32_V3
+# Vendor docs and the ESPHome device page agree on 8MB (ESP32-S3FN8,
+# FN8 = 8MB, no PSRAM). No alternate-size SKU found, but Heltec
+# publishes no ordering matrix -- so this is 'no contrary evidence',
+# not vendor-guaranteed. Unverified against silicon.
 flash_size_mb: 8
 
 rails:

--- a/wirestudio/library/boards/heltec-wifi-lora32-v4.yaml
+++ b/wirestudio/library/boards/heltec-wifi-lora32-v4.yaml
@@ -8,6 +8,9 @@ framework: arduino
 # ESP32-S3 core, same console wiring) but partitions for 8MB of the
 # 16MB flash. Switch when upstream ships a V4 def.
 platformio_board: heltec_wifi_lora_32_V3
+# Verified on silicon: the ESP-IDF bootloader reports
+#   I (33) boot.esp32s3: SPI Flash Size : 16MB
+# on the bench unit (2026-08-01, re-confirmed 2026-08-22).
 flash_size_mb: 16
 
 rails:

--- a/wirestudio/library/boards/m5stack-atoms3-lite.yaml
+++ b/wirestudio/library/boards/m5stack-atoms3-lite.yaml
@@ -4,6 +4,8 @@ mcu: esp32
 chip_variant: esp32s3
 framework: arduino
 platformio_board: esp32-s3-devkitc-1
+# M5Stack shop spec gives 8MB (ESP32-S3FN8), PSRAM: None.
+# Unverified against silicon.
 flash_size_mb: 8
 image: https://static-cdn.m5stack.com/resource/docs/products/core/AtomS3%20Lite/img-dc6432b6-fd9b-4066-9a4d-49786503d1a3.webp
 

--- a/wirestudio/library/boards/m5stack-atoms3.yaml
+++ b/wirestudio/library/boards/m5stack-atoms3.yaml
@@ -4,6 +4,9 @@ mcu: esp32
 chip_variant: esp32s3
 framework: arduino
 platformio_board: m5stack-atoms3
+# M5Stack docs give 8MB (ESP32-S3FN8), no PSRAM. Distinct from the
+# AtomS3R/AtomS3U, which are separate products. Unverified against
+# silicon; M5Stack publishes no SKU ordering matrix.
 flash_size_mb: 8
 image: https://static-cdn.m5stack.com/resource/docs/products/core/AtomS3/img-abe8d8b0-3d8c-4f42-a84a-093bfed0aa38.png
 


### PR DESCRIPTION
Refs #219 — the metadata half. Does **not** close it; the silicon verification the issue asks for still needs the boards in hand.

`flash_size_mb` drives the ESPHome partition table, and its failure is asymmetric:

- **under-declaring wastes flash** — a 16MB board declared 8MB loses half its OTA slots
- **over-declaring boot-loops the board** — how a Heltec V2 was bricked in 0.26.x

Nothing in the library distinguished measured values from assumed ones, so the safe entries looked exactly like the guesses.

## Six boards now carry provenance

| Board | Basis |
|---|---|
| `heltec-wifi-lora32-v4` | **verified** — bootloader reports `SPI Flash Size : 16MB` |
| `heltec-wifi-lora32-v2` | **verified the hard way** — 8MB declaration boot-looped it, proving the 4MB PICO-D4 |
| `esp32-s3-devkitc-1` | **FLOOR, do not raise** |
| `heltec-wifi-lora32-v3` | vendor docs, unverified |
| `m5stack-atoms3` | vendor docs, unverified |
| `m5stack-atoms3-lite` | vendor docs, unverified |

The DevKitC-1 is the one that cannot be fixed by choosing a better number. Espressif sells N8/N8R2/N8R8 (8MB, WROOM-1) **and** N32R16V (32MB, WROOM-2) under that single board name. 8 is safe only because it is the smallest — and anyone "correcting" it upward would brick every 8MB unit. The comment says so, with the source.

The three vendor-doc entries are recorded as *"no contrary evidence found"*, not verified. Neither M5Stack nor Heltec publishes an ordering matrix, so a same-name variant could exist and I would not know.

## What I tried on hardware, and why it stopped

Three boards are on the bench, so I went for silicon evidence first:

- **SLOT28 (Heltec V4)** → `I (33) boot.esp32s3: SPI Flash Size : 16MB` ✅
- **SLOT12 / SLOT19** → ROM output only, no flash line. They run Arduino-framework firmware; that bootloader banner is an ESP-IDF thing.
- `esptool flash-id` over the bench RFC2217 URLs → `Wrong boot mode detected (0x33)! The chip needs to be in download mode.` Auto-reset over a network serial link does not get there.

I stopped rather than pursuing GPIO-driven download mode, because **neither of those boards is what #219 is about** — the issue targets the DevKitC-1, V3, and the two AtomS3s, none of which are attached. Chasing it further would have produced data about the wrong boards.

## Also

`docs/integration_spec.md` gains a **Flash size** section: the asymmetry, the multi-variant trap, and how to verify — including that the bootloader line only appears on ESP-IDF builds and that `esptool flash-id` needs download mode. That is the part I would have wanted before starting.

Comments only. Every value unchanged, every board parses, suite **1017 passed, 12 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ