### PR TITLE
bind a device to its slot where the binding is made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Provisioning records which slot a device sits in.** A LoRaWAN device
+  registered through the workbench path is now tagged `slot: SLOT19` in
+  ChirpStack, written by the one action that knows the board and the slot
+  at the same moment. Until now the only slot-to-DevEUI map was the
+  hardware gate's hand-maintained roster, and it went stale silently the
+  first time a board was repurposed: the board kept uplinking under its
+  new identity while the gate watched the retired one and reported dead
+  hardware for four nightly runs. Tags are merged, not replaced, so a tag
+  someone else set survives; a device reprovisioned onto another slot
+  carries the new slot with it. `ListDevices` returns tags inline, so
+  "which device is in SLOT19?" is one call.
+- **`Slot.group` / `Slot.role`** are now parsed from the bench. The
+  workbench has always reported them and the client dropped them on the
+  floor. Slot labels are positional and say nothing about purpose, so
+  without these a slot's contents can only be identified by asking
+  someone who remembers.
+
 ## [0.33.1] — 2026-08-30
 
 ### Changed

--- a/tests/test_chirpstack.py
+++ b/tests/test_chirpstack.py
@@ -355,3 +355,62 @@ def test_create_device_does_not_update_when_the_profile_already_matches():
     _client(stubs).create_device("0011223344556677", "dev", "app", "dp")
 
     assert not stubs.device.Update.called
+
+
+def test_create_device_stamps_tags_on_the_new_device():
+    stubs = _stubs()
+    _client(stubs).create_device(
+        "0011223344556677", "dev", "app", "dp", tags={"slot": "SLOT19"},
+    )
+    device = stubs.device.Create.call_args.args[0].device
+    assert dict(device.tags) == {"slot": "SLOT19"}
+
+
+def test_create_device_moves_a_stale_slot_tag_on_reprovision():
+    # The drift case: a board reprovisioned onto a different slot must carry
+    # the new slot, or anything reading the tag keeps pointing at the old one.
+    stubs = _stubs()
+    stubs.device.Create.side_effect = _RpcError(grpc.StatusCode.ALREADY_EXISTS)
+    from chirpstack_api.api import device_pb2
+
+    existing = device_pb2.Device(application_id="app", device_profile_id="dp")
+    existing.tags["slot"] = "SLOT12"
+    stubs.device.Get.return_value = SimpleNamespace(device=existing)
+
+    _client(stubs).create_device(
+        "0011223344556677", "dev", "app", "dp", tags={"slot": "SLOT19"},
+    )
+    updated = stubs.device.Update.call_args.args[0].device
+    assert updated.tags["slot"] == "SLOT19"
+
+
+def test_create_device_leaves_foreign_tags_alone():
+    stubs = _stubs()
+    stubs.device.Create.side_effect = _RpcError(grpc.StatusCode.ALREADY_EXISTS)
+    from chirpstack_api.api import device_pb2
+
+    existing = device_pb2.Device(application_id="app", device_profile_id="dp")
+    existing.tags["owner"] = "roboat"
+    stubs.device.Get.return_value = SimpleNamespace(device=existing)
+
+    _client(stubs).create_device(
+        "0011223344556677", "dev", "app", "dp", tags={"slot": "SLOT19"},
+    )
+    updated = stubs.device.Update.call_args.args[0].device
+    assert updated.tags["owner"] == "roboat"
+    assert updated.tags["slot"] == "SLOT19"
+
+
+def test_create_device_with_matching_tags_and_profile_skips_the_update():
+    stubs = _stubs()
+    stubs.device.Create.side_effect = _RpcError(grpc.StatusCode.ALREADY_EXISTS)
+    from chirpstack_api.api import device_pb2
+
+    existing = device_pb2.Device(application_id="app", device_profile_id="dp")
+    existing.tags["slot"] = "SLOT19"
+    stubs.device.Get.return_value = SimpleNamespace(device=existing)
+
+    _client(stubs).create_device(
+        "0011223344556677", "dev", "app", "dp", tags={"slot": "SLOT19"},
+    )
+    stubs.device.Update.assert_not_called()

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -111,6 +111,16 @@ def _parse_sse(body: str) -> list[dict]:
 # ----------------------------------------------------------------------
 
 
+def test_slot_carries_the_benchs_purpose_labels():
+    s = Slot.from_api(_slot(group="lorawan", role="roboat-hil"))
+    assert (s.group, s.role) == ("lorawan", "roboat-hil")
+
+
+def test_slot_purpose_labels_default_to_none_when_the_bench_omits_them():
+    s = Slot.from_api(_slot())
+    assert (s.group, s.role) == (None, None)
+
+
 def test_empty_slot_is_not_flashable():
     ok, reason = Slot.from_api(
         _slot(present=False, state="absent", usb_devices=[])

--- a/tests/test_workbench_provision.py
+++ b/tests/test_workbench_provision.py
@@ -251,6 +251,15 @@ def test_full_flow_reaches_done(fake_serial):
     assert events[-1]["dev_addr"] == "0136e110"
 
 
+def test_registration_records_the_slot_the_board_sits_in(fake_serial):
+    """The slot->DevEUI binding is written by the one action that knows both
+    for certain. A roster maintained by hand goes stale the first time a board
+    is repurposed, and nothing notices until a gate blames the hardware."""
+    chirp = FakeChirp()
+    _run(fake_serial, chirp=chirp)
+    assert chirp.calls[0]["tags"] == {"slot": "SLOT1"}
+
+
 def test_registration_follows_the_flash(fake_serial):
     """The DevEUI comes out of esptool's log, so registration cannot precede
     the flash -- and provision_device's DevNonce flush has to land after the

--- a/wirestudio/targets/lorawan/chirpstack.py
+++ b/wirestudio/targets/lorawan/chirpstack.py
@@ -268,12 +268,19 @@ class ChirpStackClient:
         device_profile_id: str,
         *,
         join_eui: Optional[str] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> None:
         """Create the device.
 
         Idempotent on identity: an existing DevEUI keeps its registration.
-        Its profile is re-pointed if the design now needs a different one --
-        see the already-exists branch.
+        Its profile is re-pointed if the design now needs a different one,
+        and `tags` are merged onto it -- see the already-exists branch.
+
+        `tags` records where the device physically lives (`slot`). It is
+        written here because provisioning is the only thing that registers a
+        device, so the binding cannot drift from the hardware the way a
+        hand-maintained roster does: reprovisioning a board onto another slot
+        moves the tag with it.
         """
         grpc, m = _load()
         device = m.dev.Device(
@@ -284,6 +291,8 @@ class ChirpStackClient:
         )
         if join_eui:
             device.join_eui = join_eui
+        if tags:
+            device.tags.update(tags)
         stubs = self._get_stubs()
         try:
             stubs.device.Create(
@@ -318,8 +327,19 @@ class ChirpStackClient:
             # pointed at the old one decodes every uplink at the wrong offsets,
             # and the caller still reports the new profile id -- success for a
             # device that is quietly emitting garbage.
+            changed = False
             if existing.device_profile_id != device_profile_id:
                 existing.device_profile_id = device_profile_id
+                changed = True
+            # Merge rather than replace: tags we do not set are someone
+            # else's, and a device reprovisioned onto a new slot must carry
+            # the new one -- a stale `slot` tag is the drift this exists to
+            # prevent.
+            for k, v in (tags or {}).items():
+                if existing.tags.get(k) != v:
+                    existing.tags[k] = v
+                    changed = True
+            if changed:
                 try:
                     stubs.device.Update(
                         m.dev.UpdateDeviceRequest(device=existing), metadata=self._auth
@@ -435,6 +455,7 @@ class ChirpStackClient:
         device_name: Optional[str] = None,
         join_eui: Optional[str] = None,
         codec: Optional[str] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> dict:
         """Full (re)provision: ensure profile (with codec) + app, create device,
         set key, flush nonces. Returns the resolved ids. Side-effecting against
@@ -450,6 +471,7 @@ class ChirpStackClient:
             application_id,
             device_profile_id,
             join_eui=join_eui,
+            tags=tags,
         )
         self.set_device_keys(dev_eui, app_key)
         self.flush_dev_nonces(dev_eui)

--- a/wirestudio/targets/lorawan/workbench_provision.py
+++ b/wirestudio/targets/lorawan/workbench_provision.py
@@ -125,6 +125,12 @@ def provision_events(
         device_profile_name=profile_name(design, library),
         join_eui=join_eui,
         codec=generate_codec(design, library),
+        # Records which slot this device physically sits in, at the one moment
+        # that fact is known for certain. Without it the only slot->DevEUI map
+        # is hand-maintained, and it goes stale silently the first time a board
+        # is repurposed -- the device keeps uplinking under its new identity
+        # while anything watching the old one reports dead hardware.
+        tags={"slot": slot},
     )
     yield {
         "type": "phase",

--- a/wirestudio/workbench/client.py
+++ b/wirestudio/workbench/client.py
@@ -72,6 +72,11 @@ class Slot:
     serial_url: Optional[str]
     flapping: bool
     last_error: Optional[str]
+    # What the board in this slot is for, as the bench itself records it.
+    # Labels are positional and say nothing about purpose, so without these
+    # a slot's contents can only be identified by asking someone.
+    group: Optional[str] = None
+    role: Optional[str] = None
 
     @property
     def busy(self) -> bool:
@@ -111,6 +116,8 @@ class Slot:
             serial_url=d.get("url"),
             flapping=bool(d.get("flapping")),
             last_error=d.get("last_error"),
+            group=d.get("group"),
+            role=d.get("role"),
         )
 
 


### PR DESCRIPTION
Follow-up to the SLOT19 gate failure (argocd#133). The roster fix there patches one stale entry; this removes the reason entries go stale.

## What went wrong

The nightly gate failed four runs straight on SLOT19 and reported `silent for over 3600s -- board may be hung`. The board was healthy the whole time. It had been reflashed for the roboat P4 HIL work and was uplinking as `monet-node` (`70b3baec29813d83`) in the `roboat` application, while the gate watched `64b708fffeab8974`, the identity it used to have.

The only slot→DevEUI map was the gate's roster, maintained by hand. Nothing made it follow the hardware, and nothing detected that it hadn't.

## The change

**Provisioning stamps the slot.** `provision_device(..., tags={"slot": slot})` — written at the one moment the board and the slot are both known for certain, by the only action that registers a device. A board reprovisioned onto another slot carries the new tag with it, so the binding cannot drift the way a separate hand-maintained copy does.

Tags merge rather than replace: a tag set by something else survives, and the update is skipped entirely when nothing changed. `ListDevices` returns tags inline, so "which device is in SLOT19?" costs one call rather than one per device.

**`Slot.group` / `Slot.role` are parsed.** The bench has always returned them; the client dropped them. Slot labels are positional and carry no purpose, which is exactly why "what is this board for?" had no answer to give.

## Scope

This is the write half. It makes the binding exist and stay true. Two things deliberately not here:

- **Backfilling the four existing devices' tags.** That is a mutation against live LoRaWAN infrastructure and should be a deliberate act, not a side effect of merging a code change.
- **Teaching the gate to read tags instead of a hardcoded `dev_eui`.** Worth doing, but it should land after tags actually exist on the devices, or the gate starts failing for a new reason.

The remaining half is firmware: the ESPHome config dump prints chip, region, pins, class and interval but never the DevEUI, so a board cannot currently be asked who it is. Filed separately against `lorawan-for-esphome`.

## Tests

1087 passed, 12 skipped. New coverage: tags stamped on create; a stale `slot` tag moved on reprovision; a foreign tag left intact; no Update call when nothing changed; the workbench path passing its slot through; and `role`/`group` parsed and defaulting to None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)