### PR TITLE
fix: never report a network failure as a bare colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Network failures reported a bare colon and nothing else.** httpx
+  raises `ConnectTimeout`, `ReadTimeout`, `PoolTimeout`, `ConnectError`,
+  `ReadError` and `RemoteProtocolError` with **no message**, so the
+  `f"...: {e}"` used in ~20 places rendered as
+  `firmware not available for run <id>: ` or `unreachable: `. Because
+  only some failure modes carry text, the same tool gave a useful
+  message one minute and an empty one the next -- which read as an
+  intermittent bug rather than a whole class of error with nothing to
+  say. Exceptions now render through `wirestudio.errors.describe`,
+  which falls back to the class name.
+
 ### Changed
 
 - **Board `flash_size_mb` now records where its value came from.** The

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,39 @@
+"""Exception rendering never produces a bare message."""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from wirestudio.errors import describe
+
+
+# Every one of these is raised by httpx with no message in real failures,
+# so `f"{e}"` renders as "" and the caller emits a message ending in a
+# colon and nothing else.
+MESSAGELESS = [
+    httpx.ConnectTimeout(""),
+    httpx.ReadTimeout(""),
+    httpx.PoolTimeout(""),
+    httpx.ConnectError(""),
+    httpx.ReadError(""),
+    httpx.RemoteProtocolError(""),
+]
+
+
+@pytest.mark.parametrize("exc", MESSAGELESS, ids=lambda e: type(e).__name__)
+def test_messageless_exceptions_render_as_their_class(exc):
+    assert str(exc) == "", "premise: httpx renders these empty"
+    assert describe(exc) == type(exc).__name__
+
+
+def test_a_real_message_is_preserved():
+    assert describe(ValueError("bad offset 0x10000")) == "bad offset 0x10000"
+
+
+def test_whitespace_only_counts_as_empty():
+    assert describe(ValueError("   \n ")) == "ValueError"
+
+
+def test_never_returns_empty():
+    for exc in MESSAGELESS + [ValueError(""), RuntimeError(), Exception()]:
+        assert describe(exc), f"{type(exc).__name__} rendered empty"

--- a/tests/test_mcp_hardware.py
+++ b/tests/test_mcp_hardware.py
@@ -379,6 +379,37 @@ async def test_fleet_firmware_info_reports_size_not_bytes(tmp_path):
     assert "data" not in out and "firmware" not in out
 
 
+async def test_transport_failure_names_the_error_not_a_bare_colon(tmp_path):
+    """httpx raises timeouts with no message, so `f"{e}"` renders empty.
+
+    The tool then reported `firmware not available for run <id>: ` --
+    a failure with nothing after the colon, which reads as an
+    intermittent bug in the tool rather than a class of error that
+    carries no text.
+    """
+    def timing_out(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("")
+
+    server, _ = _server(tmp_path, fleet_handler=timing_out)
+
+    out = _payload(await server.call_tool("fleet_firmware_info", {"run_id": "run-1"}))
+    assert out["ok"] is False
+    assert not out["error"].rstrip().endswith(":"), out["error"]
+    assert "ConnectTimeout" in out["error"], out["error"]
+
+
+async def test_fleet_status_reason_is_never_blank(tmp_path):
+    def timing_out(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("")
+
+    server, _ = _server(tmp_path, fleet_handler=timing_out)
+
+    out = _payload(await server.call_tool("fleet_status", {}))
+    assert out["available"] is False
+    assert out["reason"] and out["reason"].strip() != "unreachable:"
+    assert "ConnectError" in out["reason"], out["reason"]
+
+
 async def test_fleet_tools_without_config_are_errors(tmp_path):
     server, _ = _server(tmp_path)
     out = _payload(await server.call_tool("fleet_push", {"design_id": "bench-dut"}))

--- a/wirestudio/api/circuitpython.py
+++ b/wirestudio/api/circuitpython.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Response
 
 from wirestudio.library import Library, LibraryBoard
+from wirestudio.errors import describe
 
 _RELEASES_LATEST = "https://api.github.com/repos/adafruit/circuitpython/releases/latest"
 _BIN_BASE = "https://downloads.circuitpython.org/bin"
@@ -83,7 +84,7 @@ def firmware_status() -> dict:
         version = _latest_stable()
         available, reason = True, None
     except Exception as e:
-        version, available, reason = None, False, f"release lookup failed: {e}"
+        version, available, reason = None, False, f"release lookup failed: {describe(e)}"
     return {
         "available": available,
         "version": version,
@@ -231,7 +232,7 @@ def router(lib: Library) -> APIRouter:
             data = _fetch_firmware(url)
         except Exception as e:
             raise HTTPException(
-                status_code=502, detail=f"could not fetch firmware: {e}"
+                status_code=502, detail=f"could not fetch firmware: {describe(e)}"
             ) from e
         return Response(
             content=data,

--- a/wirestudio/api/meshtastic.py
+++ b/wirestudio/api/meshtastic.py
@@ -13,6 +13,7 @@ links to client.meshtastic.org instead.
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Response
+from wirestudio.errors import describe
 
 _RELEASE_LIST = "https://api.meshtastic.org/github/firmware/list"
 _FILES_BASE = "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master"
@@ -57,7 +58,7 @@ def firmware_status() -> dict:
         version = _latest_stable()
         available, reason = True, None
     except Exception as e:
-        version, available, reason = None, False, f"release list unreachable: {e}"
+        version, available, reason = None, False, f"release list unreachable: {describe(e)}"
     return {
         "available": available,
         "version": version,
@@ -90,7 +91,7 @@ def router() -> APIRouter:
             data = _fetch_firmware(url)
         except Exception as e:
             raise HTTPException(
-                status_code=502, detail=f"could not fetch firmware: {e}"
+                status_code=502, detail=f"could not fetch firmware: {describe(e)}"
             ) from e
         return Response(
             content=data,

--- a/wirestudio/errors.py
+++ b/wirestudio/errors.py
@@ -1,0 +1,24 @@
+"""Rendering exceptions into something a reader can act on."""
+from __future__ import annotations
+
+
+def describe(exc: BaseException) -> str:
+    """Human-readable text for an exception. Never empty.
+
+    httpx raises its timeout and connection errors with no message, so
+    `f"{exc}"` renders as `""` -- every one of ConnectTimeout,
+    ReadTimeout, PoolTimeout, ConnectError, ReadError and
+    RemoteProtocolError does it. The caller then emits "unreachable: "
+    or "firmware not available for run <id>: " and the reader is told
+    that something failed but not what.
+
+    Worse, it only happens for *some* failure modes, so the same tool
+    reports a useful message one minute and a bare colon the next --
+    which reads as an intermittent bug in the tool rather than a class
+    of error that carries no text.
+
+    Falls back to the exception's class name, which for this family is
+    the informative part anyway.
+    """
+    text = str(exc).strip()
+    return text or type(exc).__name__

--- a/wirestudio/fleet/client.py
+++ b/wirestudio/fleet/client.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import httpx
+from wirestudio.errors import describe
 
 
 _FILENAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
@@ -134,7 +135,7 @@ class FleetClient:
             async with self._client() as c:
                 r = await c.get("/ui/api/targets")
         except httpx.HTTPError as e:
-            return False, f"unreachable: {e}"
+            return False, f"unreachable: {describe(e)}"
         if r.status_code == 401:
             return False, "unauthorized (check FLEET_TOKEN)"
         if r.status_code >= 400:

--- a/wirestudio/mcp/hardware.py
+++ b/wirestudio/mcp/hardware.py
@@ -30,6 +30,7 @@ from wirestudio.designs.store import DesignStore
 from wirestudio.library import Library
 from wirestudio.mcp.jobs import JobNotFound, JobRegistry
 from wirestudio.model import Design
+from wirestudio.errors import describe
 
 _EUI_LEN = 16
 
@@ -98,7 +99,7 @@ def _decode_images(raw: Optional[list[dict]]) -> list[tuple[int, bytes]]:
             offset = int(str(img["offset"]), 0)
             data = base64.b64decode(img["data"], validate=True)
         except (KeyError, ValueError, TypeError) as e:
-            raise ValueError(f"image {i}: {e}") from e
+            raise ValueError(f"image {i}: {describe(e)}") from e
         if offset < 0:
             raise ValueError(f"image {i}: negative offset")
         if not data:
@@ -136,7 +137,7 @@ def register_hardware_tools(
         try:
             return Design.model_validate(raw), None
         except Exception as e:
-            return None, _err(f"design '{rid}' failed validation: {e}")
+            return None, _err(f"design '{rid}' failed validation: {describe(e)}")
 
     def _workbench() -> Any:
         if workbench_factory is not None:
@@ -255,7 +256,7 @@ def _register_workbench_tools(
         try:
             slots = await wc.slots()
         except Exception as e:
-            return _err(f"workbench unreachable: {e}")
+            return _err(f"workbench unreachable: {describe(e)}")
         return {
             "ok": True,
             "slots": [
@@ -316,7 +317,7 @@ def _register_workbench_tools(
             try:
                 blob = await fc.get_firmware(fleet_run_id, factory=factory)
             except Exception as e:
-                return _err(f"could not fetch firmware for run {fleet_run_id}: {e}")
+                return _err(f"could not fetch firmware for run {fleet_run_id}: {describe(e)}")
             # The artifact kind decides the offset and getting it wrong
             # bricks the board, so read it off the bytes rather than
             # trusting which endpoint served them.
@@ -339,7 +340,7 @@ def _register_workbench_tools(
         try:
             ok, reason = (await wc.slot(slot)).flashable
         except Exception as e:
-            return _err(f"workbench unreachable: {e}")
+            return _err(f"workbench unreachable: {describe(e)}")
         if not ok:
             return _err(f"slot {slot} is not flashable: {reason}")
 
@@ -605,7 +606,7 @@ def _register_lorawan_tools(
         try:
             ok, reason = wb.slot_sync(slot).flashable
         except Exception as e:
-            return _err(f"workbench unreachable: {e}")
+            return _err(f"workbench unreachable: {describe(e)}")
         if not ok:
             return _err(f"slot {slot} is not flashable: {reason}")
 
@@ -690,7 +691,7 @@ def _register_fleet_tools(
         except ValueError as e:
             return _err(str(e))
         except Exception as e:
-            return _err(f"fleet unreachable: {e}")
+            return _err(f"fleet unreachable: {describe(e)}")
         return {
             "ok": True,
             "filename": result.filename,
@@ -715,7 +716,7 @@ def _register_fleet_tools(
         try:
             status = await fc.get_run_status(run_id)
         except Exception as e:
-            return _err(f"fleet unreachable: {e}")
+            return _err(f"fleet unreachable: {describe(e)}")
         return {
             "ok": True,
             "run_id": status.run_id,
@@ -745,7 +746,7 @@ def _register_fleet_tools(
         try:
             chunk = await fc.get_job_log(run_id, offset=offset)
         except Exception as e:
-            return _err(f"fleet unreachable: {e}")
+            return _err(f"fleet unreachable: {describe(e)}")
         return {
             "ok": True, "run_id": run_id,
             "log": chunk.log, "offset": chunk.offset, "finished": chunk.finished,
@@ -767,5 +768,5 @@ def _register_fleet_tools(
         try:
             blob = await fc.get_firmware(run_id, factory=factory)
         except Exception as e:
-            return _err(f"firmware not available for run {run_id}: {e}")
+            return _err(f"firmware not available for run {run_id}: {describe(e)}")
         return {"ok": True, "run_id": run_id, "factory": factory, "bytes": len(blob)}

--- a/wirestudio/workbench/client.py
+++ b/wirestudio/workbench/client.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import AsyncIterator, Iterator, Optional
 
 import httpx
+from wirestudio.errors import describe
 
 
 class WorkbenchUnavailable(RuntimeError):
@@ -167,7 +168,7 @@ class WorkbenchClient:
             async with self._client() as c:
                 r = await c.get("/api/info")
         except httpx.HTTPError as e:
-            return False, f"unreachable: {e}"
+            return False, f"unreachable: {describe(e)}"
         if r.status_code == 401:
             return False, "unauthorized (check WORKBENCH_TOKEN)"
         if r.status_code >= 400:
@@ -196,7 +197,7 @@ class WorkbenchClient:
             async with self._client() as c:
                 r = await c.get(path)
         except httpx.HTTPError as e:
-            raise WorkbenchUnavailable(f"unreachable: {e}") from e
+            raise WorkbenchUnavailable(f"unreachable: {describe(e)}") from e
         if r.status_code == 401:
             raise WorkbenchUnavailable("unauthorized (check WORKBENCH_TOKEN)")
         if r.status_code >= 400:
@@ -239,7 +240,7 @@ class WorkbenchClient:
             async with self._client(timeout=self.flash_timeout) as c:
                 r = await c.post("/api/flash", data=form, files=files)
         except httpx.HTTPError as e:
-            raise WorkbenchUnavailable(f"flash transport failed: {e}") from e
+            raise WorkbenchUnavailable(f"flash transport failed: {describe(e)}") from e
 
         for event in _flash_events(r, slot):
             yield event
@@ -268,7 +269,7 @@ class WorkbenchClient:
             with self._sync_client() as c:
                 r = c.get("/api/devices")
         except httpx.HTTPError as e:
-            raise WorkbenchUnavailable(f"unreachable: {e}") from e
+            raise WorkbenchUnavailable(f"unreachable: {describe(e)}") from e
         if r.status_code == 401:
             raise WorkbenchUnavailable("unauthorized (check WORKBENCH_TOKEN)")
         if r.status_code >= 400:
@@ -305,7 +306,7 @@ class WorkbenchClient:
             with self._sync_client(timeout=self.flash_timeout) as c:
                 r = c.post("/api/flash", data=form, files=files)
         except httpx.HTTPError as e:
-            raise WorkbenchUnavailable(f"flash transport failed: {e}") from e
+            raise WorkbenchUnavailable(f"flash transport failed: {describe(e)}") from e
         yield from _flash_events(r, slot)
 
 

--- a/wirestudio/workbench/serial.py
+++ b/wirestudio/workbench/serial.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import re
 import time
+from wirestudio.errors import describe
 from typing import Iterator, Optional, Pattern, Sequence
 
 DEFAULT_BAUD = 115200
@@ -63,7 +64,7 @@ def answer_prompts(
     try:
         port = serial.serial_for_url(url, baudrate=baud, timeout=1)
     except Exception as exc:
-        raise SerialUnavailable(f"cannot open {url}: {exc}") from exc
+        raise SerialUnavailable(f"cannot open {url}: {describe(exc)}") from exc
 
     buf = ""
     last_sent = 0.0


### PR DESCRIPTION
Closes #222.

## Root cause

httpx raises its whole timeout/connection family with **no message**:

```
exception                  str(e)
  ConnectTimeout           
  ReadTimeout              
  PoolTimeout              
  ConnectError             
  ReadError                
  RemoteProtocolError      
```

Roughly twenty call sites do `f"...: {e}"`, so any of those produced:

```
firmware not available for run 3d2f4987-158b-44fb-9d45-64746f4a7c61:
unreachable:
```

The reader is told something failed, and nothing else.

## Why it looked intermittent

That is the part worth naming. Failures that *do* carry text render fine, so the same tool gives a useful message one minute and a bare colon the next. #222 was filed as "**intermittently** returns an error with an empty message" for exactly that reason — I assumed a flaky call, when it was a whole class of exception with nothing to say. I hit the same thing again later on `fleet_status` returning `reason: "unreachable: "`.

## Fix

`wirestudio.errors.describe()` falls back to the exception class name, which for this family is the informative part — `ConnectTimeout` tells you more than the empty string it replaces. Applied across fleet, workbench, MCP and the firmware proxies.

`mcp/jobs.py` already did this by hand (`f"{type(exc).__name__}: {exc}"`); the rest now match it.

Messages that already carry text are unchanged — `describe()` returns `str(e)` whenever it is non-empty, so no existing message regresses.

## Verified against the old behaviour

Reverting `describe()` to a bare `str(e)`:

```
10 failed, 19 passed
  test_messageless_exceptions_render_as_their_class[ConnectTimeout]
  ... (all six httpx types)
  test_transport_failure_names_the_error_not_a_bare_colon
  test_fleet_status_reason_is_never_blank
```

The last two are end-to-end: they drive a real tool call through a transport that raises `ConnectTimeout("")` and assert the message does not end in a colon. The unit tests also assert the *premise* (`str(exc) == ""`), so if httpx ever starts populating these, the tests say so rather than silently passing.

Full suite: **1028 passed, 12 skipped** (up 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ