### PR TITLE
docs(workbench): how a hardware-gate failure reaches an operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Document how a hardware-gate failure reaches an operator: a failed Job
+  is the report, and two Prometheus alerts turn it into a push. One
+  covers "the run failed", the other "no successful run in 26 hours" --
+  the second exists because if the CronJob stops firing there is no
+  failed Job to alert on, and absence would otherwise read as health.
+
 ### Fixed
 
 - The hardware gate reports an unreadable or empty roster as one line and

--- a/docs/workbench.md
+++ b/docs/workbench.md
@@ -224,3 +224,26 @@ real traffic, and reflashing one nightly costs a rejoin, a DevNonce and
 about ten minutes off the air each time. Until then the gate is a
 bench-health detector, and the "no live-flash gate" caveat on the
 framework tiers still stands.
+
+### How a failure reaches you
+
+There is no PR to annotate, so a failed Job is the report. Two Prometheus
+alerts turn that into a push notification via the cluster's
+alertmanager → ntfy bridge:
+
+- `WireStudioHardwareGateFailed` — the newest run failed and nothing has
+  succeeded since. It compares against the CronJob's `lastSuccessfulTime`
+  rather than alerting on `kube_job_status_failed` directly, because
+  failed Jobs are deliberately kept for a week as evidence and a bare
+  `> 0` would keep firing long after a fix. Re-running the gate by hand
+  clears it: `kubectl create job --from=cronjob/...` inherits the
+  CronJob's ownerReference, so `lastSuccessfulTime` advances.
+- `WireStudioHardwareGateStale` — no successful run in 26 hours. This
+  covers the mode the gate itself is built around: absence reading as
+  health. If the CronJob stops firing there is no failed Job to find, so
+  the first alert stays silent; staleness cannot be fooled that way, and
+  it also catches a sustained failure whose Jobs have aged out.
+
+Both live in the argocd repo, not here, since they describe the
+deployment. The pod log is the full report:
+`kubectl logs -n wirestudio -l job-name=<job> --tail=30`.


### PR DESCRIPTION
Completes the phase-3 loop: the gate now notifies.

Two Prometheus alerts (in the argocd repo, since they describe the deployment) feed the cluster's existing alertmanager → ntfy bridge:

- `WireStudioHardwareGateFailed` — the newest run failed and nothing has succeeded since. It compares against the CronJob's `lastSuccessfulTime` rather than alerting on `kube_job_status_failed` directly, because failed Jobs are deliberately retained for a week as evidence and a bare `> 0` would keep firing long after a fix.
- `WireStudioHardwareGateStale` — no successful run in 26h. This covers the mode the gate itself is built around: if the CronJob stops firing there is no failed Job to find, so the first alert stays silent and absence reads as health.

Both expressions were checked against live Prometheus in the firing and cleared states using a deliberately failing gate Job, and both load `health=ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ