### PR TITLE
feat(workbench): assert firmware actually booted, not just flashed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Boot-marker verification (workbench phase 2, server side).** A
+  successful flash proves bytes reached the chip and nothing more -- a
+  wrong flash size or an undriven front end flashes perfectly and then
+  fails at start-up, which is the failure class CI cannot see. The new
+  `workbench_verify_boot` MCP tool watches a slot for a line the running
+  firmware emits, upgrading "flashed" to "flashed and booted". Supports
+  `esphome`, `lorawan` (standalone RadioLib) and `lorawan-esphome`;
+  Meshtastic and CircuitPython are explicitly unsupported with the
+  reason, rather than approximated.
+- Joining is a separate, opt-in check with a 7-minute budget, because
+  the first join after a flash reliably fails and only the retry --
+  one uplink interval later -- succeeds. Asserting it by default would
+  fail on a healthy board.
+
 - **A check that `[Unreleased]` keeps one heading per kind.** Every PR
   adds its own entry, so four PRs each writing `### Fixed` left four
   separate Fixed blocks -- visible only when someone read the whole

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -47,6 +47,7 @@ HARDWARE_TOOLS = {
     "job_list",
     "workbench_status",
     "workbench_slots",
+    "workbench_verify_boot",
     "workbench_flash",
     "lorawan_chirpstack_status",
     "lorawan_compile",

--- a/tests/test_workbench_boot.py
+++ b/tests/test_workbench_boot.py
@@ -1,0 +1,133 @@
+"""Boot-marker verification: did the firmware we flashed actually run?
+
+Drives the real WorkbenchClient against a wire-level fake that speaks the
+bench's /api/serial/monitor shape, rather than a fake client -- a fake
+client would only prove verify_boot calls the method I think exists.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from wirestudio.workbench import WorkbenchClient
+from wirestudio.workbench.boot import (
+    BOOT_CHECKS,
+    JOIN_CHECKS,
+    UNSUPPORTED,
+    supported_frameworks,
+    verify_boot,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _bench(script):
+    """script: pattern -> (matched, line, output). Speaks /api/serial/monitor."""
+    calls = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path != "/api/serial/monitor":
+            return httpx.Response(404, json={"error": "unexpected path"})
+        body = __import__("json").loads(req.content)
+        pattern = body.get("pattern")
+        calls.append(body)
+        matched, line, output = script.get(pattern, (False, None, []))
+        return httpx.Response(200, json={
+            "ok": True, "matched": matched, "line": line, "output": output,
+        })
+
+    client = WorkbenchClient(base_url="http://bench:8080", token="",
+                             transport=httpx.MockTransport(handler))
+    return client, calls
+
+
+async def test_booted_when_the_marker_appears():
+    marker = BOOT_CHECKS["esphome"].pattern
+    client, calls = _bench({marker: (True, f"[I][app:117]: {marker}", [])})
+
+    out = await verify_boot(client, "SLOT1", "esphome")
+
+    assert out["ok"] is True
+    assert out["booted"] is True
+    assert out["checks"][0]["stage"] == "boot"
+    assert out["checks"][0]["matched"] is True
+    assert calls[0]["pattern"] == marker
+
+
+async def test_not_booted_returns_a_result_not_an_error():
+    """A board that flashed but did not boot is the finding, not a failure."""
+    client, _ = _bench({BOOT_CHECKS["esphome"].pattern:
+                        (False, None, ["rst:0x10 (RTCWDT_RTC_RESET)"] * 20)})
+
+    out = await verify_boot(client, "SLOT1", "esphome")
+
+    assert out["ok"] is True          # the call worked
+    assert out["booted"] is False     # the board did not
+    assert out["recent_output"], "should surface what it printed instead"
+    assert len(out["recent_output"]) <= 15
+
+
+async def test_join_is_not_checked_unless_asked():
+    """The first join after a flash reliably fails, so asserting it by
+    default would fail on a healthy board."""
+    marker = BOOT_CHECKS["lorawan"].pattern
+    client, calls = _bench({marker: (True, marker, [])})
+
+    out = await verify_boot(client, "SLOT1", "lorawan")
+
+    assert out["booted"] is True
+    assert "joined" not in out
+    assert len(calls) == 1, "should not have monitored for a join"
+
+
+async def test_join_checked_on_request():
+    boot = BOOT_CHECKS["lorawan"].pattern
+    join = JOIN_CHECKS["lorawan"].pattern
+    client, calls = _bench({boot: (True, boot, []), join: (True, join, [])})
+
+    out = await verify_boot(client, "SLOT1", "lorawan", check_join=True)
+
+    assert out["booted"] is True and out["joined"] is True
+    assert [c["stage"] for c in out["checks"]] == ["boot", "join"]
+    assert len(calls) == 2
+
+
+async def test_join_is_not_attempted_when_the_board_never_booted():
+    boot = BOOT_CHECKS["lorawan"].pattern
+    client, calls = _bench({boot: (False, None, [])})
+
+    out = await verify_boot(client, "SLOT1", "lorawan", check_join=True)
+
+    assert out["booted"] is False
+    assert len(calls) == 1, "no point waiting 7 minutes for a join that cannot come"
+
+
+async def test_join_timeout_allows_for_the_post_flash_retry():
+    """The first join after a flash fails; the retry is one uplink interval
+    later. A timeout under ~5 minutes would fail on a healthy board."""
+    for framework, check in JOIN_CHECKS.items():
+        assert check.timeout_s >= 360, f"{framework} join timeout too tight"
+
+
+@pytest.mark.parametrize("framework", sorted(UNSUPPORTED))
+async def test_unsupported_frameworks_say_why(framework):
+    client, calls = _bench({})
+
+    out = await verify_boot(client, "SLOT1", framework)
+
+    assert out["ok"] is False
+    assert out["error"] == UNSUPPORTED[framework]
+    assert not calls, "should not have touched the bench"
+
+
+async def test_unknown_framework_lists_the_known_ones():
+    client, _ = _bench({})
+    out = await verify_boot(client, "SLOT1", "nonesuch")
+    assert out["ok"] is False
+    for known in supported_frameworks():
+        assert known in out["error"]

--- a/wirestudio/mcp/hardware.py
+++ b/wirestudio/mcp/hardware.py
@@ -241,6 +241,44 @@ def _register_workbench_tools(
         }
 
     @mcp.tool(
+        name="workbench_verify_boot",
+        description=(
+            "Assert that firmware on a slot actually started, by watching "
+            "the slot's serial for a line the running firmware emits. A "
+            "successful flash only proves bytes reached the chip -- a wrong "
+            "flash size or an undriven front end flashes perfectly and then "
+            "fails at start-up. Frameworks: esphome, lorawan (standalone "
+            "RadioLib), lorawan-esphome.\n\n"
+            "Set check_join=true to additionally wait for the LoRaWAN join. "
+            "It is off by default and generously timed because the first "
+            "join after a flash reliably fails and only the retry, one "
+            "uplink interval later, succeeds -- so asserting it immediately "
+            "would fail on a healthy board.\n\n"
+            "Pass `since` (an epoch from just before the flash) so the slot's "
+            "already-captured output is searched before waiting on new "
+            "lines -- a boot marker is printed once, seconds after reset, "
+            "and is usually gone by the time you ask.\n\n"
+            "Returns booted=true/false rather than erroring: a board that "
+            "flashed but did not boot is a result. When it did not boot, "
+            "recent_output carries what it printed instead."
+        ),
+    )
+    async def workbench_verify_boot(
+        slot: str, framework: str, check_join: bool = False,
+        since: Optional[float] = None,
+    ) -> dict:
+        wc = workbench()
+        if not wc.is_configured():
+            return _err("workbench not configured (set WORKBENCH_URL)")
+        from wirestudio.workbench.boot import verify_boot
+
+        try:
+            return await verify_boot(wc, slot, framework,
+                                     since=since, check_join=check_join)
+        except Exception as e:
+            return _err(f"workbench unreachable: {describe(e)}")
+
+    @mcp.tool(
         name="workbench_slots",
         description=(
             "List the bench's USB slots: label, state, present, detected "

--- a/wirestudio/workbench/boot.py
+++ b/wirestudio/workbench/boot.py
@@ -1,0 +1,207 @@
+"""Boot-marker verification: did the firmware we just flashed actually run?
+
+A successful flash proves bytes reached the chip. It says nothing about
+whether they boot -- a wrong flash size, an undriven front end, a
+half-configured peripheral all flash perfectly and then fail at start-up,
+which is the failure class CI cannot see. This asserts a line the running
+firmware emits, read through the bench's read-only serial fan-out so
+watching cannot disturb what is being watched.
+
+Every marker here comes from a line observed on hardware or emitted by a
+template in this repo; none are guessed. Frameworks whose success
+signature has not been established are absent rather than approximated --
+see UNSUPPORTED.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# ESPHome colours its log lines; the escapes survive into the buffer and
+# make a returned line unreadable in JSON.
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+@dataclass(frozen=True)
+class BootCheck:
+    """One assertion about a line the firmware emits."""
+
+    pattern: str
+    proves: str
+    timeout_s: float
+
+
+# Booted: the firmware started and got through init. Fast and reliable --
+# this is the assertion worth gating on.
+BOOT_CHECKS: dict[str, BootCheck] = {
+    # ESPHome logs this once every component's setup() returned.
+    # Observed on a Heltec V4: "[I][app:117]: setup() finished successfully!"
+    "esphome": BootCheck(
+        pattern="setup() finished successfully!",
+        proves="every ESPHome component initialised",
+        timeout_s=60.0,
+    ),
+    # The standalone LoRaWAN target prints its own banner from
+    # templates/main.cpp.j2 before touching the radio.
+    # Observed on a T-Beam and a Heltec V2.
+    "lorawan": BootCheck(
+        pattern="wirestudio lorawan:",
+        proves="standalone LoRaWAN firmware started",
+        timeout_s=45.0,
+    ),
+}
+
+# The ESPHome external-component path boots like any ESPHome device.
+BOOT_CHECKS["lorawan-esphome"] = BOOT_CHECKS["esphome"]
+
+
+# Joined: the device reached the network. Deliberately separate from
+# booting, because the first join after a flash reliably fails and only
+# the retry -- one uplink interval later -- succeeds. Asserting this
+# straight after flashing would fail on a healthy board, so the timeouts
+# below allow for that retry and the check is opt-in.
+JOIN_CHECKS: dict[str, BootCheck] = {
+    # templates/main.cpp.j2 prints this on a successful activation.
+    "lorawan": BootCheck(
+        pattern="JOINED: OTAA session active",
+        proves="joined the LoRaWAN network",
+        timeout_s=420.0,
+    ),
+    # lorawan-for-esphome logs "OTAA join OK (new session)".
+    "lorawan-esphome": BootCheck(
+        pattern="OTAA join OK",
+        proves="joined the LoRaWAN network",
+        timeout_s=420.0,
+    ),
+}
+
+# Frameworks this cannot verify yet, and why. Listed so the gap is a
+# recorded fact rather than an apparent oversight.
+UNSUPPORTED: dict[str, str] = {
+    "meshtastic": (
+        "no boot signature established -- needs a Meshtastic board on the "
+        "bench to observe one"
+    ),
+    "circuitpython": (
+        "success is CIRCUITPY enumerating as USB mass storage, not a serial "
+        "line, so a serial marker is the wrong mechanism"
+    ),
+}
+
+
+def boot_check(framework: str) -> Optional[BootCheck]:
+    return BOOT_CHECKS.get(framework)
+
+
+def join_check(framework: str) -> Optional[BootCheck]:
+    return JOIN_CHECKS.get(framework)
+
+
+def supported_frameworks() -> list[str]:
+    return sorted(BOOT_CHECKS)
+
+
+async def _match(client, slot: str, check: BootCheck, since: Optional[float]) -> dict:
+    """Look for `check.pattern`, first in what was already captured.
+
+    A boot marker is printed once, in the second or two after reset. By
+    the time a caller finishes flashing and asks, it has usually already
+    gone past -- and `monitor` only sees the *next* line. So the
+    recorder's buffer is consulted first, and live monitoring is the
+    fallback for a marker still to come.
+    """
+    if since is not None:
+        for entry in await client.output(slot, lines=1000, since=since):
+            text = entry.get("text", "")
+            if check.pattern in text:
+                return {"matched": True, "line": _ANSI.sub("", text), "via": "buffer"}
+    res = await client.monitor(slot, pattern=check.pattern, timeout=check.timeout_s)
+    line = res.get("line")
+    return {
+        "matched": bool(res.get("matched")),
+        "line": _ANSI.sub("", line) if line else line,
+        "output": res.get("output") or [],
+        "via": "monitor",
+    }
+
+
+async def verify_boot(
+    client,
+    slot: str,
+    framework: str,
+    *,
+    since: Optional[float] = None,
+    check_join: bool = False,
+) -> dict:
+    """Assert the firmware on `slot` started, and optionally that it joined.
+
+    `since` is an epoch bracketing the reset -- pass the time just before
+    flashing and the already-captured buffer is searched before waiting
+    on new output, which removes the race between a device booting and
+    the caller getting around to watching.
+
+    Returns {"ok", "booted", "framework", "checks": [...]} -- never raises
+    for a failed assertion, only for an unreachable bench. A board that
+    flashed but did not boot is a result, not an error.
+    """
+    check = boot_check(framework)
+    if check is None:
+        return {
+            "ok": False,
+            "framework": framework,
+            "error": UNSUPPORTED.get(
+                framework,
+                f"no boot marker for '{framework}'; known: "
+                f"{', '.join(supported_frameworks())}",
+            ),
+        }
+
+    checks: list[dict] = []
+    res = await _match(client, slot, check, since)
+    booted = res["matched"]
+    checks.append({
+        "stage": "boot",
+        "pattern": check.pattern,
+        "proves": check.proves,
+        "matched": booted,
+        "line": res.get("line"),
+        "via": res.get("via"),
+        "timeout_s": check.timeout_s,
+    })
+
+    joined = None
+    if booted and check_join:
+        jc = join_check(framework)
+        if jc is None:
+            checks.append({
+                "stage": "join",
+                "matched": None,
+                "skipped": f"no join marker for '{framework}'",
+            })
+        else:
+            jres = await _match(client, slot, jc, since)
+            joined = jres["matched"]
+            checks.append({
+                "stage": "join",
+                "pattern": jc.pattern,
+                "proves": jc.proves,
+                "matched": joined,
+                "line": jres.get("line"),
+                "via": jres.get("via"),
+                "timeout_s": jc.timeout_s,
+            })
+
+    out = {
+        "ok": True,
+        "framework": framework,
+        "slot": slot,
+        "booted": booted,
+        "checks": checks,
+    }
+    if joined is not None:
+        out["joined"] = joined
+    if not booted:
+        # The tail is the useful part: whatever it did print instead.
+        out["recent_output"] = (res.get("output") or [])[-15:]
+    return out

--- a/wirestudio/workbench/client.py
+++ b/wirestudio/workbench/client.py
@@ -188,6 +188,44 @@ class WorkbenchClient:
                 return s
         raise WorkbenchUnavailable(f"no such slot '{label}'")
 
+    async def monitor(
+        self, slot: str, pattern: Optional[str] = None, timeout: float = 10.0
+    ) -> dict:
+        """Watch a slot's serial for `pattern`, up to `timeout` seconds.
+
+        The bench reads through its read-only fan-out port rather than an
+        RFC2217 client, so this cannot disturb the device it is watching --
+        which is what makes it safe to assert on a board mid-boot.
+
+        Returns the bench's answer as-is: {matched, line, output}.
+        """
+        body: dict = {"slot": slot, "timeout": timeout}
+        if pattern is not None:
+            body["pattern"] = pattern
+        # The bench blocks for `timeout` before answering, so the HTTP read
+        # has to outlast it.
+        return await self._post_json("/api/serial/monitor", body,
+                                     read_timeout=timeout + 15.0)
+
+    async def output(
+        self, slot: str, lines: int = 500, since: float = 0
+    ) -> list[dict]:
+        """Read the slot's recorder buffer -- lines already captured.
+
+        The recorder runs whenever the proxy is up, so this sees output
+        that was printed before anyone was watching. `monitor` cannot:
+        it waits for the *next* line, which loses any marker emitted in
+        the second between a flash finishing and the call starting.
+
+        Note the bench returns the OLDEST `lines` entries after `since`,
+        not the newest, so pass a `since` that brackets the window you
+        care about rather than relying on a small `lines`.
+        """
+        data = await self._get_json(
+            f"/api/serial/output?slot={slot}&lines={lines}&since={since}"
+        )
+        return data.get("lines", [])
+
     async def _get_json(self, path: str) -> dict:
         if not self.is_configured():
             raise WorkbenchUnavailable(
@@ -196,6 +234,24 @@ class WorkbenchClient:
         try:
             async with self._client() as c:
                 r = await c.get(path)
+        except httpx.HTTPError as e:
+            raise WorkbenchUnavailable(f"unreachable: {describe(e)}") from e
+        if r.status_code == 401:
+            raise WorkbenchUnavailable("unauthorized (check WORKBENCH_TOKEN)")
+        if r.status_code >= 400:
+            raise WorkbenchUnavailable(f"{path}: http {r.status_code}")
+        return r.json()
+
+    async def _post_json(
+        self, path: str, body: dict, read_timeout: Optional[float] = None
+    ) -> dict:
+        if not self.is_configured():
+            raise WorkbenchUnavailable(
+                self.unconfigured_reason() or "workbench not configured"
+            )
+        try:
+            async with self._client() as c:
+                r = await c.post(path, json=body, timeout=read_timeout)
         except httpx.HTTPError as e:
             raise WorkbenchUnavailable(f"unreachable: {describe(e)}") from e
         if r.status_code == 401:


### PR DESCRIPTION
Workbench **phase 2**, server side. Phase 1 shipped remote flashing; this closes the gap between "flashed" and "flashed and booted".

A successful flash proves bytes reached the chip and nothing more. A wrong flash size, an undriven front end, a half-configured peripheral all flash cleanly and then fail at start-up — the failure class CI cannot see, and the one this repo has hit repeatedly.

`workbench_verify_boot` watches a slot for a line the running firmware emits, through the bench's **read-only serial fan-out**, so watching cannot disturb what is being watched.

## Two things the implementation had to get right

Both learned on hardware, not assumed.

**It reads the recorder buffer before waiting on new output.** A boot marker is printed once, a second or two after reset. `monitor()` only sees the *next* line — so a caller that finishes flashing and then asks has already missed it. My first version did exactly that:

```
SLOT28   lorawan-esphome  booted=False
SLOT12   lorawan          booted=False
SLOT19   lorawan          booted=False
```

Three healthy boards. Passing `since` searches what the always-on recorder already captured, which removes the race:

```
SLOT12   lorawan          booted=True  via=buffer  'wirestudio lorawan: US915 sub-band 2 joinEUI 0'
SLOT19   lorawan          booted=True  via=buffer  'wirestudio lorawan: US915 sub-band 2 joinEUI 0'
SLOT28   lorawan-esphome  booted=True  via=buffer  '[I][app:117]: setup() finished successf'
```

**Joining is separate and opt-in**, with a 7-minute budget. Yesterday's measurements (#223) showed the first join after a flash reliably fails and only the retry, one uplink interval later, succeeds. Asserting it by default would fail on a working board — and a gate that is red on healthy hardware is a gate people learn to ignore. There is a test pinning the timeout at ≥6 minutes so nobody tightens it back into that trap.

## Markers are evidence-based

Each comes from a line observed on the bench or emitted by a template in this repo:

| Framework | Marker | Source |
|---|---|---|
| `esphome` | `setup() finished successfully!` | observed, Heltec V4 |
| `lorawan` | `wirestudio lorawan:` | `main.cpp.j2` line 40 |
| `lorawan-esphome` | (as esphome) + `OTAA join OK` | observed |

**Meshtastic and CircuitPython are explicitly unsupported**, with the reason returned to the caller rather than a guessed pattern: no signature has been observed for the former, and the latter's success is CIRCUITPY enumerating as USB mass storage, which a serial marker structurally cannot detect.

## Verification

9 new tests driving the **real** `WorkbenchClient` against a wire-level fake, plus on-hardware checks across all three attached boards — including the negative: asking for the wrong framework returns `booted=False` and surfaces what the board actually printed.

Suite: **1037 passed, 12 skipped**. Tool count 18 hardware / 40 total.

## Not in this PR

The flash-dialog UI integration. Phase 1 shipped server-side first for the same reason — the transport and the browser are separable, and the MCP path is what the headless flow needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ