### PR TITLE
drop board.pinned_esphome_version: nothing ever read it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It had been parked in an unrelated repo, where a session opened on that
   tree could not act on any of it.
 
+### Removed
+
+- **`board.pinned_esphome_version` in `design.json`.** Declared in the
+  0.1 schema sketch and never wired to anything -- no generator, API,
+  or gate has ever read it, so a design that set it got the same YAML
+  built against the same ESPHome as one that didn't. ESPHome version
+  pinning is real, but it lives in CI and the container images, not
+  per design. Dropped from the model, the JSON schema, the three
+  bundled examples that carried it, and the `START.md` schema sketch.
+  `design.json` rejects unknown keys, so a design still carrying the
+  line needs it deleted; nothing else changes, since nothing consumed
+  the value.
+
 ### Fixed
 
 - **Heltec V4 FEM: `PA_TX_EN` is per-transfer, not static.** Holding the

--- a/START.md
+++ b/START.md
@@ -1480,8 +1480,7 @@ agent never has to *guess* what hardware you have — the device tells us.
   "board": {
     "library_id": "esp32-devkitc-v4",
     "mcu": "esp32",
-    "framework": "arduino",
-    "pinned_esphome_version": "2024.10.0"
+    "framework": "arduino"
   },
 
   "power": {

--- a/wirestudio/examples/blind-stepper.json
+++ b/wirestudio/examples/blind-stepper.json
@@ -9,8 +9,7 @@
   "board": {
     "library_id": "esp32-devkitc-v4",
     "mcu": "esp32",
-    "framework": "arduino",
-    "pinned_esphome_version": "2024.10.0"
+    "framework": "arduino"
   },
 
   "power": {

--- a/wirestudio/examples/garage-motion.json
+++ b/wirestudio/examples/garage-motion.json
@@ -9,8 +9,7 @@
   "board": {
     "library_id": "esp32-devkitc-v4",
     "mcu": "esp32",
-    "framework": "arduino",
-    "pinned_esphome_version": "2024.10.0"
+    "framework": "arduino"
   },
 
   "power": {

--- a/wirestudio/examples/xiao-grove-climate.json
+++ b/wirestudio/examples/xiao-grove-climate.json
@@ -8,8 +8,7 @@
   "board": {
     "library_id": "seeed-xiao-esp32c3",
     "mcu": "esp32",
-    "framework": "arduino",
-    "pinned_esphome_version": "2025.12.7"
+    "framework": "arduino"
   },
   "power": {
     "supply": "usb-5v",

--- a/wirestudio/model.py
+++ b/wirestudio/model.py
@@ -25,7 +25,6 @@ class Board(_Strict):
     mcu: str
     framework: str = "arduino"
     flash_size_mb: Optional[Literal[4, 8, 16, 32]] = None
-    pinned_esphome_version: Optional[str] = None
 
 
 class Power(_Strict):

--- a/wirestudio/schema/design.schema.json
+++ b/wirestudio/schema/design.schema.json
@@ -21,8 +21,7 @@
         "library_id": { "type": "string" },
         "mcu": { "type": "string" },
         "framework": { "type": "string", "default": "arduino" },
-        "flash_size_mb": { "enum": [4, 8, 16, 32] },
-        "pinned_esphome_version": { "type": "string" }
+        "flash_size_mb": { "enum": [4, 8, 16, 32] }
       }
     },
 


### PR DESCRIPTION
Follow-up to #249, which surfaced this while adding `board.flash_size_mb` alongside it.

`board.pinned_esphome_version` came from the 0.1 schema sketch in `START.md` and was never wired to anything. A repo-wide search finds no reader — not the ESPHome generator, not the LoRaWAN one, not the API, not any CI gate. A design that set it got the same YAML, built against the same ESPHome, as one that didn't. There's no `TODO(0.x)` or roadmap item tying it to planned work either.

The ESPHome version pinning wirestudio actually does have is real, but it lives in the `esphome-config` workflow and the container images — repo-level, not per design.

Removed from:

- `wirestudio/model.py` and `wirestudio/schema/design.schema.json`
- the three bundled examples that carried it (`garage-motion`, `blind-stepper`, `xiao-grove-climate`)
- the `START.md` schema sketch it originated in

## Compatibility

`design.json` forbids unknown keys, so a design still carrying the line will now fail validation and needs it deleted. Nothing else changes — no generated output moves, because nothing consumed the value. Goldens are byte-identical; the diff touches no file under `tests/golden/`.

1080 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)