### PR TITLE
fix: classic-ESP32 merged images, and stale profiles on re-provision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A merged image for the classic ESP32 was mistaken for a bare app.**
+  `is_merged_image` required the ESP image magic at byte 0, but only the
+  ESP32-S3/C3 family puts its bootloader there -- on the classic ESP32 it
+  sits at 0x1000, so the image opens with 4 KiB of 0xff erase padding.
+  The sniffer read that as "not merged" and would have written the whole
+  image to the app offset: the exact bricking case it exists to prevent,
+  one chip family over. Caught while flashing a T-Beam.
+- **Re-provisioning left an existing device on its old ChirpStack
+  profile.** `create_device` treated a known DevEUI as a no-op, so a
+  design whose sensor set changed got a correct new profile that nothing
+  pointed at, while the caller reported the new profile id -- success for
+  a device decoding every uplink at the wrong byte offsets. Seen on a
+  real T-Beam, where `batt_mv` was reading the temperature. The device is
+  now re-pointed, and the fetched message is handed back to `UpdateDevice`
+  so its other fields survive.
+
 ### Added
 
 - **`t-beam-lorawan` example.** A T-Beam uplinking GPS position, cell

--- a/tests/test_chirpstack.py
+++ b/tests/test_chirpstack.py
@@ -308,3 +308,50 @@ def test_configured_tenant_id_skips_the_admin_only_lookup():
     )
     assert client.default_tenant_id() == "tenant-1"
     stubs.tenant.List.assert_not_called()
+
+
+def test_create_device_repoints_an_existing_device_at_the_new_profile():
+    """A design whose sensor set changed produces a new payload layout and a
+    new profile to decode it. Leaving the device on its old profile decodes
+    every uplink at the wrong byte offsets while provision_device still
+    reports the new profile id -- success for a device emitting garbage.
+    Observed on a real T-Beam: batt_mv read the temperature.
+    """
+    stubs = _stubs()
+    stubs.device.Create.side_effect = _RpcError(
+        grpc.StatusCode.INTERNAL,
+        details="UNIQUE constraint failed: device.dev_eui",
+    )
+    # A real Device proto, not a stand-in: the fix hands the fetched message
+    # straight back to UpdateDevice so the fields it does not touch (name,
+    # join_eui, tags) survive the round trip. A fake would hide that.
+    from chirpstack_api.api import device_pb2
+
+    existing = device_pb2.Device(
+        dev_eui="0011223344556677", name="T-Beam",
+        application_id="app", device_profile_id="dp-old",
+    )
+    stubs.device.Get.return_value = SimpleNamespace(device=existing)
+
+    _client(stubs).create_device("0011223344556677", "dev", "app", "dp-new")
+
+    assert stubs.device.Update.called, "device was left on its stale profile"
+    sent = stubs.device.Update.call_args[0][0].device
+    assert sent.device_profile_id == "dp-new"
+    assert sent.name == "T-Beam", "an Update must not blank the other fields"
+
+
+def test_create_device_does_not_update_when_the_profile_already_matches():
+    """No write when nothing changed -- the idempotent path stays a no-op."""
+    stubs = _stubs()
+    stubs.device.Create.side_effect = _RpcError(
+        grpc.StatusCode.INTERNAL,
+        details="UNIQUE constraint failed: device.dev_eui",
+    )
+    stubs.device.Get.return_value = SimpleNamespace(
+        device=SimpleNamespace(application_id="app", device_profile_id="dp"),
+    )
+
+    _client(stubs).create_device("0011223344556677", "dev", "app", "dp")
+
+    assert not stubs.device.Update.called

--- a/tests/test_mcp_hardware.py
+++ b/tests/test_mcp_hardware.py
@@ -279,6 +279,19 @@ def _merged_image(app_len: int = 4096) -> bytes:
     return bytes(blob)
 
 
+def _esp32_merged_image(app_len: int = 4096) -> bytes:
+    """A merged image for the *classic* ESP32, whose bootloader lives at
+    0x1000 rather than 0x0 -- so the image opens with 4 KiB of 0xff erase
+    padding. This is what PlatformIO produces for a ttgo-t-beam, verified
+    byte-for-byte against a real factory.bin.
+    """
+    blob = bytearray(b"\xff" * 0x1000 + b"\x00" * (0xF000 + app_len))
+    blob[0x1000] = 0xE9
+    blob[0x8000:0x8002] = b"\xaa\x50"
+    blob[0x10000] = 0xE9
+    return bytes(blob)
+
+
 def _app_image(size: int = 4096) -> bytes:
     """A bare app image: ESP magic, and nothing at the partition offset."""
     return b"\xe9" + b"\x11" * (size - 1)
@@ -291,6 +304,26 @@ def test_merged_and_app_images_are_told_apart():
     assert is_merged_image(_app_image()) is False
     assert is_merged_image(b"") is False
     assert is_merged_image(b"\x00" * 0x20000) is False  # no ESP magic
+
+
+def test_a_classic_esp32_merged_image_is_recognised():
+    """Its bootloader is at 0x1000, so the image starts with 0xff padding.
+    Requiring the ESP magic at byte 0 classified it as a bare app, which
+    would write the whole thing to the app offset and brick the board --
+    the exact failure this function exists to prevent, one chip family over.
+    """
+    from wirestudio.mcp.hardware import is_merged_image
+
+    assert is_merged_image(_esp32_merged_image()) is True
+
+
+def test_padding_alone_is_not_a_merged_image():
+    """0xff with no bootloader behind it is an erased region, not an image."""
+    from wirestudio.mcp.hardware import is_merged_image
+
+    blob = bytearray(b"\xff" * 0x20000)
+    blob[0x8000:0x8002] = b"\xaa\x50"
+    assert is_merged_image(bytes(blob)) is False
 
 
 async def test_merged_artifact_is_written_at_zero(tmp_path):

--- a/wirestudio/mcp/hardware.py
+++ b/wirestudio/mcp/hardware.py
@@ -63,6 +63,7 @@ def _valid_eui(dev_eui: str) -> bool:
 _PARTITION_TABLE_MAGIC = b"\xaa\x50"
 _PARTITION_TABLE_OFFSET = 0x8000
 _ESP_IMAGE_MAGIC = 0xE9
+_BOOTLOADER_OFFSETS = (0x0, 0x1000)
 _DEFAULT_APP_OFFSET = 0x10000
 
 
@@ -78,7 +79,16 @@ def is_merged_image(blob: bytes) -> bool:
     partitions". Getting this from the artifact is the only way that
     stays correct across addon versions.
     """
-    if len(blob) <= _PARTITION_TABLE_OFFSET + 2 or blob[0] != _ESP_IMAGE_MAGIC:
+    if len(blob) <= _PARTITION_TABLE_OFFSET + 2:
+        return False
+    # The bootloader is at 0x0 on the ESP32-S3/C3 family but at 0x1000 on the
+    # classic ESP32, whose merged image therefore opens with 4 KiB of 0xff
+    # padding. Requiring the image magic at byte 0 read that padding as "not
+    # merged" and would have written the whole image to the app offset --
+    # the bricking case this function exists to prevent, just one chip family
+    # over.
+    if not any(len(blob) > off and blob[off] == _ESP_IMAGE_MAGIC
+               for off in _BOOTLOADER_OFFSETS):
         return False
     at_table = blob[_PARTITION_TABLE_OFFSET:_PARTITION_TABLE_OFFSET + 2]
     return at_table == _PARTITION_TABLE_MAGIC

--- a/wirestudio/targets/lorawan/chirpstack.py
+++ b/wirestudio/targets/lorawan/chirpstack.py
@@ -269,7 +269,12 @@ class ChirpStackClient:
         *,
         join_eui: Optional[str] = None,
     ) -> None:
-        """Create the device. Idempotent: an existing DevEUI is left in place."""
+        """Create the device.
+
+        Idempotent on identity: an existing DevEUI keeps its registration.
+        Its profile is re-pointed if the design now needs a different one --
+        see the already-exists branch.
+        """
         grpc, m = _load()
         device = m.dev.Device(
             dev_eui=dev_eui,
@@ -307,6 +312,20 @@ class ChirpStackClient:
                     f"application ({existing.application_id}); remove it from "
                     "that application before re-provisioning here."
                 )
+            # The device is ours, but it may be sitting on a stale profile.
+            # Re-provisioning a design whose sensor set changed produces a new
+            # payload layout and a new profile to decode it; leaving the device
+            # pointed at the old one decodes every uplink at the wrong offsets,
+            # and the caller still reports the new profile id -- success for a
+            # device that is quietly emitting garbage.
+            if existing.device_profile_id != device_profile_id:
+                existing.device_profile_id = device_profile_id
+                try:
+                    stubs.device.Update(
+                        m.dev.UpdateDeviceRequest(device=existing), metadata=self._auth
+                    )
+                except grpc.RpcError as upd_exc:
+                    raise ChirpStackUnavailable(_rpc_msg(upd_exc)) from upd_exc
 
     def set_device_keys(self, dev_eui: str, app_key: str) -> None:
         """Set the device's root key. For our pinned LoRaWAN 1.0.4 devices the


### PR DESCRIPTION
Two bugs found while flashing the T-Beam on the bench. Both are silent-failure classes.

## A merged image for the classic ESP32 was read as a bare app

`is_merged_image` required the ESP image magic at byte 0. Only the ESP32-S3/C3 family puts its bootloader there — the **classic ESP32 puts it at 0x1000**, so its merged image opens with 4 KiB of 0xff erase padding.

The sniffer read that padding as "not merged" and would have written the whole image, bootloader and all, to the app offset. That is the exact bricking case this function was added to prevent, one chip family over.

Verified against the real 476 KB `factory.bin` PlatformIO produced for `ttgo-t-beam`:

```
  0x000000: ffffffffffffffff    padding
  0x001000: e9030220e4050840    bootloader magic
  0x008000: aa50010200900000    partition table
  0x010000: e906022048320840    app
```

## Re-provisioning left a device on its old profile

`create_device` treated an already-registered DevEUI as a pure no-op, so it never re-pointed the device at a new profile. Re-provisioning a design whose sensor set changed therefore created the correct new profile, left the device on the old one, and **returned the new profile id anyway** — a success report for a device decoding every uplink at the wrong offsets.

Concretely, on the T-Beam: the new firmware packs `temp_c` at b[17..18] and `batt_mv` at b[20..21], but the stale profile decoded `batt_mv` from b[17..18] and reported **3559 mV** — the temperature, ×100.

The fix hands the *fetched* message back to `UpdateDevice` rather than building a fresh one, so name / join_eui / tags survive; a test asserts that specifically.

## Verification

Both fixes confirmed against live hardware. After re-pointing, a real uplink decodes correctly:

```
data: AAAA+AABFWNb+cftk50CXAMN5ykQDA==   (22 bytes)
object: {uptime_s: 248, boot_count: 1, lat: 35.8833145, lon: -94.0731491,
         alt_m: 604, sats: 3, temp_c: 35.59, humidity: 41, batt_mv: 4108}
```

4 new tests; suite 1067 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ