### PR TITLE
flash size: a per-design override for multi-SKU boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`board.flash_size_mb` in `design.json`: a per-design override of the
+  library board file's flash size.** Board files pin the *floor* for
+  boards sold in several sizes under one name -- the ESP32-S3-DevKitC-1
+  ships as N8/N8R2/N8R8 (8MB) and N32R16V (32MB) -- because
+  over-declaring boot-loops the board and no static value is right for
+  every unit. That left an N32R16V owner with three quarters of their
+  flash unreachable and no way to claim it short of editing the shared
+  library. The override wins over the board file in both the ESPHome and
+  the LoRaWAN generator, is restricted to the sizes both can name a
+  partition table for (4/8/16/32), warns
+  (`flash_size_override_above_board`) when it raises the board file's
+  value since that is the direction that bricks, and is dropped when
+  `set_board` switches boards -- a size measured on one board says
+  nothing about another. Closes the last actionable half of #219; the
+  remaining half is `esptool flash-id` on four boards not at the bench.
 - `HANDOFF.md`: current backlog and bench state for picking this up in a
   fresh session -- what is shipped, what is blocked on hardware at the
   bench, which beliefs are unverified, and the gotchas that cost time.
@@ -17,6 +32,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Heltec V4 FEM: `PA_TX_EN` is per-transfer, not static.** Holding the
+  GC1109's PA_TX_EN (GPIO46) high pinned the PA output stage on and left
+  the receiver deaf -- 69 join-requests accepted server-side, zero
+  join-accepts heard (RadioLib -1116). The board file and both firmware
+  paths now drive it through RadioLib's rf-switch (`txen`), with VFEM
+  (GPIO7) and CSD (GPIO2) static high and VEXT (GPIO36) static low;
+  without VEXT the FEM path is unpowered and TX is leakage-grade
+  (-52 dBm at 2 m). OTAA join and a Class C downlink validated on the
+  bench. On a V4.3 (KCT8103L) that is still deaf, move `txen` to GPIO5.
+- **Heltec V4 GNSS UART direction was backwards.** Heltec's GNSS_TX/RX
+  net names are direction-ambiguous, and the Meshtastic-derived table
+  0.24.1 cited when it added the auto-wiring has them reversed. Measured
+  against a live L76K: the *module's* TX is GPIO39 (the MCU reads NMEA
+  there) and its RX is GPIO38.
+- **Heltec V4 GNSS stayed mute until standby was driven.** STANDBY
+  (GPIO40) undriven leaves the module silent with its TX held low, which
+  reads as a UART break flood and is easily mistaken for a floating pin.
+  `uart_gps` now carries `standby_pin` and `reset_pin` through the seed
+  into both firmware paths, and the power-up order is pinned: VEXT(36
+  low) -> settle -> EN(34 low) -> RST(42 high) -> WAKE(40 high) -> ~1 s
+  warmup, giving 1 Hz multi-constellation NMEA at 9600. (V4-R8 moves EN
+  to GPIO42 and drops reset.)
+- **`$GPTXT ... ANTENNA OPEN` on the V4 GNSS is benign**, and this
+  bring-up chased it as a fault. The L76K's antenna is an integrated
+  passive patch -- there is nothing to connect -- so its active-antenna
+  DC-detect always reports open. Noted in the board file. Zero satellites
+  indoors is also normal; a first fix needs sky view.
 - **The roadmap contradicted itself on why the hardware gate is a
   CronJob.** `docs/index.md` still described phase 3 as carrying "a
   self-hosted runner as real setup and maintenance cost" while

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -73,10 +73,12 @@ TX power check for radio boards.
 ## Open issues / PRs
 
 - **wirestudio #219** — board `flash_size` unverified; `esp32-s3-devkitc-1`
-  ships 8 MB and 32 MB under one name. **Partly unblocked**: SLOT28 is an
-  esp32s3, so flash size can now be read from silicon. The undecidable half
-  stands (one board name, four SKUs) — it likely needs a detected-at-flash-time
-  value rather than a board-file constant.
+  ships 8 MB and 32 MB under one name. The undecidable half is now handled:
+  the board file keeps the floor and `design.json` carries a
+  `board.flash_size_mb` override for a unit whose size has been measured.
+  What remains is measurement, and it is still blocked — none of the four
+  boards named in the issue is on the bench (SLOT28 is a V4, already
+  verified at 16 MB). Each is seconds of `esptool flash-id` once present.
 - **SensorsIot/Embedded-AI-Harness #29** — "MCP could reset a slot but never
   answer it". Open **18 days, no review**. Nudge or ping.
 - **SensorsIot/Embedded-AI-Harness #31** — keep-hostname opt-out (opened

--- a/docs/integration_spec.md
+++ b/docs/integration_spec.md
@@ -244,6 +244,21 @@ ESP32-S3-DevKitC-1 ships as N8/N8R2/N8R8 (8MB) *and* N32R16V (32MB); no
 static value is right for every unit. Pin the floor and comment that it
 must not be raised.
 
+A design that has *measured* its own unit claims the rest with a
+per-design override, which wins over the board file in both the ESPHome
+and LoRaWAN generators:
+
+```json
+"board": { "library_id": "esp32-s3-devkitc-1", "mcu": "esp32", "flash_size_mb": 32 }
+```
+
+Allowed values are 4, 8, 16 and 32 — the sizes both generators can name a
+partition table for. Raising it above the board file's value validates
+with a `flash_size_override_above_board` warning, because that is the
+direction that boot-loops; lowering it is safe and silent. Switching the
+design's board drops the override, since a size measured on one board
+says nothing about another.
+
 To verify against silicon, the reliable route is the ESP-IDF bootloader,
 which prints the real size at boot:
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -69,6 +69,12 @@ def test_set_board_updates_design(lib, garage_motion_design):
     assert garage_motion_design["board"]["mcu"] == "esp8266"
 
 
+def test_set_board_drops_a_flash_size_measured_on_the_old_board(lib, garage_motion_design):
+    garage_motion_design["board"]["flash_size_mb"] = 16
+    execute_tool("set_board", {"library_id": "wemos-d1-mini"}, garage_motion_design, lib)
+    assert "flash_size_mb" not in garage_motion_design["board"]
+
+
 def test_set_board_unknown_returns_error(lib, garage_motion_design):
     out, is_error = execute_tool(
         "set_board", {"library_id": "no-such-board"}, garage_motion_design, lib,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -101,6 +101,13 @@ def test_validate_accepts_known_example(client):
     assert body["component_count"] == 2
 
 
+def test_validate_surfaces_a_flash_size_override_above_the_board_file(client):
+    design = json.loads((EXAMPLES_DIR / "garage-motion.json").read_text())
+    design["board"]["flash_size_mb"] = 16  # esp32-devkitc-v4 is a 4MB board
+    body = client.post("/design/validate", json=design).json()
+    assert "flash_size_override_above_board" in {w["code"] for w in body["warnings"]}
+
+
 def test_validate_rejects_missing_required(client):
     bad = {"schema_version": "0.1", "id": "x", "name": "x"}  # missing board/power
     r = client.post("/design/validate", json=bad)

--- a/tests/test_firmware_gen.py
+++ b/tests/test_firmware_gen.py
@@ -184,3 +184,20 @@ def test_tbeam_powers_its_rails_before_using_them(lib):
     assert "XPowersLib.h" in src
     assert "enableLDO2" in src and "enableLDO3" in src
     assert src.index("power.begin") < src.index("GPSSerial.begin")
+
+
+def test_design_flash_size_override_wins_over_board_file(lib):
+    # heltec-wifi-lora32-v3 pins 8MB; a design that measured 16MB on its own
+    # unit gets the bigger partition table.
+    design = _design("heltec-wifi-lora32-v3")
+    design.board.flash_size_mb = 16
+    ini = generate_firmware(design, lib)["platformio.ini"]
+    assert "board_build.flash_size = 16MB" in ini
+    assert "board_upload.flash_size = 16MB" in ini
+    assert "board_build.partitions = default_16MB.csv" in ini
+
+
+def test_no_override_uses_board_file_flash_size(lib):
+    ini = generate_firmware(_design("heltec-wifi-lora32-v3"), lib)["platformio.ini"]
+    assert "board_build.flash_size = 8MB" in ini
+    assert "board_build.partitions = default_8MB.csv" in ini

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -32,3 +32,16 @@ def test_examples_validate_against_schema(name):
     schema = json.loads((REPO_ROOT / "wirestudio" / "schema" / "design.schema.json").read_text())
     design = json.loads((REPO_ROOT / "wirestudio" / "examples" / f"{name}.json").read_text())
     jsonschema.validate(design, schema)
+
+
+def test_board_flash_size_override_is_constrained_to_emittable_sizes():
+    schema = json.loads((REPO_ROOT / "wirestudio" / "schema" / "design.schema.json").read_text())
+    design = json.loads((REPO_ROOT / "wirestudio" / "examples" / "garage-motion.json").read_text())
+
+    design["board"]["flash_size_mb"] = 32
+    jsonschema.validate(design, schema)
+
+    # 2MB has no default_2MB.csv partition table; neither generator can name one.
+    design["board"]["flash_size_mb"] = 2
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(design, schema)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -3,7 +3,49 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from wirestudio.validate import dry_run, esphome_available
+from wirestudio.library import default_library
+from wirestudio.model import Design
+from wirestudio.validate import check_board_flash, dry_run, esphome_available
+
+
+def _design(board_id: str, mcu: str = "esp32", **board) -> Design:
+    return Design(
+        schema_version="0.1",
+        id="dev1",
+        name="Dev 1",
+        board={"library_id": board_id, "mcu": mcu, **board},
+        power={"supply": "usb", "rail_voltage_v": 3.3},
+    )
+
+
+def test_no_override_is_silent() -> None:
+    assert check_board_flash(_design("esp32-s3-devkitc-1"), default_library()) == []
+
+
+def test_override_below_board_file_is_silent() -> None:
+    # The DevKitC-1 floor is 8MB; someone who measured a 4MB part is safe.
+    design = _design("esp32-s3-devkitc-1", flash_size_mb=4)
+    assert check_board_flash(design, default_library()) == []
+
+
+def test_override_above_board_file_warns() -> None:
+    # N32R16V: correct for that unit, catastrophic on the 8MB SKUs.
+    design = _design("esp32-s3-devkitc-1", flash_size_mb=32)
+    warnings = check_board_flash(design, default_library())
+    assert [w.code for w in warnings] == ["flash_size_override_above_board"]
+    assert warnings[0].level == "warn"
+    assert "esptool flash-id" in warnings[0].text
+
+
+def test_override_on_non_esp32_board_warns_it_does_nothing() -> None:
+    design = _design("wemos-d1-mini", mcu="esp8266", flash_size_mb=4)
+    warnings = check_board_flash(design, default_library())
+    assert [w.code for w in warnings] == ["flash_size_override_ignored"]
+
+
+def test_unknown_board_defers_to_the_core_validators() -> None:
+    design = _design("no-such-board", flash_size_mb=16)
+    assert check_board_flash(design, default_library()) == []
 
 
 def test_esphome_available_true() -> None:

--- a/tests/test_yaml_gen.py
+++ b/tests/test_yaml_gen.py
@@ -651,3 +651,13 @@ def test_tsl2561_renders_with_address_override(library):
     assert tsl["gain"] == "16x"
     assert tsl["integration_time"] == "402ms"
     assert tsl["name"] == "Window Illuminance"
+
+
+def test_design_flash_size_override_wins_over_board_file(garage_motion_design, library):
+    parsed = yaml.unsafe_load(render_yaml(garage_motion_design, library))
+    assert parsed["esp32"]["flash_size"] == "4MB"
+
+    override = garage_motion_design.model_copy(deep=True)
+    override.board.flash_size_mb = 16
+    parsed = yaml.unsafe_load(render_yaml(override, library))
+    assert parsed["esp32"]["flash_size"] == "16MB"

--- a/wirestudio/agent/tools.py
+++ b/wirestudio/agent/tools.py
@@ -22,6 +22,7 @@ from wirestudio.kicad.pcb import PcbUnavailable, generate_kicad_pcb
 from wirestudio.library import Library
 from wirestudio.model import Design
 from wirestudio.recommend.recommender import Constraints, recommend_components
+from wirestudio.validate import check_board_flash
 
 
 # ---------------------------------------------------------------------------
@@ -396,8 +397,12 @@ def _run_list_boards(design: dict, library: Library) -> dict:
 
 def _run_set_board(design: dict, library: Library, *, library_id: str) -> dict:
     board = library.board(library_id)  # raises FileNotFoundError if unknown
+    kept = dict(design.get("board") or {})
+    # A flash size measured on the old board says nothing about the new one,
+    # and carrying it over is the direction that boot-loops.
+    kept.pop("flash_size_mb", None)
     design["board"] = {
-        **(design.get("board") or {}),
+        **kept,
         "library_id": board.id,
         "mcu": board.mcu,
         "framework": board.framework,
@@ -589,6 +594,7 @@ def _run_validate(design: dict, library: Library) -> dict:
     except (FileNotFoundError, ValueError) as e:
         return {"ok": False, "error": str(e), "schema_ok": True}
     compat = check_pin_compatibility(design, library)
+    board_warnings = check_board_flash(d, library)
     # Strict blockers are surfaced regardless of mode so the caller can see
     # what *would* block; in strict mode their presence also flips ok=False.
     blockers = strict_blockers(design, library)
@@ -600,7 +606,7 @@ def _run_validate(design: dict, library: Library) -> dict:
         "components": len(d.components),
         "buses": len(d.buses),
         "connections": len(d.connections),
-        "warnings": [w.model_dump() for w in d.warnings],
+        "warnings": [w.model_dump() for w in list(d.warnings) + board_warnings],
         "compatibility_warnings": [
             {
                 "severity": w.severity, "code": w.code, "pin": w.pin,

--- a/wirestudio/api/app.py
+++ b/wirestudio/api/app.py
@@ -85,6 +85,7 @@ from wirestudio.fleet.client import FleetClient, FleetUnavailable
 from wirestudio.csp.compatibility import check_pin_compatibility, strict_blockers
 from wirestudio.csp.pin_solver import solve_pins as run_solve_pins
 from wirestudio.intent import validate_automations
+from wirestudio.validate import check_board_flash
 from wirestudio.enclosure import (
     EnclosureUnavailable,
     default_sources,
@@ -429,6 +430,7 @@ def create_app(
         # (warnings, not blocks) so a half-authored automation can render.
         target_warnings = get_target(d.target).validate(d, lib)
         automation_warnings = validate_automations(d, lib)
+        board_warnings = check_board_flash(d, lib)
         # In strict mode, warn/error compatibility entries and design warnings
         # flip ok to false (the render/push gates refuse the same design).
         # Permissive mode always reports ok -- warnings are guidance, not blocks.
@@ -442,7 +444,7 @@ def create_app(
             connection_count=len(d.connections),
             warnings=[
                 w.model_dump()
-                for w in list(d.warnings) + target_warnings + automation_warnings
+                for w in list(d.warnings) + target_warnings + automation_warnings + board_warnings
             ],
             compatibility_warnings=_wire_compat(check_pin_compatibility(design, lib)),
         )

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -518,9 +518,11 @@ def build_yaml_dict(
         # of the flash unused and OTA slots smaller than the chip allows.
         # Nothing errors, which is why it goes unnoticed. Under-declaring is
         # the safe direction (over-declaring boot-loops the bootloader on a
-        # size mismatch), so emit what the board file says.
-        if board.flash_size_mb:
-            chip_block["flash_size"] = f"{board.flash_size_mb}MB"
+        # size mismatch), so the board file pins a floor for boards sold in
+        # several sizes; the design overrides it once the size is measured.
+        flash_size_mb = design.board.flash_size_mb or board.flash_size_mb
+        if flash_size_mb:
+            chip_block["flash_size"] = f"{flash_size_mb}MB"
         out["esp32"] = chip_block
     else:
         out[board.chip_variant] = chip_block

--- a/wirestudio/library/boards/esp32-s3-devkitc-1.yaml
+++ b/wirestudio/library/boards/esp32-s3-devkitc-1.yaml
@@ -9,7 +9,8 @@ platformio_board: esp32-s3-devkitc-1
 # WROOM-2). No single value is correct for every unit, so this is the
 # smallest. Under-declaring only wastes flash; over-declaring boot-loops
 # the board, which is how a Heltec V2 was bricked in 0.26.x by an 8MB
-# declaration on a 4MB part. Unverified against silicon.
+# declaration on a 4MB part. Unverified against silicon. An N32R16V owner
+# who has measured their unit sets board.flash_size_mb in design.json.
 # https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/user_guide_v1.1.html
 flash_size_mb: 8
 

--- a/wirestudio/model.py
+++ b/wirestudio/model.py
@@ -10,9 +10,21 @@ class _Strict(BaseModel):
 
 
 class Board(_Strict):
+    """The board this design targets.
+
+    `flash_size_mb` overrides the library board file's value for this design
+    only. It exists for boards sold in several flash sizes under one name --
+    the ESP32-S3-DevKitC-1 ships as N8/N8R2/N8R8 (8MB) and N32R16V (32MB) --
+    where the board file pins the floor because no static value is right for
+    every unit. Set it only from a measured size (the ESP-IDF bootloader's
+    "SPI Flash Size" banner, or `esptool flash-id`): raising it past what the
+    chip has boot-loops the board. Restricted to sizes both generators can
+    emit a partition table for, and ignored on non-ESP32 boards.
+    """
     library_id: str
     mcu: str
     framework: str = "arduino"
+    flash_size_mb: Optional[Literal[4, 8, 16, 32]] = None
     pinned_esphome_version: Optional[str] = None
 
 

--- a/wirestudio/schema/design.schema.json
+++ b/wirestudio/schema/design.schema.json
@@ -21,6 +21,7 @@
         "library_id": { "type": "string" },
         "mcu": { "type": "string" },
         "framework": { "type": "string", "default": "arduino" },
+        "flash_size_mb": { "enum": [4, 8, 16, 32] },
         "pinned_esphome_version": { "type": "string" }
       }
     },

--- a/wirestudio/targets/lorawan/firmware_gen.py
+++ b/wirestudio/targets/lorawan/firmware_gen.py
@@ -194,7 +194,7 @@ def generate_firmware(design: Design, library: Library) -> dict[str, str]:
             "platformio_board": board.platformio_board,
             "chip_variant": board.chip_variant,
             "mcu": board.mcu,
-            "flash_size_mb": board.flash_size_mb,
+            "flash_size_mb": design.board.flash_size_mb or board.flash_size_mb,
         },
         "region": region,
         "sub_band": sub_band,

--- a/wirestudio/validate.py
+++ b/wirestudio/validate.py
@@ -1,13 +1,62 @@
-"""Wrapper around `esphome config` for dry-run validation.
+"""Design-level checks that aren't about pins, plus a wrapper around
+`esphome config` for dry-run validation.
 
-Stub for 0.1 — only checks for binary presence and shells out. The CSP layer
-in 0.3 will run this before declaring a design valid.
+The dry-run half is a stub for 0.1 — only checks for binary presence and
+shells out. The CSP layer in 0.3 will run this before declaring a design
+valid.
 """
 from __future__ import annotations
 
 import shutil
 import subprocess
 from pathlib import Path
+
+from wirestudio.library import Library
+from wirestudio.model import Design, DesignWarning
+
+
+def check_board_flash(design: Design, library: Library) -> list[DesignWarning]:
+    """Permissive checks on `design.board.flash_size_mb`, the per-design
+    override of the library board file's flash size.
+
+    Over-declaring is the direction that bricks: the bootloader asserts on a
+    size mismatch and boot-loops before any sketch code runs. So raising the
+    override above the board file's value warns; lowering it is safe and
+    silent.
+    """
+    override = design.board.flash_size_mb
+    if override is None:
+        return []
+    try:
+        board = library.board(design.board.library_id)
+    except FileNotFoundError:
+        # An unknown board is surfaced by the core validators; not our job.
+        return []
+
+    if not board.chip_variant.startswith("esp32"):
+        return [DesignWarning(
+            level="warn",
+            code="flash_size_override_ignored",
+            text=(
+                f"board.flash_size_mb is set to {override} but board "
+                f"{board.id!r} is not an ESP32 family part; neither generator "
+                "emits a flash size for it and the override does nothing"
+            ),
+        )]
+
+    if board.flash_size_mb and override > board.flash_size_mb:
+        return [DesignWarning(
+            level="warn",
+            code="flash_size_override_above_board",
+            text=(
+                f"board.flash_size_mb raises {board.id!r} from "
+                f"{board.flash_size_mb}MB to {override}MB. Declaring more "
+                "flash than the chip has boot-loops the board. Confirm the "
+                "size on this unit first -- the ESP-IDF bootloader prints "
+                "'SPI Flash Size' at boot, or run `esptool flash-id`."
+            ),
+        )]
+    return []
 
 
 def esphome_available() -> bool:


### PR DESCRIPTION
Closes the last actionable half of #219, and records #248 in the changelog.

## `board.flash_size_mb` in design.json

Board files pin the flash-size **floor**: over-declaring boot-loops the board (that is how a Heltec V2 was bricked in 0.26.x), and the ESP32-S3-DevKitC-1 ships as N8/N8R2/N8R8 (8MB) *and* N32R16V (32MB) under one name, so no static value is right for every unit. Safe — but it left an N32R16V owner with three quarters of their flash unreachable and no way to claim it short of editing the shared library.

`design.json` now carries an override that wins over the board file in **both** generators (ESPHome `flash_size:` and the LoRaWAN `platformio.ini`):

```json
"board": { "library_id": "esp32-s3-devkitc-1", "mcu": "esp32", "flash_size_mb": 32 }
```

Guard rails:

- Restricted to 4/8/16/32 — the sizes both paths can name a partition table for. `default_2MB.csv` does not exist, so 2 is rejected by the schema rather than emitted and failing at build.
- Raising it above the board file's value validates with `flash_size_override_above_board` (warn), pointing at the bootloader banner and `esptool flash-id`. Lowering is safe and silent.
- Set on a non-ESP32 board it warns `flash_size_override_ignored` — nothing emits a flash size there.
- `set_board` drops it. A size measured on one board says nothing about another, and carrying it across is the direction that boot-loops.

Issue #219's item 3 (a generator warning for unverified board metadata) stays declined for the reason given on the issue. Item 1 — `esptool flash-id` on the four named boards — is still blocked: none of them is at the bench. `HANDOFF.md` is corrected on that point; it implied SLOT28 had unblocked it, but SLOT28 is a V4, already verified at 16MB.

## Changelog: the Heltec V4 bench findings

The four commits behind #248 (FEM per-transfer `PA_TX_EN`, GNSS module TX = GPIO39, GNSS standby/power order, benign `ANTENNA OPEN`) were direct-pushed with no CHANGELOG entry, and 0.24.1's GNSS auto-wiring entry still states the Meshtastic-derived pin direction that bring-up disproved. Added under Unreleased/Fixed. The historical entry is left as the record of what shipped.

## Tests

1080 passed, 12 skipped. New coverage: override wins in both generators, board-file fallback unchanged, the two warning cases plus the two silent ones, schema accepts 32 and rejects 2, the warning surfaces through `POST /design/validate`, and `set_board` drops a stale override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)