### PR TITLE
feat(workbench): track a device whose cable is out, and notice its return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The hardware gate roster accepts `on_bench: false` for a device that is
+  powered and transmitting but whose USB cable is out. It is dropped from
+  the slots and serial stages and asserted over the radio only. Failing
+  every night on a condition everyone already knows about is how a gate
+  gets muted, which `docs/workbench.md` warns about explicitly.
+- The slots stage now reports a present slot that no roster entry claims.
+  That is the same class of divergence as a declared slot being absent,
+  and it is how an off-bench device announces its return: slot labels are
+  positional, so a reconnected board cannot be predicted onto a label.
+- The roster is rejected if an on-bench device declares no slot, or an
+  off-bench device declares no `dev_eui` -- the latter would sit in the
+  roster looking monitored while nothing about it could be checked.
 - Document how a hardware-gate failure reaches an operator: a failed Job
   is the report, and two Prometheus alerts turn it into a push. One
   covers "the run failed", the other "no successful run in 26 hours" --

--- a/scripts/hardware_gate.example.yaml
+++ b/scripts/hardware_gate.example.yaml
@@ -36,6 +36,18 @@ devices:
     framework: lorawan-esphome
     dev_eui: 8cfd49fffeb55758
 
+  # A board that is powered and transmitting but whose USB cable is out.
+  # `on_bench: false` drops it from the slots and serial stages -- failing
+  # nightly on a known condition is how a gate gets muted -- and keeps the
+  # uplinks check, which is the only assertion still possible. It needs no
+  # slot: labels are positional, so a reconnected board cannot be predicted
+  # onto one. Its return is caught instead by the slots stage reporting a
+  # present slot that no entry claims.
+  - name: TTGO LoRa32 v2
+    on_bench: false
+    framework: lorawan
+    dev_eui: 500291fffe9df404
+
 # Add `flash: true` to a device once there is a *dedicated* board that
 # nothing depends on. Every board above carries real traffic, and
 # reflashing one nightly costs a rejoin, a DevNonce and roughly ten

--- a/tests/test_hardware_gate.py
+++ b/tests/test_hardware_gate.py
@@ -167,3 +167,91 @@ def test_a_roster_with_no_devices_is_rejected(tmp_path, body):
     p.write_text(body)
     with pytest.raises(gate.ConfigError):
         gate._load_config(p)
+
+
+OFF_BENCH = {
+    "max_serial_silence_s": 1800,
+    "max_uplink_silence_s": 3600,
+    "devices": [
+        {"slot": "SLOT1", "framework": "lorawan"},
+        {"name": "TTGO LoRa32 v2", "on_bench": False, "dev_eui": "bb"},
+    ],
+}
+
+
+def _chirp_seen(seconds_ago):
+    chirp = FakeChirp({"bb": {"dev_addr": "02", "f_cnt_up": 9}}, {})
+
+    class Stubs:
+        class device:
+            @staticmethod
+            def Get(req, metadata=None):
+                class R:
+                    class last_seen_at:
+                        seconds = int(time.time()) - seconds_ago
+                return R()
+
+    chirp._get_stubs = lambda: Stubs
+    chirp._auth = []
+    return chirp
+
+
+async def test_off_bench_device_does_not_fail_the_slots_stage():
+    """Its cable is out and everyone knows. Failing nightly on a known
+    condition is how a gate gets muted."""
+    report = gate.Report()
+    bench = FakeBench([FakeSlot("SLOT1")], {"SLOT1": _fresh()})
+    await gate.run(OFF_BENCH, report, client=bench, chirp=_chirp_seen(30))
+
+    assert not report.failed, report.rows
+    assert not any(s in ("slots", "serial") and "LoRa32" in subj
+                   for s, subj, _, _ in report.rows)
+
+
+async def test_off_bench_device_is_still_asserted_over_the_air():
+    """The radio is the only assertion it gets, so it has to be a real one."""
+    report = gate.Report()
+    bench = FakeBench([FakeSlot("SLOT1")], {"SLOT1": _fresh()})
+    await gate.run(OFF_BENCH, report, client=bench, chirp=_chirp_seen(99_999))
+
+    assert any(s == "uplinks" and "LoRa32" in subj and "silent for over" in d
+               for s, subj, ok, d in report.rows if not ok), report.rows
+
+
+async def test_a_reconnected_board_is_reported():
+    """Slot labels are positional, so a returning board cannot be predicted
+    onto a label -- it has to be caught as 'something is here that should
+    not be'. This is the whole point of listing an off-bench device."""
+    report = gate.Report()
+    bench = FakeBench([FakeSlot("SLOT1"), FakeSlot("SLOT7")],
+                      {"SLOT1": _fresh(), "SLOT7": _fresh()})
+    await gate.run(OFF_BENCH, report, client=bench, chirp=_chirp_seen(30))
+
+    hits = [r for r in report.failed if r[1] == "SLOT7"]
+    assert hits, report.rows
+    assert "unexpected board present" in hits[0][3]
+
+
+async def test_an_absent_unclaimed_slot_is_not_reported():
+    """The bench has 31 slots and most are always empty."""
+    report = gate.Report()
+    bench = FakeBench([FakeSlot("SLOT1"), FakeSlot("SLOT7", present=False)],
+                      {"SLOT1": _fresh()})
+    await gate.run(OFF_BENCH, report, client=bench, chirp=_chirp_seen(30))
+    assert not report.failed, report.rows
+
+
+def test_an_on_bench_device_without_a_slot_is_rejected(tmp_path):
+    p = tmp_path / "r.yaml"
+    p.write_text("devices:\n  - name: nameless\n    dev_eui: aa\n")
+    with pytest.raises(gate.ConfigError, match="has no slot"):
+        gate._load_config(p)
+
+
+def test_an_off_bench_device_without_a_dev_eui_is_rejected(tmp_path):
+    """Off the bench and no radio identity means nothing can be checked --
+    it would sit in the roster looking monitored."""
+    p = tmp_path / "r.yaml"
+    p.write_text("devices:\n  - name: ghost\n    on_bench: false\n")
+    with pytest.raises(gate.ConfigError, match="nothing about it can be checked"):
+        gate._load_config(p)

--- a/wirestudio/workbench/gate.py
+++ b/wirestudio/workbench/gate.py
@@ -62,6 +62,15 @@ def _load_config(path: Path) -> dict:
         raise ConfigError(f"roster {path} is empty")
     if not isinstance(raw, dict) or not raw.get("devices"):
         raise ConfigError(f"roster {path} lists no devices")
+    for i, dev in enumerate(raw["devices"]):
+        if dev.get("on_bench", True) and not dev.get("slot"):
+            raise ConfigError(
+                f"roster {path}: device {i} ({dev.get('name', '?')}) has no slot. "
+                "Set `on_bench: false` if it is off the bench on purpose.")
+        if not dev.get("on_bench", True) and not dev.get("dev_eui"):
+            raise ConfigError(
+                f"roster {path}: device {i} ({dev.get('name', '?')}) is off the "
+                "bench with no dev_eui, so nothing about it can be checked.")
     return raw
 
 
@@ -107,7 +116,13 @@ async def run(config: dict, report: Report, client=None, chirp=None) -> None:
         report.add("slots", "listing", False, str(e))
         return
 
-    for dev in devices:
+    # A device declared `on_bench: false` is known to be off the bench -- its
+    # USB cable is out, but it is still powered and on the air. Failing on that
+    # every night would train the reader to ignore the gate, so it is asserted
+    # over the radio only (uplinks, below) and claims no slot.
+    on_bench = [d for d in devices if d.get("on_bench", True)]
+
+    for dev in on_bench:
         label = dev["slot"]
         s = slots.get(label)
         if s is None:
@@ -126,9 +141,21 @@ async def run(config: dict, report: Report, client=None, chirp=None) -> None:
             continue
         report.add("slots", label, True, f"present, chip={s.chip or 'undetected'}")
 
+    # A board present on a slot no entry claims is a divergence from the
+    # declared bench, the same class as a declared slot being absent, and it
+    # is how an off-bench device announces it is back: slot labels are
+    # positional, so a reconnected board cannot be predicted onto a label and
+    # has to be caught by "something is here that should not be".
+    claimed = {d["slot"] for d in on_bench}
+    for label, s in sorted(slots.items()):
+        if s.present and label not in claimed:
+            report.add("slots", label, False,
+                       "unexpected board present -- a device declared "
+                       "`on_bench: false` may be reconnected and flashable again")
+
     # --- serial liveness ------------------------------------------------
     cutoff = time.time() - max_silence
-    for dev in devices:
+    for dev in on_bench:
         label = dev["slot"]
         s = slots.get(label)
         if s is None or not s.present:
@@ -148,7 +175,10 @@ async def run(config: dict, report: Report, client=None, chirp=None) -> None:
                        f"nothing captured in {int(max_silence)}s -- board may be hung")
 
     # --- uplinks --------------------------------------------------------
-    euis = [(d["slot"], d["dev_eui"]) for d in devices if d.get("dev_eui")]
+    # An off-bench device has no slot to name it by, so fall back to its
+    # roster name -- this stage is the only assertion it gets.
+    euis = [(d.get("slot") or d.get("name") or d["dev_eui"], d["dev_eui"])
+            for d in devices if d.get("dev_eui")]
     if euis:
         from wirestudio.targets.lorawan import chirpstack as cs
 


### PR DESCRIPTION
The TTGO LoRa32 v2 (`500291fffe9df404`) is powered and uplinking every few minutes, but its USB cable is out — it is absent from the bench and cannot be flashed.

Two bad options, and a third:

- List it as an ordinary device → the slots and serial stages fail **every night** on a condition everyone already knows about. `docs/workbench.md` says explicitly that this is how a gate gets muted within a month.
- Leave it out → nothing watches it at all.
- `on_bench: false` → drop it from the stages that need a cable, keep the uplink check. That is the only assertion still possible for it, and it is a real one: if it goes silent, its power died.

## Noticing when it comes back

This needed a separate mechanism. Slot labels are **positional** — assigned in sorted hub-port order — so a reconnected board cannot be predicted onto a label. Pinning the entry to its old SLOT31 would silently miss it returning on any other port.

So the slots stage now reports any present slot that no roster entry claims. That is the same class of divergence as a declared slot being absent, which the gate already fails on; it just means the gate now asserts the bench matches its declared configuration **in both directions** instead of only one. As a side effect it also catches a board nobody told the roster about.

## Roster validation

Rejected at load: an on-bench device with no slot, and an off-bench device with no `dev_eui`. The second matters — such an entry would sit in the roster looking monitored while nothing about it could be checked.

## Verification

Against the real bench, all-green as configured (no unclaimed slots). Then with SLOT12 deliberately removed from the roster to simulate a reconnection:

```
  ok   slots     SLOT19    present, chip=undetected
  ok   slots     SLOT28    present, chip=esp32s3
  FAIL slots     SLOT12    unexpected board present -- a device declared
                           `on_bench: false` may be reconnected and flashable again
```

6 new tests; full suite 1053 passed, 12 skipped.

**Deploy order matters:** the roster entry must not land in the cluster ConfigMap until this ships, since 0.30.0 would `KeyError` on an entry with no `slot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ