### PR TITLE
ci: keep [Unreleased] to one heading per kind

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,6 +21,13 @@ name: changelog
 #   - put [skip changelog] anywhere in the PR title, or
 #   - add the `skip-changelog` label to the PR.
 
+#
+# The `shape` job is separate and unexempted: it checks the section is
+# still coherent rather than whether an entry was required. Four PRs each
+# writing "### Fixed" leaves four Fixed blocks, which is only visible when
+# someone reads the whole section at release time -- 0.27.0 and 0.28.2
+# both needed that tidy-up by hand.
+
 on:
   pull_request:
     branches: [main, dev]
@@ -56,3 +63,17 @@ jobs:
             exit 1
           fi
           echo "changelog check: OK"
+
+  # Deliberately a separate job with no exemptions. The gate above asks
+  # "is there an entry?" and can be skipped; this one asks "is the
+  # section still coherent?", which is cheap and true regardless of who
+  # opened the PR or whether they were required to write an entry.
+  shape:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: No duplicate or unknown headings under [Unreleased]
+        run: python scripts/check_changelog.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A check that `[Unreleased]` keeps one heading per kind.** Every PR
+  adds its own entry, so four PRs each writing `### Fixed` left four
+  separate Fixed blocks -- visible only when someone read the whole
+  section at release time, which 0.27.0 and 0.28.2 both needed by hand.
+  Also catches a misspelled heading (`### Fixes`), which fails the same
+  way but looks correct in a diff. Released sections are not checked:
+  0.26.0, 0.25.0 and 0.17.0 already carry duplicates, so enforcing
+  history would block unrelated work.
+
 ## [0.28.2] — 2026-08-23
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,5 +301,9 @@ done
       board's `enclosure:` block).
 - [ ] If you added or changed a library entry, an example uses it.
 - [ ] If a golden changed, the regenerated golden is in the same diff.
+- [ ] Your CHANGELOG entry went under an *existing* heading if
+      `[Unreleased]` already has one — `python scripts/check_changelog.py`
+      fails on a second `### Fixed` rather than leaving it to be merged
+      by hand at release time.
 - [ ] If you bumped the ESPHome pin, all three pin sites (config
       workflow, compile workflow, README) moved together.

--- a/scripts/check_changelog.py
+++ b/scripts/check_changelog.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Fail when the [Unreleased] section has duplicate or unknown headings.
+
+Every PR adds its own entry, so `[Unreleased]` accumulates whatever
+headings each author reached for. Four PRs each writing `### Fixed`
+leaves four separate Fixed blocks, and the duplication is only visible
+when someone reads the whole section at release time -- which is exactly
+when nobody wants to be reorganising a changelog. 0.27.0 and 0.28.2 both
+needed that tidy-up.
+
+A misspelled heading (`### Fixes`) fails the same way and is harder to
+spot: the entry is present, looks right in the diff, and silently forms
+its own group.
+
+Only `[Unreleased]` is checked. Released sections are history -- failing
+CI on a past release's layout would block unrelated work to fix
+something nobody is reading.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Keep a Changelog's set, which is what this file has always used.
+VALID = ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]
+
+_RELEASE = re.compile(r"^## ", re.M)
+_HEADING = re.compile(r"^### +(.+?)\s*$", re.M)
+
+
+def unreleased_section(text: str) -> str | None:
+    """The [Unreleased] body, up to the next `## ` heading."""
+    start = text.find("## [Unreleased]")
+    if start == -1:
+        return None
+    rest = text[start + len("## [Unreleased]"):]
+    nxt = _RELEASE.search(rest)
+    return rest[: nxt.start()] if nxt else rest
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--changelog", type=Path, default=REPO_ROOT / "CHANGELOG.md")
+    args = ap.parse_args()
+
+    text = args.changelog.read_text()
+    section = unreleased_section(text)
+    if section is None:
+        print("::error::CHANGELOG.md has no '## [Unreleased]' section.", file=sys.stderr)
+        return 1
+
+    headings = _HEADING.findall(section)
+    counts = Counter(headings)
+    dupes = sorted(h for h, n in counts.items() if n > 1)
+    unknown = sorted({h for h in headings if h not in VALID})
+
+    print(f"[Unreleased] headings: {headings or '(none)'}")
+
+    if not dupes and not unknown:
+        print("OK: no duplicate or unknown headings.")
+        return 0
+
+    sys.stdout.flush()
+    if dupes:
+        print("::error::Duplicate headings under [Unreleased]:", file=sys.stderr)
+        for h in dupes:
+            print(f"  '### {h}' appears {counts[h]} times", file=sys.stderr)
+        print(
+            "\nMerge the entries under a single heading. Separate blocks read as\n"
+            "separate concerns and have to be reorganised by hand at release time.",
+            file=sys.stderr,
+        )
+    if unknown:
+        print("::error::Unknown headings under [Unreleased]:", file=sys.stderr)
+        for h in unknown:
+            print(f"  '### {h}'", file=sys.stderr)
+        print(f"\nUse one of: {', '.join(VALID)}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
From cutting 0.28.2, which — like 0.27.0 — needed its `[Unreleased]` section reorganised by hand at release time.

## The problem

Every PR writes its own changelog entry, so `[Unreleased]` accumulates whatever heading each author reached for. Four PRs each adding `### Fixed` leaves four Fixed blocks. Nothing notices until someone reads the whole section while cutting a release, which is the worst moment to be editing a changelog.

It also catches a **misspelled heading**. `### Fixes` fails the same way and is harder to spot: the entry is present, the diff looks correct, and it silently forms its own group.

## Scoped to [Unreleased], deliberately

This turned out to matter more than expected. Released sections already carry duplicates:

```
released sections with duplicate headings:
  [(0.26.0, [Fixed]), (0.25.0, [Added]), (0.17.0, [Added, Changed])]
```

Checking the whole file would have failed **every PR** until someone rewrote release history to fix something nobody reads. History stays as it is.

## A separate, unexempted job

The existing gate asks *"is there an entry?"* and can be skipped by `[skip changelog]`, the `skip-changelog` label, or a `Bolt:` title. This one asks *"is the section coherent?"* — cheap, and true regardless of who opened the PR or whether they were required to write an entry. So it runs as its own job with no `if:`.

## Verified against the real case

The exact pre-consolidation shape of 0.28.2:

```
[Unreleased] headings: [Changed, Fixed, Changed, Added]
::error::Duplicate headings under [Unreleased]:
  '### Changed' appears 2 times
```

Plus: a typo'd `### Fixes` fails; duplicates in released sections are ignored; a missing `[Unreleased]` fails; the current file passes.

## One judgement worth flagging

You asked for the duplicate check. I also made **unknown headings** fatal, because a typo produces the identical outcome — an entry that does not group — and fixing one while leaving the other seemed like answering the letter of the request. The allowed set is Keep a Changelog's, which is what this file has always used. Easy to drop if you would rather it only flagged duplicates.

Suite: **1028 passed, 12 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ