### PR TITLE
Bump lorawan-for-esphome pin to the #10 squash-merge SHA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`lorawan-for-esphome` pin moved to the #10 squash-merge on `main`**
+  (`b7da6174`). The previous pin was the PR's branch-head SHA, which
+  fell off-history when the PR squash-merged; GitHub keeps such commits
+  fetchable via PR refs for now, but a pin on main's history is the
+  durable choice. Generated YAML changes only in the ref string.
+
 ### Added
 
 - **`board.flash_size_mb` in `design.json`: a per-design override of the

--- a/tests/golden/lorawan-battery-uplink.yaml
+++ b/tests/golden/lorawan-battery-uplink.yaml
@@ -20,7 +20,7 @@ sensor:
   lorawan_id: lw
   sensor: battery
 external_components:
-- source: github://moellere/lorawan-for-esphome@3abc55852e90814c28ce0ffa38b918ba5230a5e1
+- source: github://moellere/lorawan-for-esphome@b7da617482bf59341a5d14992f033e522af72b57
   components:
   - lorawan
 lorawan:

--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -370,14 +370,15 @@ def _secret_name(ref: str) -> str:
 # the component repo cuts its first stable release post hardware-join
 # validation (decision logged in docs/lorawan/workflow-integration.md).
 _LORAWAN_FOR_ESPHOME_REPO = "moellere/lorawan-for-esphome"
-# Pinned to the head of lorawan-for-esphome#10 (setup_low, per-transfer
-# rxen/txen rf-switch pins, device_class C, send_raw). Its predecessor
+# Pinned to the lorawan-for-esphome#10 squash-merge on main (setup_low,
+# per-transfer rxen/txen rf-switch pins, device_class C, send_raw). Its
+# pre-merge branch-head predecessor
 # RADIO_SCHEMA is a strict cv.Schema, so the ref and the keys emitted below
 # have to move together: an older ref rejects `tcxo_voltage`,
 # `dio2_as_rf_switch` and `setup_high` outright, and ESPHome refuses the
 # config rather than ignoring them. The previous pin (#2) carried the
 # sck/miso/mosi keys and nothing more.
-_LORAWAN_FOR_ESPHOME_REF = "3abc55852e90814c28ce0ffa38b918ba5230a5e1"
+_LORAWAN_FOR_ESPHOME_REF = "b7da617482bf59341a5d14992f033e522af72b57"
 
 
 def _emit_lorawan_blocks(


### PR DESCRIPTION
The pinned branch-head SHA (`3abc5585`) fell off-history when moellere/lorawan-for-esphome#10 squash-merged as `b7da6174`. GitHub keeps the old commit fetchable via PR refs for now, but pinning a SHA on main's history is the durable choice. Golden regenerated (ref string only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cq9nfcj8xeaSiv924epUHp