### PR TITLE
release 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] — 2026-08-23
+
 ### Added
 
 - **Boot-marker verification (workbench phase 2, server side).** A

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.28.2"
+__version__ = "0.29.0"


### PR DESCRIPTION
Minor release — workbench phase 2.

## Added

**Boot-marker verification** (#237). A successful flash proves bytes reached the chip and nothing more; a wrong flash size or an undriven front end flashes cleanly and then fails at start-up. `workbench_verify_boot` watches a slot for a line the running firmware emits, through the bench's read-only serial fan-out.

Supports `esphome`, `lorawan` (standalone RadioLib) and `lorawan-esphome`. **Meshtastic and CircuitPython are explicitly unsupported with the reason returned** — no signature has been observed for the former, and the latter's success is CIRCUITPY enumerating as USB mass storage, which a serial marker structurally cannot detect.

Joining is a separate, opt-in check with a 7-minute budget, because the first join after a flash reliably fails and only the retry succeeds. Asserting it by default would fail on a healthy board.

**A `[Unreleased]` heading check** (#236) — CI-only, reaches no artifact, already in force since it merged.

## Verified on hardware before tagging

All three attached boards, including the negative case:

```
SLOT12   lorawan          booted=True  via=buffer
SLOT19   lorawan          booted=True  via=buffer
SLOT28   lorawan-esphome  booted=True  via=buffer
wrong framework           booted=False + the output it did print
```

Suite: **1037 passed, 12 skipped**. Tool surface now 40 (18 hardware).

## Why minor rather than patch

New module (`wirestudio/workbench/boot.py`), a new MCP tool, and two new `WorkbenchClient` methods. Nothing existing changes behaviour — `monitor()` and `output()` are additions, and no current tool's contract moved — but a new capability is not a bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ