### PR TITLE
release 0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.1] — 2026-08-30
+
 ### Changed
 
 - **`lorawan-for-esphome` pin moved to the #10 squash-merge on `main`**

--- a/wirestudio/__init__.py
+++ b/wirestudio/__init__.py
@@ -1,3 +1,3 @@
 """wirestudio: design.json -> ESPHome YAML + ASCII diagram."""
 
-__version__ = "0.33.0"
+__version__ = "0.33.1"


### PR DESCRIPTION
Version bump + changelog dating for 0.33.1.

**Patch:** a dependency-pin move, no API or schema change. Generated YAML differs only in the ref string.

Contents — the `lorawan-for-esphome` pin moved from the #10 branch-head SHA (`3abc5585`) to its squash-merge on `main` (`b7da6174`), from #251. The old SHA fell off-history when the PR squash-merged; GitHub keeps such commits fetchable via PR refs for now, but pinning a commit on main's history is the durable choice.

#253 (a comment rewrap in the same block) is also on main but carries no changelog entry, being comment-only.

Tag `v0.33.1` follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)