### PR TITLE
[skip changelog] unbreak the lorawan pin comment's sentence

### DIFF
--- a/wirestudio/generate/yaml_gen.py
+++ b/wirestudio/generate/yaml_gen.py
@@ -372,7 +372,6 @@ def _secret_name(ref: str) -> str:
 _LORAWAN_FOR_ESPHOME_REPO = "moellere/lorawan-for-esphome"
 # Pinned to the lorawan-for-esphome#10 squash-merge on main (setup_low,
 # per-transfer rxen/txen rf-switch pins, device_class C, send_raw). Its
-# pre-merge branch-head predecessor
 # RADIO_SCHEMA is a strict cv.Schema, so the ref and the keys emitted below
 # have to move together: an older ref rejects `tcxo_voltage`,
 # `dio2_as_rf_switch` and `setup_high` outright, and ESPHome refuses the


### PR DESCRIPTION
Comment-only. #251 edited

```
). Its predecessor
# RADIO_SCHEMA is a strict cv.Schema, so the ref and the keys emitted below
```

into

```
). Its
# pre-merge branch-head predecessor
# RADIO_SCHEMA is a strict cv.Schema, so the ref and the keys emitted below
```

leaving "Its pre-merge branch-head predecessor" dangling on its own line with no verb, ahead of a sentence that now reads as a fragment. The pre-merge branch-head detail is already in the changelog entry and #251's body; this comment only needs to say why the ref and the emitted keys have to move together.

No behavior change, no generated-output change — `[skip changelog]` for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)