### PR TITLE
fix(workbench): report a bad hardware-gate roster instead of raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The hardware gate reports an unreadable or empty roster as one line and
+  exits 2, instead of raising a traceback. It also rejects a roster with
+  no devices: silently checking nothing and exiting 0 is the worst
+  outcome for a gate, since it reads as "all clear".
+
 ## [0.30.0] — 2026-08-24
 
 ### Added

--- a/tests/test_hardware_gate.py
+++ b/tests/test_hardware_gate.py
@@ -150,3 +150,20 @@ async def test_a_device_silent_for_months_fails():
 
     assert any(s == "uplinks" and "silent for over" in d
                for s, _, ok, d in report.rows if not ok), report.rows
+
+
+def test_a_missing_roster_is_reported_not_raised(tmp_path):
+    """The gate runs unattended; a config typo should read as one line,
+    not a traceback."""
+    with pytest.raises(gate.ConfigError, match="no such roster"):
+        gate._load_config(tmp_path / "nope.yaml")
+
+
+@pytest.mark.parametrize("body", ["", "max_serial_silence_s: 60\n"])
+def test_a_roster_with_no_devices_is_rejected(tmp_path, body):
+    """Silently checking nothing and exiting 0 is the worst outcome for a
+    gate -- it reads as 'all clear'."""
+    p = tmp_path / "roster.yaml"
+    p.write_text(body)
+    with pytest.raises(gate.ConfigError):
+        gate._load_config(p)

--- a/wirestudio/workbench/gate.py
+++ b/wirestudio/workbench/gate.py
@@ -30,7 +30,9 @@ traffic -- reflashing one nightly costs a rejoin, a DevNonce and about
 ten minutes of downtime each time. Add a spare board, set `flash:` on
 its entry, and the stage below turns on.
 
-Exit code is 0 when every enabled check passes, 1 otherwise.
+Exit code is 0 when every enabled check passes, 1 when one fails,
+and 2 when the roster itself is unusable -- a bad config must not read
+as a clean bench.
 """
 from __future__ import annotations
 
@@ -42,10 +44,25 @@ import sys
 import time
 from pathlib import Path
 
+
+class ConfigError(Exception):
+    pass
+
+
 def _load_config(path: Path) -> dict:
     import yaml
 
-    return yaml.safe_load(path.read_text()) or {}
+    try:
+        raw = yaml.safe_load(path.read_text())
+    except FileNotFoundError:
+        raise ConfigError(f"no such roster: {path}") from None
+    except (OSError, yaml.YAMLError) as e:
+        raise ConfigError(f"cannot read roster {path}: {e}") from None
+    if raw is None:
+        raise ConfigError(f"roster {path} is empty")
+    if not isinstance(raw, dict) or not raw.get("devices"):
+        raise ConfigError(f"roster {path} lists no devices")
+    return raw
 
 
 class Report:
@@ -192,7 +209,11 @@ def main() -> int:
               "is deployment state (slot labels, DevEUIs), so it is not shipped --\n"
               "see docs/workbench.md for the schema.", file=sys.stderr)
         return 2
-    config = _load_config(args.config)
+    try:
+        config = _load_config(args.config)
+    except ConfigError as e:
+        print(f"hardware gate: {e}", file=sys.stderr)
+        return 2
     print(f"hardware gate: {args.config}")
     print(f"bench: {os.environ.get('WORKBENCH_URL', '(WORKBENCH_URL unset)')}\n")
 


### PR DESCRIPTION
Follow-up to #239, found while verifying the deployed CronJob's failure signalling.

A missing `--config` raised a bare traceback:

```
FileNotFoundError: [Errno 2] No such file or directory: '/config/does-not-exist.yaml'
```

The Job did fail correctly, so the signal worked — but the gate runs unattended and a config typo should read as one line, not a stack trace. CLAUDE.md's "validate at boundaries (file load, CLI input)" covers exactly this case.

Now:

```
$ wirestudio-hardware-gate --config /nope.yaml
hardware gate: no such roster: /nope.yaml
exit=2
```

Exit 2 distinguishes "the roster is unusable" from exit 1's "a check failed".

Also rejects a roster with no `devices`. Checking nothing and exiting 0 is the worst possible outcome for a gate — it reads as all clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ