### PR TITLE
feat(lorawan): report how stale the GPS position is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`fix_age_min` on every GPS payload.** The position is deliberately
+  never cleared when the fix drops -- on a vehicle "where was it last
+  seen" is the whole point, and a machine parked with its GNSS off should
+  still report where it is. But then nothing distinguished a live fix from
+  a week-old one, so the age of the position now rides alongside it.
+  65535 is the sentinel for "never had a fix": without the `isValid()`
+  guard an unfixed device reports age 0, reading as perfectly fresh, which
+  is the confusion the field exists to end.
+- This is a **breaking payload change for any design carrying a GPS**.
+  The field sits after `sats`, so everything downstream of it shifts by
+  two bytes and existing devices need a rebuild, reflash and profile
+  update before their uplinks decode correctly again. The T-Beam example
+  goes 22 -> 24 bytes, still inside DR1's 53-byte cap, so it costs no
+  range.
+- **`t-beam-lorawan` example.** A T-Beam uplinking GPS position, cell
+  voltage and DHT22 temperature/humidity, with an SSD1306 showing live
+  status. The only standalone-LoRaWAN example so far was a bare board;
+  this one exercises sensors the board file knows nothing about
+  alongside the two it does.
+- The cell voltage comes from the onboard AXP192, not an ADC divider:
+  `ttgo-t-beam` declares no `battery_adc`, and the codec already refuses
+  to synthesize one when a PMIC is present, since both would collide on
+  `batt_mv`.
+- The design carries no radio component. The board file owns the SX1276
+  wiring and `lorawan.region` drives the frequency, so the 433 MHz
+  `sx127x` the ESPHome T-Beam example carries would be a false statement
+  on a US915 device.
+
 ### Fixed
 
 - **A merged image for the classic ESP32 was mistaken for a bare app.**
@@ -24,22 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   real T-Beam, where `batt_mv` was reading the temperature. The device is
   now re-pointed, and the fetched message is handed back to `UpdateDevice`
   so its other fields survive.
-
-### Added
-
-- **`t-beam-lorawan` example.** A T-Beam uplinking GPS position, cell
-  voltage and DHT22 temperature/humidity, with an SSD1306 showing live
-  status. The only standalone-LoRaWAN example so far was a bare board;
-  this one exercises sensors the board file knows nothing about
-  alongside the two it does.
-- The cell voltage comes from the onboard AXP192, not an ADC divider:
-  `ttgo-t-beam` declares no `battery_adc`, and the codec already refuses
-  to synthesize one when a PMIC is present, since both would collide on
-  `batt_mv`.
-- The design carries no radio component. The board file owns the SX1276
-  wiring and `lorawan.region` drives the frequency, so the 433 MHz
-  `sx127x` the ESPHome T-Beam example carries would be a false statement
-  on a US915 device.
 
 ## [0.31.0] — 2026-08-25
 

--- a/tests/golden/t-beam-lorawan.cpp
+++ b/tests/golden/t-beam-lorawan.cpp
@@ -95,7 +95,7 @@ if (Wire.endTransmission() == 0 && display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
   } else {
     Serial.println("JOIN FAILED: not activated (check keys + gateway coverage; retries on reboot)");
   }
-  // US915 DR0 (SF10) caps the app payload at 11 bytes; this 22-byte
+  // US915 DR0 (SF10) caps the app payload at 11 bytes; this 24-byte
   // payload needs at least DR1. ADR tunes the rate from here.
   node->setDatarate(1);
 }
@@ -151,7 +151,7 @@ if (oledReady) {
     if (node->isActivated()) {
       // Payload packed big-endian from the generated field spec (codec.py),
       // in lockstep with the ChirpStack decodeUplink codec on the profile.
-      uint8_t payload[22];
+      uint8_t payload[24];
   uint32_t _v_uptime_s = (uint32_t)(millis() / 1000UL);
   payload[0] = (uint8_t)(_v_uptime_s >> 24);
   payload[1] = (uint8_t)(_v_uptime_s >> 16);
@@ -175,17 +175,22 @@ if (oledReady) {
   payload[15] = (uint8_t)(_v_alt_m);
   uint8_t _v_sats = (uint8_t)gps.satellites.value();
   payload[16] = (uint8_t)(_v_sats);
+  uint16_t _v_fix_age_min = (uint16_t)(gps.location.isValid()
+  ? ((gps.location.age() / 60000UL) > 65534UL ? 65534UL : (gps.location.age() / 60000UL))
+  : 65535UL);
+  payload[17] = (uint8_t)(_v_fix_age_min >> 8);
+  payload[18] = (uint8_t)(_v_fix_age_min);
   int16_t _v_temp_c = (int16_t)(dhtTempC * 100.0);
-  payload[17] = (uint8_t)(_v_temp_c >> 8);
-  payload[18] = (uint8_t)(_v_temp_c);
+  payload[19] = (uint8_t)(_v_temp_c >> 8);
+  payload[20] = (uint8_t)(_v_temp_c);
   uint8_t _v_humidity = (uint8_t)dhtHumidity;
-  payload[19] = (uint8_t)(_v_humidity);
+  payload[21] = (uint8_t)(_v_humidity);
   uint16_t _v_batt_mv = batteryMv;
-  payload[20] = (uint8_t)(_v_batt_mv >> 8);
-  payload[21] = (uint8_t)(_v_batt_mv);
+  payload[22] = (uint8_t)(_v_batt_mv >> 8);
+  payload[23] = (uint8_t)(_v_batt_mv);
       // Re-assert the rate every uplink. Setting it once after join is not
       // enough: a restored session or an ADR downlink can drop us to DR0,
-      // whose payload cap is below these 22 bytes, and then
+      // whose payload cap is below these 24 bytes, and then
       // every sendReceive fails RADIOLIB_ERR_PACKET_TOO_LONG (-4) with nothing
       // but a serial line to show for it -- the device stays joined and
       // silently stops uplinking.

--- a/tests/golden/t-beam-lorawan.js
+++ b/tests/golden/t-beam-lorawan.js
@@ -1,7 +1,7 @@
 function decodeUplink(input) {
   var b = input.bytes;
-  if (b.length < 22) {
-    return { data: {}, warnings: [], errors: ['expected 22 bytes, got ' + b.length] };
+  if (b.length < 24) {
+    return { data: {}, warnings: [], errors: ['expected 24 bytes, got ' + b.length] };
   }
   var data = {};
   data.uptime_s = (((b[0] << 24) | (b[1] << 16) | (b[2] << 8) | b[3]) >>> 0);
@@ -10,8 +10,125 @@ function decodeUplink(input) {
   data.lon = ((b[10] << 24) | (b[11] << 16) | (b[12] << 8) | b[13]) / 10000000;
   data.alt_m = ((((b[14] << 8) | b[15]) << 16) >> 16);
   data.sats = ((b[16]) >>> 0);
-  data.temp_c = ((((b[17] << 8) | b[18]) << 16) >> 16) / 100;
-  data.humidity = ((b[19]) >>> 0);
-  data.batt_mv = (((b[20] << 8) | b[21]) >>> 0);
+  data.fix_age_min = (((b[17] << 8) | b[18]) >>> 0);
+  data.temp_c = ((((b[19] << 8) | b[20]) << 16) >> 16) / 100;
+  data.humidity = ((b[21]) >>> 0);
+  data.batt_mv = (((b[22] << 8) | b[23]) >>> 0);
   return { data: data, warnings: [], errors: [] };
+}
+
+function getHaDeviceInfo() {
+  return {
+    device: { manufacturer: "wirestudio", model: "wirestudio-ttgo-t-beam-us915-sub2-gps-batt-dht" },
+    entities: {
+    uptime_s: {
+      entity_conf: {
+        value_template: "{{ value_json.object.uptime_s | int }}",
+        entity_category: "diagnostic",
+        device_class: "duration",
+        unit_of_measurement: "s"
+      }
+    },
+    boot_count: {
+      entity_conf: {
+        value_template: "{{ value_json.object.boot_count | int }}",
+        entity_category: "diagnostic",
+        state_class: "measurement",
+        icon: "mdi:restart"
+      }
+    },
+    lat: {
+      entity_conf: {
+        value_template: "{{ value_json.object.lat | float }}",
+        entity_category: "diagnostic",
+        unit_of_measurement: "°",
+        icon: "mdi:latitude"
+      }
+    },
+    lon: {
+      entity_conf: {
+        value_template: "{{ value_json.object.lon | float }}",
+        entity_category: "diagnostic",
+        unit_of_measurement: "°",
+        icon: "mdi:longitude"
+      }
+    },
+    alt_m: {
+      entity_conf: {
+        value_template: "{{ value_json.object.alt_m | float }}",
+        entity_category: "diagnostic",
+        state_class: "measurement",
+        device_class: "distance",
+        unit_of_measurement: "m"
+      }
+    },
+    sats: {
+      entity_conf: {
+        value_template: "{{ value_json.object.sats | int }}",
+        entity_category: "diagnostic",
+        state_class: "measurement",
+        icon: "mdi:satellite-variant"
+      }
+    },
+    fix_age_min: {
+      entity_conf: {
+        value_template: "{{ value_json.object.fix_age_min | int }}",
+        entity_category: "diagnostic",
+        state_class: "measurement",
+        unit_of_measurement: "min",
+        icon: "mdi:map-clock"
+      }
+    },
+    temp_c: {
+      entity_conf: {
+        value_template: "{{ value_json.object.temp_c | float }}",
+        state_class: "measurement",
+        device_class: "temperature",
+        unit_of_measurement: "°C"
+      }
+    },
+    humidity: {
+      entity_conf: {
+        value_template: "{{ value_json.object.humidity | int }}",
+        state_class: "measurement",
+        device_class: "humidity",
+        unit_of_measurement: "%"
+      }
+    },
+    batt_mv: {
+      entity_conf: {
+        value_template: "{{ (value_json.object.batt_mv | float) / 1000 }}",
+        entity_category: "diagnostic",
+        state_class: "measurement",
+        device_class: "voltage",
+        unit_of_measurement: "V"
+      }
+    },
+    rssi: {
+      entity_conf: {
+        value_template: "{{ value_json.rxInfo[-1].rssi | int }}",
+        entity_category: "diagnostic",
+        device_class: "signal_strength",
+        unit_of_measurement: "dBm"
+      }
+    },
+    snr: {
+      entity_conf: {
+        value_template: "{{ value_json.rxInfo[-1].snr | float }}",
+        entity_category: "diagnostic",
+        unit_of_measurement: "dB",
+        icon: "mdi:wave"
+      }
+    },
+    location: {
+      integration: "device_tracker",
+      entity_conf: {
+        source_type: "gps",
+        value_template: "{{ 'home' if (value_json.object.sats | int) > 0 else 'not_home' }}",
+        json_attributes_topic: "{status_topic}",
+        json_attributes_template: "{{ {'latitude': value_json.object.lat, 'longitude': value_json.object.lon, 'gps_accuracy': 10} | tojson }}"
+      }
+    }
+    }
+  };
 }

--- a/tests/golden/t-beam.cpp
+++ b/tests/golden/t-beam.cpp
@@ -65,7 +65,7 @@ if (power.begin(Wire, AXP192_SLAVE_ADDRESS, 21, 22)) {
   } else {
     Serial.println("JOIN FAILED: not activated (check keys + gateway coverage; retries on reboot)");
   }
-  // US915 DR0 (SF10) caps the app payload at 11 bytes; this 19-byte
+  // US915 DR0 (SF10) caps the app payload at 11 bytes; this 21-byte
   // payload needs at least DR1. ADR tunes the rate from here.
   node->setDatarate(1);
 }
@@ -103,7 +103,7 @@ while (GPSSerial.available()) gps.encode(GPSSerial.read());  // keep the fix cur
     if (node->isActivated()) {
       // Payload packed big-endian from the generated field spec (codec.py),
       // in lockstep with the ChirpStack decodeUplink codec on the profile.
-      uint8_t payload[19];
+      uint8_t payload[21];
   uint32_t _v_uptime_s = (uint32_t)(millis() / 1000UL);
   payload[0] = (uint8_t)(_v_uptime_s >> 24);
   payload[1] = (uint8_t)(_v_uptime_s >> 16);
@@ -127,12 +127,17 @@ while (GPSSerial.available()) gps.encode(GPSSerial.read());  // keep the fix cur
   payload[15] = (uint8_t)(_v_alt_m);
   uint8_t _v_sats = (uint8_t)gps.satellites.value();
   payload[16] = (uint8_t)(_v_sats);
+  uint16_t _v_fix_age_min = (uint16_t)(gps.location.isValid()
+  ? ((gps.location.age() / 60000UL) > 65534UL ? 65534UL : (gps.location.age() / 60000UL))
+  : 65535UL);
+  payload[17] = (uint8_t)(_v_fix_age_min >> 8);
+  payload[18] = (uint8_t)(_v_fix_age_min);
   uint16_t _v_batt_mv = batteryMv;
-  payload[17] = (uint8_t)(_v_batt_mv >> 8);
-  payload[18] = (uint8_t)(_v_batt_mv);
+  payload[19] = (uint8_t)(_v_batt_mv >> 8);
+  payload[20] = (uint8_t)(_v_batt_mv);
       // Re-assert the rate every uplink. Setting it once after join is not
       // enough: a restored session or an ADR downlink can drop us to DR0,
-      // whose payload cap is below these 19 bytes, and then
+      // whose payload cap is below these 21 bytes, and then
       // every sendReceive fails RADIOLIB_ERR_PACKET_TOO_LONG (-4) with nothing
       // but a serial line to show for it -- the device stays joined and
       // silently stops uplinking.

--- a/tests/golden/t-beam.js
+++ b/tests/golden/t-beam.js
@@ -1,7 +1,7 @@
 function decodeUplink(input) {
   var b = input.bytes;
-  if (b.length < 19) {
-    return { data: {}, warnings: [], errors: ['expected 19 bytes, got ' + b.length] };
+  if (b.length < 21) {
+    return { data: {}, warnings: [], errors: ['expected 21 bytes, got ' + b.length] };
   }
   var data = {};
   data.uptime_s = (((b[0] << 24) | (b[1] << 16) | (b[2] << 8) | b[3]) >>> 0);
@@ -10,7 +10,8 @@ function decodeUplink(input) {
   data.lon = ((b[10] << 24) | (b[11] << 16) | (b[12] << 8) | b[13]) / 10000000;
   data.alt_m = ((((b[14] << 8) | b[15]) << 16) >> 16);
   data.sats = ((b[16]) >>> 0);
-  data.batt_mv = (((b[17] << 8) | b[18]) >>> 0);
+  data.fix_age_min = (((b[17] << 8) | b[18]) >>> 0);
+  data.batt_mv = (((b[19] << 8) | b[20]) >>> 0);
   return { data: data, warnings: [], errors: [] };
 }
 
@@ -65,6 +66,15 @@ function getHaDeviceInfo() {
         entity_category: "diagnostic",
         state_class: "measurement",
         icon: "mdi:satellite-variant"
+      }
+    },
+    fix_age_min: {
+      entity_conf: {
+        value_template: "{{ value_json.object.fix_age_min | int }}",
+        entity_category: "diagnostic",
+        state_class: "measurement",
+        unit_of_measurement: "min",
+        icon: "mdi:map-clock"
       }
     },
     batt_mv: {

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -27,9 +27,10 @@ def test_tbeam_adds_onboard_gps_and_battery():
     lib = default_library()
     fields = codec.fields_for(_design("ttgo-t-beam"), lib)
     assert [f["name"] for f in fields] == [
-        "uptime_s", "boot_count", "lat", "lon", "alt_m", "sats", "batt_mv",
+        "uptime_s", "boot_count", "lat", "lon", "alt_m", "sats",
+        "fix_age_min", "batt_mv",
     ]
-    assert codec.payload_size(fields) == 19
+    assert codec.payload_size(fields) == 21
 
 
 def test_radio_only_board_reports_battery_from_its_divider():
@@ -78,7 +79,9 @@ def test_decode_js_offsets_and_scaling():
     assert "data.lat = ((b[6] << 24)" in js  # lat begins after the 6-byte built-in block
     assert "/ 10000000" in js
     assert "data.alt_m = ((((b[14] << 8) | b[15]) << 16) >> 16)" in js  # signed 16-bit
-    assert "data.batt_mv = (((b[17] << 8) | b[18]) >>> 0)" in js
+    # fix_age_min sits at b[17:18], pushing batt_mv out by two.
+    assert "data.fix_age_min = (((b[17] << 8) | b[18]) >>> 0)" in js
+    assert "data.batt_mv = (((b[19] << 8) | b[20]) >>> 0)" in js
 
 
 def test_pack_cpp_matches_size_and_reads_sensors():

--- a/tests/test_tbeam_lorawan_example.py
+++ b/tests/test_tbeam_lorawan_example.py
@@ -54,14 +54,17 @@ def test_the_pmic_supplies_the_cell_voltage(design, lib):
 def test_payload_carries_gps_environment_and_battery(design, lib):
     names = [f["name"] for f in codec.fields_for(design, lib)]
     assert names == ["uptime_s", "boot_count", "lat", "lon", "alt_m",
-                     "sats", "temp_c", "humidity", "batt_mv"]
+                     "sats", "fix_age_min", "temp_c", "humidity", "batt_mv"]
 
 
 def test_the_datarate_floor_clears_the_payload(design, lib):
-    """US915 DR0 caps the app payload at 11 bytes and this payload is 22, so
-    a build that let ADR reach DR0 would have its uplinks rejected outright."""
+    """US915 DR0 caps the app payload at 11 bytes and this payload is 24, so
+    a build that let ADR reach DR0 would have its uplinks rejected outright.
+    24 is still well inside DR1's 53-byte cap, so adding fix_age_min cost no
+    range."""
     size = codec.payload_size(codec.fields_for(design, lib))
-    assert size == 22
+    assert size == 24
+    assert size <= 53, "still fits DR1"
 
     cpp = generate_firmware(design, lib)["src/main.cpp"]
     assert "node->setDatarate(1);" in cpp
@@ -100,5 +103,29 @@ def test_firmware_matches_golden(design, lib, key, golden):
 
 
 def test_codec_matches_golden(design, lib):
-    js = codec.decode_js(codec.fields_for(design, lib))
-    assert js == (GOLDEN / "t-beam-lorawan.js").read_text()
+    """generate_codec, not decode_js: the HA entity block rides along with
+    the decoder and is what actually lands on the ChirpStack profile."""
+    assert codec.generate_codec(design, lib) == (GOLDEN / "t-beam-lorawan.js").read_text()
+
+
+def test_position_is_retained_when_the_fix_drops(design, lib):
+    """lat/lon are published unconditionally, on purpose. On a vehicle,
+    "where was it last seen" is the point -- a machine parked with its GNSS
+    off should still report where it is. So the position is never cleared."""
+    cpp = generate_firmware(design, lib)["src/main.cpp"]
+    assert "(int32_t)(gps.location.lat() * 10000000.0)" in cpp
+    assert "isValid() ? (int32_t)" not in cpp, "position must not be gated on a fix"
+
+
+def test_fix_age_distinguishes_stale_from_fresh(design, lib):
+    """Retaining the position means nothing marks a week-old fix as old, so
+    the age rides alongside it. The isValid() guard is load-bearing: without
+    it a device that never got a fix reports age 0 -- reading as perfectly
+    fresh, which is the exact confusion this field exists to end."""
+    cpp = generate_firmware(design, lib)["src/main.cpp"]
+    assert "gps.location.isValid()" in cpp
+    assert "65535" in cpp, "sentinel for 'never had a fix'"
+    assert "60000UL" in cpp, "milliseconds -> minutes"
+
+    names = [f["name"] for f in codec.fields_for(design, lib)]
+    assert names.index("fix_age_min") == names.index("sats") + 1

--- a/wirestudio/library/components/uart_gps.yaml
+++ b/wirestudio/library/components/uart_gps.yaml
@@ -75,6 +75,24 @@ lorawan:
       ha_state_class: measurement
       ha_diagnostic: true
       ha_icon: mdi:satellite-variant
+    # How stale lat/lon are. The position is deliberately NOT cleared when the
+    # fix drops -- on a vehicle, "where was it last seen" is the whole point,
+    # and a parked machine with its GNSS off should still report its location.
+    # But then nothing distinguishes a live fix from a week-old one, so the age
+    # rides alongside it. 65535 is the sentinel for "never had a fix": without
+    # the isValid() guard an unfixed device reports age 0, i.e. reads as
+    # perfectly fresh, which is the exact confusion this field exists to end.
+    - name: fix_age_min
+      bytes: 2
+      cpp_type: uint16_t
+      cpp_expr: >-
+        (uint16_t)(gps.location.isValid()
+          ? ((gps.location.age() / 60000UL) > 65534UL ? 65534UL : (gps.location.age() / 60000UL))
+          : 65535UL)
+      ha_unit: min
+      ha_state_class: measurement
+      ha_diagnostic: true
+      ha_icon: mdi:map-clock
 
 esphome:
   required_components: [uart]


### PR DESCRIPTION
The T-Beam is destined for a side-by-side or the tractor, so **the last known position is a feature, not a bug** — a machine parked with its GNSS off should still report where it is. Position stays published unconditionally.

What was missing is that nothing distinguished a live fix from a week-old one. Observed on the bench: an uplink reporting `sats=0` carried coordinates anyway, indistinguishable from a current fix.

## The field

`fix_age_min`, uint16, immediately after `sats`:

```cpp
(uint16_t)(gps.location.isValid()
  ? ((gps.location.age() / 60000UL) > 65534UL ? 65534UL : (gps.location.age() / 60000UL))
  : 65535UL)
```

The `isValid()` guard is load-bearing, not defensive. TinyGPSPlus hands back a last-known position indefinitely, so **a device that never had a fix would report age 0** — reading as perfectly fresh, which is precisely the confusion this field exists to end. 65535 is the sentinel for that case; 65534 caps a genuinely old fix at ~45 days.

## Breaking payload change

Any design carrying a GPS shifts by two bytes downstream of `sats`. Existing devices need a rebuild, reflash and profile update before they decode correctly again.

```
b[ 0: 4] uptime_s      b[16:17] sats
b[ 4: 6] boot_count    b[17:19] fix_age_min   <- new
b[ 6:10] lat           b[19:21] temp_c
b[10:14] lon           b[21:22] humidity
b[14:16] alt_m         b[22:24] batt_mv
```

T-Beam example: 22 → 24 bytes, still inside DR1's 53-byte cap, so **no range cost**. The bare-board golden goes 19 → 21.

## Also

`t-beam-lorawan.js` now pins `generate_codec` rather than `decode_js`. The HA entity block ships to the ChirpStack profile too, and the golden was not covering it — spotted when regenerating dropped 98 lines.

Suite 1069 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRSc1tPDTs7F12PshpWdwJ