### PR TITLE
release 0.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.2] — 2026-08-23
+
+### Added
+
+- **A gate that keeps `constraints.txt` honest.** The pins added in
+  0.28.1 only hold while the file names every package pip installs; add
+  a dependency to `pyproject.toml` and it is simply not pinned, nothing
+  fails, and builds can drift again. The `constraints` workflow installs
+  under the pins on Python 3.11 (the image's) and fails if anything
+  arrived unpinned. Runnable locally via
+  `scripts/check_constraints.py`.
+
 ### Changed
 
 - **Documented that the first join after a flash fails, and that verbose
@@ -16,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   try) against 4 flashes (all failed first try), on both a default and a
   VERBOSE build -- so the logger level, which the symptom was previously
   attributed to, makes no difference.
+- **Board `flash_size_mb` now records where its value came from.** The
+  field drives the ESPHome partition table, and the failure is
+  asymmetric: under-declaring wastes flash, over-declaring boot-loops
+  the board. Six boards now carry provenance -- two verified against
+  silicon, three from vendor docs and marked unverified, and
+  `esp32-s3-devkitc-1` marked as a floor that must not be raised,
+  because Espressif sells it as both an 8MB and a 32MB part under one
+  name. `docs/integration_spec.md` explains the asymmetry and how to
+  read the real size off an ESP-IDF bootloader.
 
 ### Fixed
 
@@ -29,28 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   intermittent bug rather than a whole class of error with nothing to
   say. Exceptions now render through `wirestudio.errors.describe`,
   which falls back to the class name.
-
-### Changed
-
-- **Board `flash_size_mb` now records where its value came from.** The
-  field drives the ESPHome partition table, and the failure is
-  asymmetric: under-declaring wastes flash, over-declaring boot-loops
-  the board. Six boards now carry provenance -- two verified against
-  silicon, three from vendor docs and marked unverified, and
-  `esp32-s3-devkitc-1` marked as a floor that must not be raised,
-  because Espressif sells it as both an 8MB and a 32MB part under one
-  name. `docs/integration_spec.md` explains the asymmetry and how to
-  read the real size off an ESP-IDF bootloader.
-
-### Added
-
-- **A gate that keeps `constraints.txt` honest.** The pins added in
-  0.28.1 only hold while the file names every package pip installs; add
-  a dependency to `pyproject.toml` and it is simply not pinned, nothing
-  fails, and builds can drift again. The `constraints` workflow installs
-  under the pins on Python 3.11 (the image's) and fails if anything
-  arrived unpinned. Runnable locally via
-  `scripts/check_constraints.py`.
 
 ## [0.28.1] — 2026-08-22
 

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.28.1"
+__version__ = "0.28.2"


### PR DESCRIPTION
Patch release. The user-visible change is the empty-message fix.

## Fixed

**Network failures reported a bare colon and nothing else** (#233). httpx raises `ConnectTimeout`, `ReadTimeout`, `PoolTimeout`, `ConnectError`, `ReadError` and `RemoteProtocolError` with **no message**, so the `f"...: {e}"` used in ~20 places rendered as:

```
firmware not available for run 3d2f4987-...:
unreachable:
```

Because only some failure modes carry text, the same tool gave a useful message one minute and an empty one the next — which is why it was filed as an *intermittent* bug rather than a whole class of error with nothing to say. Exceptions now render through `wirestudio.errors.describe`, falling back to the class name.

It proved itself within the hour: a flash during unrelated testing failed with `could not fetch firmware for run 92dbe24c-...: ReadTimeout`, which on the previous release would have ended at the colon.

## Added

**A gate that keeps `constraints.txt` honest** (#231). The pins from 0.28.1 hold only while the file names every package pip installs; add a dependency and it is simply not pinned. The gate installs under the pins on Python 3.11 and fails if anything arrived unpinned.

## Changed

**`flash_size_mb` records its provenance** (#232) — two boards verified against silicon, three marked vendor-doc-and-unverified, and `esp32-s3-devkitc-1` marked a floor that must not be raised, since Espressif sells it as both an 8MB and a 32MB part under one name.

**Two LoRaWAN doc corrections** (#234): the first join after a *flash* fails with -1116 and self-corrects, and verbose logging is **not** the cause — measured 11 reboots (all joined first try) against 4 flashes (all failed), on both default and VERBOSE builds.

## Verification

Suite: **1028 passed, 12 skipped**. The new constraints gate runs on this PR.

`pyproject.toml` is unchanged since 0.28.1, so the pins remain complete and the image should resolve identically.

Also consolidated the four PRs' separate `### Added` / `### Changed` / `### Fixed` headings into one set — same tidy-up 0.27.0 needed, and a symptom of per-PR changelog entries that is worth watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ