### PR TITLE
release 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] — 2026-08-30
+
 ### Added
 
 - **`board.flash_size_mb` in `design.json`: a per-design override of the

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"


### PR DESCRIPTION
Version bump + changelog dating for 0.33.0.

**Minor, not patch:** `board.pinned_esphome_version` is gone (#250), and `design.json` forbids unknown keys, so any design still carrying that line fails validation until it's deleted. Nothing else changes for it — nothing consumed the value.

Contents:

- **Added** — `board.flash_size_mb`, a per-design override of the library board file's flash size, for boards sold in several sizes under one name (#249). Plus `HANDOFF.md` (#247).
- **Removed** — `board.pinned_esphome_version` (#250).
- **Fixed** — the four Heltec V4 bench corrections from #248 (FEM per-transfer `PA_TX_EN`, GNSS module TX = GPIO39, GNSS standby/power order, benign `ANTENNA OPEN`), which had landed without changelog entries; and the roadmap self-contradiction on the hardware gate (#246).

Tag `v0.33.0` follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)