### PR TITLE
Library sweep: 18 new components with validated examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Library sweep: 18 new components** (65 -> 83), drawn from the
+  maintainer fleet's real device configs plus the most-requested
+  ESPHome hardware, each validated end-to-end through upstream
+  `esphome config`:
+  - *Environment:* SHT4x, SCD4x true CO2, SGP4x VOC/NOx index,
+    VEML7700 lux, BME680, MH-Z19 (UART), PMS5003/PMSX003 particulate
+    (UART).
+  - *Presence:* LD2410 mmWave (UART, richer channel set than the
+    existing LD2420; the stale `ld2410` alias moved off the ld2420
+    entry).
+  - *Power:* INA219 DC current/power, PZEM-004T v3 AC meter (rides the
+    modbus hub like sdm_meter), SCT-013 CT clamp (adc + ct_clamp with
+    burden/bias passives modeled).
+  - *Input:* PN532 NFC (I2C), Wiegand keypad/reader, IR receiver
+    (remote_receiver, with a Tasmota IRrecv mapping).
+  - *Output:* TM1637 7-segment display, hobby servo (per-chip
+    ledc/esp8266_pwm output plus an HA position slider), PCA9685 16ch
+    PWM, SN74HC595 shift register as a first-class expander
+    (`expander_pin_key`; downstream components wire to its pins).
+- **Six new bundled examples** covering all 18: air-quality-station,
+  co2-display (MH-Z19 driving a TM1637 readout), presence-media-node,
+  energy-monitor (PZEM-004T + CT clamp + INA219), access-panel (PN532 +
+  Wiegand + servo latch), output-hub (PCA9685 + shift-register relay on
+  an expander pin). The mhz19/scd4x templates give their CO2 channel a
+  referenceable id (`<id>_co2`) so displays and automations can read it.
+
 - **Provisioning records which slot a device sits in.** A LoRaWAN device
   registered through the workbench path is now tagged `slot: SLOT19` in
   ChirpStack, written by the one action that knows the board and the slot

--- a/wirestudio/examples/access-panel.json
+++ b/wirestudio/examples/access-panel.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "0.1",
+  "id": "access-panel",
+  "name": "Door access panel (NFC + keypad + servo latch)",
+  "description": "ESP32-DevKitC-V4 door controller: a PN532 NFC reader on I2C for fobs/cards/phone tags, a Wiegand keypad on GPIO32/GPIO33 for PIN entry, a servo-driven latch on GPIO13 and a relay output for the strike plate.",
+  "created_at": "2026-08-31T00:00:00Z",
+  "updated_at": "2026-08-31T00:00:00Z",
+
+  "board": {
+    "library_id": "esp32-devkitc-v4",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "external-5v",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117-3v3",
+    "budget_ma": 1500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "scan NFC tags and forward UIDs to Home Assistant's tag registry" },
+    { "id": "r2", "kind": "capability", "text": "accept PIN entry from the Wiegand keypad" },
+    { "id": "r3", "kind": "capability", "text": "actuate the latch servo and strike relay" }
+  ],
+
+  "components": [
+    { "id": "reader", "library_id": "pn532", "label": "Door Reader",
+      "params": {
+        "update_interval": "500ms",
+        "on_tag": [ { "homeassistant.tag_scanned": "!lambda return x;" } ]
+      } },
+    { "id": "keypad", "library_id": "wiegand", "label": "Keypad", "params": {} },
+    { "id": "latch", "library_id": "servo", "label": "Latch",
+      "params": { "auto_detach_time": "2s", "transition_length": "500ms" } },
+    { "id": "strike", "library_id": "gpio_output", "label": "Door Strike", "params": {} }
+  ],
+
+  "buses": [
+    { "id": "i2c0", "type": "i2c", "frequency_hz": 100000, "sda": "GPIO21", "scl": "GPIO22" }
+  ],
+
+  "connections": [
+    { "component_id": "reader", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "reader", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "reader", "pin_role": "SDA", "target": { "kind": "bus", "bus_id": "i2c0" } },
+    { "component_id": "reader", "pin_role": "SCL", "target": { "kind": "bus", "bus_id": "i2c0" } },
+
+    { "component_id": "keypad", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "keypad", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "keypad", "pin_role": "D0",  "target": { "kind": "gpio", "pin": "GPIO32" } },
+    { "component_id": "keypad", "pin_role": "D1",  "target": { "kind": "gpio", "pin": "GPIO33" } },
+
+    { "component_id": "latch", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "latch", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "latch", "pin_role": "PWM", "target": { "kind": "gpio", "pin": "GPIO13" } },
+
+    { "component_id": "strike", "pin_role": "OUT", "target": { "kind": "gpio", "pin": "GPIO26" } }
+  ],
+
+  "passives": [
+    { "id": "c_servo", "kind": "capacitor", "value": "470uF",
+      "between": ["latch.VCC", "GND"], "purpose": "servo stall surge" }
+  ],
+
+  "warnings": [
+    { "level": "warn", "code": "wiegand_5v_levels",
+      "text": "Most Wiegand readers idle D0/D1 at 5V. Add resistor dividers or a level shifter before GPIO32/GPIO33 unless the reader is confirmed 3.3V-safe." }
+  ],
+
+  "esphome_extras": {
+    "captive_portal": {}
+  },
+
+  "fleet": {
+    "device_name": "access-panel",
+    "tags": ["security", "access", "nfc"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/examples/air-quality-station.json
+++ b/wirestudio/examples/air-quality-station.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "0.1",
+  "id": "air-quality-station",
+  "name": "Indoor air quality station",
+  "description": "ESP32-DevKitC-V4 with the current-generation Sensirion stack on I2C (SCD4x true CO2, SHT4x temp/RH, SGP4x VOC index, VEML7700 lux, BME680 pressure/gas) and a Plantower PMS5003 particulate sensor on UART2.",
+  "created_at": "2026-08-31T00:00:00Z",
+  "updated_at": "2026-08-31T00:00:00Z",
+
+  "board": {
+    "library_id": "esp32-devkitc-v4",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117-3v3",
+    "budget_ma": 900
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "publish CO2, PM2.5, VOC index, temperature, humidity, pressure and illuminance" },
+    { "id": "r2", "kind": "constraint", "text": "all I2C sensors share one bus; addresses must not collide" }
+  ],
+
+  "components": [
+    { "id": "co2",  "library_id": "scd4x",    "label": "Indoor",    "params": { "update_interval": "60s" } },
+    { "id": "th",   "library_id": "sht4x",    "label": "Climate",   "params": { "update_interval": "60s" } },
+    { "id": "voc",  "library_id": "sgp4x",    "label": "Air",       "params": { "model": "sgp40" } },
+    { "id": "lux",  "library_id": "veml7700", "label": "Room",      "params": {} },
+    { "id": "baro", "library_id": "bme680",   "label": "Enclosure", "params": { "address": "0x76" } },
+    { "id": "pm",   "library_id": "pmsx003",  "label": "Air",       "params": { "type": "PMSX003" } }
+  ],
+
+  "buses": [
+    { "id": "i2c0", "type": "i2c", "frequency_hz": 100000, "sda": "GPIO21", "scl": "GPIO22" },
+    { "id": "pm_uart", "type": "uart", "tx": "GPIO17", "rx": "GPIO16", "baud_rate": 9600 }
+  ],
+
+  "connections": [
+    { "component_id": "co2",  "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "co2",  "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "co2",  "pin_role": "SDA", "target": { "kind": "bus", "bus_id": "i2c0" } },
+    { "component_id": "co2",  "pin_role": "SCL", "target": { "kind": "bus", "bus_id": "i2c0" } },
+
+    { "component_id": "th",   "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "th",   "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "th",   "pin_role": "SDA", "target": { "kind": "bus", "bus_id": "i2c0" } },
+    { "component_id": "th",   "pin_role": "SCL", "target": { "kind": "bus", "bus_id": "i2c0" } },
+
+    { "component_id": "voc",  "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "voc",  "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "voc",  "pin_role": "SDA", "target": { "kind": "bus", "bus_id": "i2c0" } },
+    { "component_id": "voc",  "pin_role": "SCL", "target": { "kind": "bus", "bus_id": "i2c0" } },
+
+    { "component_id": "lux",  "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "lux",  "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "lux",  "pin_role": "SDA", "target": { "kind": "bus", "bus_id": "i2c0" } },
+    { "component_id": "lux",  "pin_role": "SCL", "target": { "kind": "bus", "bus_id": "i2c0" } },
+
+    { "component_id": "baro", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "baro", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "baro", "pin_role": "SDA", "target": { "kind": "bus", "bus_id": "i2c0" } },
+    { "component_id": "baro", "pin_role": "SCL", "target": { "kind": "bus", "bus_id": "i2c0" } },
+
+    { "component_id": "pm",   "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "pm",   "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "pm",   "pin_role": "TX",  "target": { "kind": "bus", "bus_id": "pm_uart" } },
+    { "component_id": "pm",   "pin_role": "RX",  "target": { "kind": "bus", "bus_id": "pm_uart" } }
+  ],
+
+  "passives": [],
+
+  "warnings": [
+    { "level": "info", "code": "scd4x_current_burst",
+      "text": "The SCD4x pulls ~200mA bursts during measurement; the 10uF bulk cap near its VCC matters on long supply runs." }
+  ],
+
+  "esphome_extras": {
+    "captive_portal": {}
+  },
+
+  "fleet": {
+    "device_name": "air-quality-station",
+    "tags": ["indoor", "air-quality"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/examples/co2-display.json
+++ b/wirestudio/examples/co2-display.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "0.1",
+  "id": "co2-display",
+  "name": "CO2 monitor with 7-segment readout",
+  "description": "Wemos D1 Mini with an MH-Z19 NDIR CO2 sensor on a software UART (D6/D5) and a TM1637 4-digit display (D1/D2) showing the live ppm value.",
+  "created_at": "2026-08-31T00:00:00Z",
+  "updated_at": "2026-08-31T00:00:00Z",
+
+  "board": {
+    "library_id": "wemos-d1-mini",
+    "mcu": "esp8266",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-me6211",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "publish CO2 ppm and show it on the local display" }
+  ],
+
+  "components": [
+    { "id": "co2meter", "library_id": "mhz19", "label": "Room",
+      "params": { "update_interval": "30s" } },
+    { "id": "readout", "library_id": "tm1637", "label": "CO2 Readout",
+      "params": {
+        "intensity": 3,
+        "lambda": "if (id(co2meter_co2).has_state()) { it.printf(\"%4.0f\", id(co2meter_co2).state); } else { it.print(\"----\"); }"
+      } }
+  ],
+
+  "buses": [
+    { "id": "co2_uart", "type": "uart", "tx": "D6", "rx": "D5", "baud_rate": 9600 }
+  ],
+
+  "connections": [
+    { "component_id": "co2meter", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "co2meter", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "co2meter", "pin_role": "TX",  "target": { "kind": "bus", "bus_id": "co2_uart" } },
+    { "component_id": "co2meter", "pin_role": "RX",  "target": { "kind": "bus", "bus_id": "co2_uart" } },
+
+    { "component_id": "readout", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "readout", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "readout", "pin_role": "CLK", "target": { "kind": "gpio", "pin": "D1" } },
+    { "component_id": "readout", "pin_role": "DIO", "target": { "kind": "gpio", "pin": "D2" } }
+  ],
+
+  "passives": [],
+
+  "warnings": [
+    { "level": "info", "code": "mhz19_warmup",
+      "text": "MH-Z19 needs ~3 minutes of warm-up after power-on before readings settle." }
+  ],
+
+  "esphome_extras": {
+    "captive_portal": {}
+  },
+
+  "fleet": {
+    "device_name": "co2-display",
+    "tags": ["indoor", "air-quality", "display"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/examples/energy-monitor.json
+++ b/wirestudio/examples/energy-monitor.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "0.1",
+  "id": "energy-monitor",
+  "name": "Whole-circuit energy monitor",
+  "description": "ESP32-DevKitC-V4 measuring mains power three ways: a PZEM-004T v3 over Modbus/UART2 for real power on one circuit, an SCT-013 CT clamp on GPIO34 for a second circuit's current, and an INA219 on I2C watching a 12V DC rail.",
+  "created_at": "2026-08-31T00:00:00Z",
+  "updated_at": "2026-08-31T00:00:00Z",
+
+  "board": {
+    "library_id": "esp32-devkitc-v4",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117-3v3",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "publish real power, energy and power factor for the monitored AC circuit" },
+    { "id": "r2", "kind": "capability", "text": "publish RMS current from a clamp-on CT without breaking the conductor" },
+    { "id": "r3", "kind": "capability", "text": "publish voltage/current/power of the 12V DC accessory rail" }
+  ],
+
+  "components": [
+    { "id": "pzem_bus", "library_id": "modbus", "label": "PZEM modbus",
+      "params": { "send_wait_time": "200ms" } },
+    { "id": "mains", "library_id": "pzemac", "label": "Heater Circuit",
+      "params": { "address": 1, "update_interval": "10s" } },
+    { "id": "clamp", "library_id": "ct_clamp", "label": "Dryer Circuit",
+      "params": { "sample_duration": "300ms", "update_interval": "30s" } },
+    { "id": "dcrail", "library_id": "ina219", "label": "12V Rail",
+      "params": { "address": "0x40", "update_interval": "30s" } }
+  ],
+
+  "buses": [
+    { "id": "pzem_uart", "type": "uart", "tx": "GPIO17", "rx": "GPIO16", "baud_rate": 9600 },
+    { "id": "i2c0", "type": "i2c", "frequency_hz": 100000, "sda": "GPIO21", "scl": "GPIO22" }
+  ],
+
+  "connections": [
+    { "component_id": "pzem_bus", "pin_role": "UART", "target": { "kind": "bus", "bus_id": "pzem_uart" } },
+    { "component_id": "mains",    "pin_role": "HUB",  "target": { "kind": "component", "component_id": "pzem_bus" } },
+
+    { "component_id": "clamp",  "pin_role": "OUT", "target": { "kind": "gpio", "pin": "GPIO34" } },
+
+    { "component_id": "dcrail", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "dcrail", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "dcrail", "pin_role": "SDA", "target": { "kind": "bus", "bus_id": "i2c0" } },
+    { "component_id": "dcrail", "pin_role": "SCL", "target": { "kind": "bus", "bus_id": "i2c0" } }
+  ],
+
+  "passives": [
+    { "id": "r_burden", "kind": "resistor", "value": "33R",
+      "between": ["clamp.OUT", "GND"], "purpose": "CT burden (SCT-013-000)" },
+    { "id": "r_bias1", "kind": "resistor", "value": "10k",
+      "between": ["clamp.OUT", "3V3"], "purpose": "mid-rail bias" },
+    { "id": "r_bias2", "kind": "resistor", "value": "10k",
+      "between": ["clamp.OUT", "GND"], "purpose": "mid-rail bias" }
+  ],
+
+  "warnings": [
+    { "level": "warn", "code": "mains_isolation",
+      "text": "The PZEM-004T measurement side connects to live mains: enclose it, fuse the voltage tap, and keep the TTL side's optocoupled isolation intact." }
+  ],
+
+  "esphome_extras": {
+    "captive_portal": {}
+  },
+
+  "fleet": {
+    "device_name": "energy-monitor",
+    "tags": ["energy", "mains", "dc"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/examples/output-hub.json
+++ b/wirestudio/examples/output-hub.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "0.1",
+  "id": "output-hub",
+  "name": "PWM + shift-register output hub",
+  "description": "ESP32-DevKitC-V4 driving banks of outputs without spending MCU pins: a PCA9685 on I2C provides two dimmable 12-bit PWM channels, and an SN74HC595 shift register (GPIO25/26/27) fans out a relay-module output on its pin 0.",
+  "created_at": "2026-08-31T00:00:00Z",
+  "updated_at": "2026-08-31T00:00:00Z",
+
+  "board": {
+    "library_id": "esp32-devkitc-v4",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117-3v3",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "expose two dimmable LED channels from the PCA9685" },
+    { "id": "r2", "kind": "capability", "text": "switch a relay through the shift register without using an MCU pin" }
+  ],
+
+  "components": [
+    { "id": "pwmhub", "library_id": "pca9685", "label": "LED Bank",
+      "params": {
+        "frequency": "1000Hz",
+        "channels": [
+          { "channel": 0, "name": "Shelf Strip" },
+          { "channel": 1, "name": "Cabinet Strip" }
+        ]
+      } },
+    { "id": "shift1", "library_id": "sn74hc595", "label": "Relay Fanout",
+      "params": { "sr_count": 1 } },
+    { "id": "fan_relay", "library_id": "gpio_output", "label": "Vent Fan", "params": {} }
+  ],
+
+  "buses": [
+    { "id": "i2c0", "type": "i2c", "frequency_hz": 400000, "sda": "GPIO21", "scl": "GPIO22" }
+  ],
+
+  "connections": [
+    { "component_id": "pwmhub", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "pwmhub", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "pwmhub", "pin_role": "SDA", "target": { "kind": "bus", "bus_id": "i2c0" } },
+    { "component_id": "pwmhub", "pin_role": "SCL", "target": { "kind": "bus", "bus_id": "i2c0" } },
+
+    { "component_id": "shift1", "pin_role": "VCC",   "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "shift1", "pin_role": "GND",   "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "shift1", "pin_role": "DATA",  "target": { "kind": "gpio", "pin": "GPIO25" } },
+    { "component_id": "shift1", "pin_role": "CLOCK", "target": { "kind": "gpio", "pin": "GPIO26" } },
+    { "component_id": "shift1", "pin_role": "LATCH", "target": { "kind": "gpio", "pin": "GPIO27" } },
+
+    { "component_id": "fan_relay", "pin_role": "OUT",
+      "target": { "kind": "expander_pin", "expander_id": "shift1", "number": 0 } }
+  ],
+
+  "passives": [],
+
+  "warnings": [
+    { "level": "info", "code": "sn74hc595_boot_float",
+      "text": "Shift-register outputs float until the first latch after boot; wire OE with a pull-up if the relay must stay off through reset." }
+  ],
+
+  "esphome_extras": {
+    "captive_portal": {}
+  },
+
+  "fleet": {
+    "device_name": "output-hub",
+    "tags": ["outputs", "led", "relay"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/examples/presence-media-node.json
+++ b/wirestudio/examples/presence-media-node.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "0.1",
+  "id": "presence-media-node",
+  "name": "mmWave presence + IR remote receiver",
+  "description": "ESP32-DevKitC-V4 media-room node: an LD2410 mmWave sensor on UART2 (256000 baud) for still-presence detection, and a TSOP38238 IR receiver on GPIO25 to learn and react to remote-control codes.",
+  "created_at": "2026-08-31T00:00:00Z",
+  "updated_at": "2026-08-31T00:00:00Z",
+
+  "board": {
+    "library_id": "esp32-devkitc-v4",
+    "mcu": "esp32",
+    "framework": "arduino"
+  },
+
+  "power": {
+    "supply": "usb",
+    "rail_voltage_v": 5.0,
+    "regulator": "onboard-ams1117-3v3",
+    "budget_ma": 500
+  },
+
+  "requirements": [
+    { "id": "r1", "kind": "capability", "text": "detect still presence (couch occupancy) for media-room automations" },
+    { "id": "r2", "kind": "capability", "text": "receive and decode IR remote codes" }
+  ],
+
+  "components": [
+    { "id": "presence", "library_id": "ld2410", "label": "Couch",
+      "params": { "throttle": "2s" } },
+    { "id": "ir", "library_id": "remote_receiver", "label": "IR Receiver",
+      "params": { "dump": "all" } }
+  ],
+
+  "buses": [
+    { "id": "radar_uart", "type": "uart", "tx": "GPIO17", "rx": "GPIO16", "baud_rate": 256000 }
+  ],
+
+  "connections": [
+    { "component_id": "presence", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },
+    { "component_id": "presence", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "presence", "pin_role": "TX",  "target": { "kind": "bus", "bus_id": "radar_uart" } },
+    { "component_id": "presence", "pin_role": "RX",  "target": { "kind": "bus", "bus_id": "radar_uart" } },
+
+    { "component_id": "ir", "pin_role": "VCC", "target": { "kind": "rail", "rail": "3V3" } },
+    { "component_id": "ir", "pin_role": "GND", "target": { "kind": "rail", "rail": "GND" } },
+    { "component_id": "ir", "pin_role": "OUT", "target": { "kind": "gpio", "pin": "GPIO25" } }
+  ],
+
+  "passives": [],
+
+  "warnings": [
+    { "level": "info", "code": "ld2410_mounting",
+      "text": "Mount the LD2410 with clear line of sight; it detects through plastic but not metal. Ceiling or high-wall placement reads the room best." }
+  ],
+
+  "esphome_extras": {
+    "captive_portal": {}
+  },
+
+  "fleet": {
+    "device_name": "presence-media-node",
+    "tags": ["indoor", "presence", "ir"],
+    "secrets_ref": {
+      "wifi_ssid": "!secret wifi_ssid",
+      "wifi_password": "!secret wifi_password",
+      "api_key": "!secret api_key"
+    }
+  }
+}

--- a/wirestudio/library/components/bme680.yaml
+++ b/wirestudio/library/components/bme680.yaml
@@ -1,0 +1,66 @@
+id: bme680
+name: Bosch BME680 environmental sensor (temp/humidity/pressure/gas, I2C)
+category: sensor
+use_cases: [temperature, humidity, pressure, voc, air_quality, indoor_air]
+aliases: ["bme688", "gy-bme680"]
+
+electrical:
+  vcc_min: 1.71
+  vcc_max: 3.6
+  current_ma_typical: 12
+  current_ma_peak: 18
+  pins:
+  - {role: VCC, kind: power}
+  - {role: GND, kind: ground}
+  - role: SDA
+    kind: i2c_sda
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  - role: SCL
+    kind: i2c_scl
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+  - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: bme680
+        i2c_id: {{ bus.id }}
+        address: {{ params.address | default('0x76') }}
+        temperature:
+          name: "{{ label }} Temperature"
+        pressure:
+          name: "{{ label }} Pressure"
+        humidity:
+          name: "{{ label }} Humidity"
+        gas_resistance:
+          name: "{{ label }} Gas Resistance"
+        update_interval: {{ params.update_interval | default('60s') }}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+
+params_schema:
+  address:
+    type: string
+    enum: ["0x76", "0x77"]
+    default: "0x76"
+    description: "SDO low = 0x76, high = 0x77. Adafruit boards default to 0x77."
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  The four-in-one climate sensor. gas_resistance is a raw MOX reading
+  (ohms) -- turning it into an IAQ score needs Bosch's closed-source
+  BSEC library (ESPHome's separate bme68x_bsec2 platform). The heater
+  also warms the die slightly; expect temperature ~1C high unless you
+  calibrate it out with a filter.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x06
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x06_P2.54mm_Vertical
+  value: BME680

--- a/wirestudio/library/components/ct_clamp.yaml
+++ b/wirestudio/library/components/ct_clamp.yaml
@@ -1,0 +1,67 @@
+id: ct_clamp
+name: Current transformer clamp (SCT-013 class, analog)
+category: sensor
+use_cases: [ac_current, power_metering, mains_monitoring, sub_metering]
+aliases: ["sct-013", "sct013", "current-clamp"]
+
+electrical:
+  current_ma_typical: 0
+  current_ma_peak: 0
+  pins:
+    - {role: OUT, kind: adc}
+  passives:
+    - {kind: resistor, value: "33R", between: [OUT, GND], purpose: burden (SCT-013-000 current-output type only)}
+    - {kind: resistor, value: "10k", between: [OUT, VCC], purpose: bias divider to mid-rail}
+    - {kind: resistor, value: "10k", between: [OUT, GND], purpose: bias divider to mid-rail}
+    - {kind: capacitor, value: "10uF", between: [OUT, GND], purpose: bias rail smoothing}
+
+esphome:
+  required_components: []
+  yaml_template: |
+    sensor:
+      - platform: adc
+        id: {{ id }}_adc
+        pin: {{ pins.OUT | tojson }}
+        attenuation: 12db
+        internal: true
+      - platform: ct_clamp
+        sensor: {{ id }}_adc
+        name: "{{ label }} Current"
+        sample_duration: {{ params.sample_duration | default('200ms') }}
+        update_interval: {{ params.update_interval | default('60s') }}
+        filters:
+          - calibrate_linear:
+              - 0.0 -> 0.0
+              - {{ params.calibration_point | default('0.0125 -> 1.25') }}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+
+params_schema:
+  sample_duration:
+    type: string
+    default: "200ms"
+    description: "Integrate over >= several mains cycles (200ms = 10-12 cycles)."
+  update_interval:
+    type: string
+    default: "60s"
+  calibration_point:
+    type: string
+    default: "0.0125 -> 1.25"
+    description: "measured_raw -> amps, from a known load (e.g. a heater through a kill-a-watt)."
+
+notes: |
+  Non-invasive AC current sensing: clamp around ONE conductor (live or
+  neutral, not the whole cord). The SCT-013-000 is a current-output CT
+  and needs the burden resistor; -030 (1V/30A) variants have it
+  built in. Bias the signal to mid-rail with the divider so the ADC
+  sees the full sine. Reports RMS current only -- multiply by an
+  assumed voltage for apparent power, or use a PZEM-004T where real
+  power matters. ESP32 ADC only (ESP8266 A0 works at reduced range).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x02
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical
+  value: SCT-013

--- a/wirestudio/library/components/ina219.yaml
+++ b/wirestudio/library/components/ina219.yaml
@@ -1,0 +1,79 @@
+id: ina219
+name: TI INA219 high-side current/power monitor (I2C)
+category: sensor
+use_cases: [current, power_metering, dc_power, battery_monitoring, voltage]
+aliases: ["gy-219", "adafruit-904"]
+
+electrical:
+  vcc_min: 3.0
+  vcc_max: 5.5
+  current_ma_typical: 1
+  current_ma_peak: 1.2
+  pins:
+  - {role: VCC, kind: power}
+  - {role: GND, kind: ground}
+  - role: SDA
+    kind: i2c_sda
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  - role: SCL
+    kind: i2c_scl
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  - {role: VIN_PLUS, kind: analog_in, voltage: 26.0}
+  - {role: VIN_MINUS, kind: analog_in, voltage: 26.0}
+  passives:
+  - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: ina219
+        i2c_id: {{ bus.id }}
+        address: {{ params.address | default('0x40') }}
+        shunt_resistance: {{ params.shunt_resistance | default('0.1 ohm') }}
+        max_current: {{ params.max_current | default('3.2A') }}
+        max_voltage: {{ params.max_voltage | default('26.0V') }}
+        current:
+          name: "{{ label }} Current"
+        power:
+          name: "{{ label }} Power"
+        bus_voltage:
+          name: "{{ label }} Bus Voltage"
+        update_interval: {{ params.update_interval | default('60s') }}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+
+params_schema:
+  address:
+    type: string
+    enum: ["0x40", "0x41", "0x44", "0x45"]
+    default: "0x40"
+    description: "A0/A1 solder jumpers; four boards can share one bus."
+  shunt_resistance:
+    type: string
+    default: "0.1 ohm"
+    description: "The common purple GY-219 module ships an R100 (0.1 ohm) shunt."
+  max_current:
+    type: string
+    default: "3.2A"
+  max_voltage:
+    type: string
+    default: "26.0V"
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  Measures the load's current through its own shunt (VIN+ -> VIN- in
+  series with the supply, high side) up to 26V / 3.2A with the stock
+  0.1-ohm shunt. current_ma here is the chip's own draw -- the measured
+  circuit's current flows through the shunt, not the MCU rail. For
+  higher current swap the shunt and set shunt_resistance/max_current.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x06
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x06_P2.54mm_Vertical
+  value: INA219

--- a/wirestudio/library/components/ld2410.yaml
+++ b/wirestudio/library/components/ld2410.yaml
@@ -1,0 +1,70 @@
+id: ld2410
+name: Hi-Link LD2410 24GHz mmWave presence sensor (UART)
+category: binary_sensor
+use_cases: [presence, occupancy, motion, distance, still_detection]
+aliases: [ld2410b, ld2410c, hlk-ld2410]
+
+electrical:
+  vcc_min: 4.5
+  vcc_max: 5.5
+  current_ma_typical: 80
+  current_ma_peak: 120
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - {role: TX, kind: uart_tx, voltage: 3.3}
+    - {role: RX, kind: uart_rx, voltage: 3.3}
+    - {role: OUT, kind: digital_out, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "10uF", between: [VCC, GND], purpose: bulk decoupling}
+
+esphome:
+  required_components: [uart]
+  yaml_template: |
+    ld2410:
+      uart_id: {{ bus.id }}
+      id: {{ id }}
+    binary_sensor:
+      - platform: ld2410
+        has_target:
+          name: "{{ label }} Presence"
+        has_moving_target:
+          name: "{{ label }} Moving Target"
+        has_still_target:
+          name: "{{ label }} Still Target"
+    sensor:
+      - platform: ld2410
+        moving_distance:
+          name: "{{ label }} Moving Distance"
+        still_distance:
+          name: "{{ label }} Still Distance"
+        detection_distance:
+          name: "{{ label }} Detection Distance"
+
+capability:
+  role: input
+  provides:
+    - {event: on_press}
+    - {event: on_release}
+  checks:
+    - {predicate: is_on,  esphome: binary_sensor.is_on}
+    - {predicate: is_off, esphome: binary_sensor.is_off}
+
+params_schema:
+  throttle:
+    type: string
+    description: "Minimum interval between distance/energy updates (e.g. '2s') to calm the log."
+
+notes: |
+  The mmWave that made still-presence detection mainstream: detects a
+  motionless person by micro-motion out to ~5m through plastic. UART
+  runs at 256000 baud -- set the bus accordingly. Wire module TX to MCU
+  RX and vice versa. The OUT pin mirrors presence as a plain digital
+  signal if you want a wire fallback; the UART integration is richer
+  (per-gate energies, distances, engineering mode). One ld2410 hub per
+  device. Sister ld2420 has its own library entry.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x05
+  footprint: Connector_PinHeader_1.27mm:PinHeader_1x05_P1.27mm_Vertical
+  value: LD2410

--- a/wirestudio/library/components/ld2420.yaml
+++ b/wirestudio/library/components/ld2420.yaml
@@ -2,7 +2,7 @@ id: ld2420
 name: Hi-Link LD2420 24GHz mmWave presence sensor
 category: binary_sensor
 use_cases: [presence, occupancy, motion, distance]
-aliases: [ld2410, ld2412, hlk-ld2420]
+aliases: [ld2412, hlk-ld2420]
 
 electrical:
   vcc_min: 4.5

--- a/wirestudio/library/components/mhz19.yaml
+++ b/wirestudio/library/components/mhz19.yaml
@@ -1,0 +1,59 @@
+id: mhz19
+name: Winsen MH-Z19 NDIR CO2 sensor (UART)
+category: sensor
+use_cases: [co2, air_quality, ventilation, indoor_air]
+aliases: ["mh-z19b", "mh-z19c", "mh-z19e"]
+
+electrical:
+  vcc_min: 4.5
+  vcc_max: 5.5
+  current_ma_typical: 60
+  current_ma_peak: 150
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - {role: TX, kind: uart_tx, voltage: 3.3}
+    - {role: RX, kind: uart_rx, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "10uF", between: [VCC, GND], purpose: bulk decoupling for lamp pulses}
+
+esphome:
+  required_components: [uart]
+  yaml_template: |
+    sensor:
+      - platform: mhz19
+        uart_id: {{ bus.id }}
+        co2:
+          id: {{ id }}_co2
+          name: "{{ label }} CO2"
+        temperature:
+          name: "{{ label }} Temperature"
+        update_interval: {{ params.update_interval | default('60s') }}
+        automatic_baseline_calibration: {{ params.automatic_baseline_calibration | default(false) | tojson }}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+
+params_schema:
+  update_interval:
+    type: string
+    default: "60s"
+  automatic_baseline_calibration:
+    type: boolean
+    default: false
+    description: "ABC assumes the room sees ~400ppm fresh air daily; leave off for bedrooms/offices that stay occupied."
+
+notes: |
+  The classic hobbyist NDIR CO2 sensor: 5V supply, 3.3V UART at 9600
+  baud (wire sensor TX to MCU RX and vice versa). Needs ~3 minutes of
+  warm-up before readings settle. Temperature output is the internal
+  die temperature -- coarse, not a room thermometer. For new designs
+  the SCD4x costs similar and adds RH; the MH-Z19 remains the cheap
+  proven default.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical
+  value: MH-Z19

--- a/wirestudio/library/components/pca9685.yaml
+++ b/wirestudio/library/components/pca9685.yaml
@@ -1,0 +1,81 @@
+id: pca9685
+name: NXP PCA9685 16-channel 12-bit PWM driver (I2C)
+category: io_expander
+use_cases: [pwm, led_dimming, servo_bank, light_channels]
+aliases: ["adafruit-815", "16-channel-pwm"]
+
+electrical:
+  vcc_min: 2.3
+  vcc_max: 5.5
+  current_ma_typical: 6
+  current_ma_peak: 10
+  pins:
+  - {role: VCC, kind: power}
+  - {role: GND, kind: ground}
+  - role: SDA
+    kind: i2c_sda
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  - role: SCL
+    kind: i2c_scl
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  - {role: OE, kind: digital_in, voltage: 3.3}
+  passives:
+  - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    pca9685:
+      id: {{ id }}
+      i2c_id: {{ bus.id }}
+      address: {{ params.address | default('0x40') }}
+      frequency: {{ params.frequency | default('500Hz') }}
+    output:
+    {%- for ch in params.channels | default([{"channel": 0}]) %}
+      - platform: pca9685
+        pca9685_id: {{ id }}
+        id: {{ id }}_ch{{ ch.channel }}
+        channel: {{ ch.channel }}
+    {%- endfor %}
+    light:
+    {%- for ch in params.channels | default([{"channel": 0}]) %}
+      - platform: monochromatic
+        name: "{{ ch.name | default(label ~ ' Channel ' ~ ch.channel) }}"
+        output: {{ id }}_ch{{ ch.channel }}
+    {%- endfor %}
+
+capability:
+  role: output
+  accepts:
+    - {action: turn_on,  esphome: light.turn_on}
+    - {action: turn_off, esphome: light.turn_off}
+
+params_schema:
+  address:
+    type: string
+    default: "0x40"
+    description: "Six address jumpers give 0x40-0x7F; note 0x40 collides with an INA219 on the same bus."
+  frequency:
+    type: string
+    default: "500Hz"
+    description: "24Hz-1526Hz, shared by all 16 channels. Use 50Hz for servos, higher for LEDs."
+  channels:
+    type: array
+    description: "Channels to expose, e.g. [{channel: 0, name: 'Desk strip'}, {channel: 1}]. Each becomes an output + monochromatic light."
+
+notes: |
+  16 hardware PWM channels over I2C -- LED banks or servo arrays
+  without spending MCU pins. Each declared channel renders as an
+  output plus a dimmable light entity; for servos set frequency to
+  50Hz and point a `servo:` at the generated output id instead of the
+  light. The V+ screw terminal powers servos separately from VCC
+  logic; the frequency is global, so don't mix servos and fast LED
+  PWM on one chip.
+kicad:
+  symbol_lib: Driver_LED
+  symbol: PCA9685PW
+  footprint: Package_SO:TSSOP-28_4.4x9.7mm_P0.65mm
+  pin_map:
+    VCC: VDD
+    GND: VSS
+    OE: ~{OE}

--- a/wirestudio/library/components/pmsx003.yaml
+++ b/wirestudio/library/components/pmsx003.yaml
@@ -1,0 +1,57 @@
+id: pmsx003
+name: Plantower PMS5003/PMS7003 particulate matter sensor (UART)
+category: sensor
+use_cases: [pm25, air_quality, dust, particulate, outdoor_air]
+aliases: ["pms5003", "pms7003", "pmsa003", "plantower"]
+
+electrical:
+  vcc_min: 4.5
+  vcc_max: 5.5
+  current_ma_typical: 100
+  current_ma_peak: 120
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - {role: TX, kind: uart_tx, voltage: 3.3}
+    - {role: RX, kind: uart_rx, voltage: 3.3}
+    - {role: SET, kind: digital_in, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [uart]
+  yaml_template: |
+    sensor:
+      - platform: pmsx003
+        uart_id: {{ bus.id }}
+        type: {{ params.type | default('PMSX003') }}
+        pm_1_0:
+          name: "{{ label }} PM1.0"
+        pm_2_5:
+          name: "{{ label }} PM2.5"
+        pm_10_0:
+          name: "{{ label }} PM10"
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+
+params_schema:
+  type:
+    type: string
+    enum: [PMSX003, PMS5003T, PMS5003ST, PMS5003S]
+    default: PMSX003
+    description: "T/ST variants add temperature+humidity, S/ST add formaldehyde."
+
+notes: |
+  Laser-scatter particle counter, the sensor inside most DIY AQI
+  boxes. 5V fan, 3.3V UART at 9600 baud. The fan wears out over a few
+  years of continuous duty -- tie SET low or use ESPHome's
+  update_interval sleep support to duty-cycle it outdoors. Give the
+  inlet/outlet clearance in the enclosure; recirculated air reads low.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x08
+  footprint: Connector_PinHeader_1.27mm:PinHeader_1x08_P1.27mm_Vertical
+  value: PMS5003

--- a/wirestudio/library/components/pn532.yaml
+++ b/wirestudio/library/components/pn532.yaml
@@ -1,0 +1,69 @@
+id: pn532
+name: NXP PN532 NFC/RFID reader (13.56MHz, I2C)
+category: input
+use_cases: [rfid, nfc, access_control, tag_reader]
+aliases: ["pn532-nfc", "elechouse-pn532", "grove-nfc"]
+
+electrical:
+  vcc_min: 3.3
+  vcc_max: 5.5
+  current_ma_typical: 60
+  current_ma_peak: 150
+  pins:
+  - {role: VCC, kind: power}
+  - {role: GND, kind: ground}
+  - role: SDA
+    kind: i2c_sda
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  - role: SCL
+    kind: i2c_scl
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+  - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    pn532_i2c:
+      id: {{ id }}
+      i2c_id: {{ bus.id }}
+      update_interval: {{ params.update_interval | default('1s') }}
+    {%- if params.on_tag is defined %}
+      on_tag: {{ params.on_tag | tojson }}
+    {%- endif %}
+    {%- if params.uid is defined %}
+    binary_sensor:
+      - platform: pn532
+        pn532_id: {{ id }}
+        uid: {{ params.uid | tojson }}
+        name: "{{ label }} Known Tag"
+    {%- endif %}
+
+capability:
+  role: input
+  provides:
+    - {event: on_tag, kind: event}
+
+params_schema:
+  update_interval:
+    type: string
+    default: "1s"
+    description: "Tag poll interval; 100ms-500ms for snappy access control."
+  uid:
+    type: string
+    description: "Match a specific tag as a binary_sensor, e.g. '74-10-37-94'."
+  on_tag:
+    type: array
+    description: "Actions on any tag; `x` is the UID string. Pair with homeassistant.tag_scanned for HA's tag registry."
+
+notes: |
+  Reads 13.56MHz MIFARE/NTAG (the card/fob/phone-tag family) -- a
+  different band from the 125kHz RDM6300/EM4100 fobs. The common red
+  Elechouse module: set its DIP switches to I2C mode (1=on 2=off).
+  Antenna is on-board; keep it clear of ground planes and metal
+  standoffs. SPI variant exists (pn532_spi) if the bus is busy.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical
+  value: PN532

--- a/wirestudio/library/components/pzemac.yaml
+++ b/wirestudio/library/components/pzemac.yaml
@@ -1,0 +1,63 @@
+id: pzemac
+name: Peacefair PZEM-004T v3 AC energy monitor (Modbus RTU over UART)
+category: sensor
+use_cases: [power_metering, ac_voltage, ac_current, energy, mains_monitoring]
+aliases: ["pzem-004t", "pzem004t", "pzem"]
+
+electrical:
+  current_ma_typical: 10
+  current_ma_peak: 15
+  pins:
+    - role: HUB
+      kind: hub_ref
+      parent_library_id: modbus
+  passives: []
+
+esphome:
+  required_components: []
+  yaml_template: |
+    sensor:
+      - platform: pzemac
+        modbus_id: {{ parent.id }}
+        address: {{ params.address | default(1) }}
+        voltage:
+          name: "{{ label }} Voltage"
+        current:
+          name: "{{ label }} Current"
+        power:
+          name: "{{ label }} Power"
+        energy:
+          name: "{{ label }} Energy"
+        frequency:
+          name: "{{ label }} Frequency"
+        power_factor:
+          name: "{{ label }} Power Factor"
+        update_interval: {{ params.update_interval | default('10s') }}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+
+params_schema:
+  address:
+    type: number
+    default: 1
+    description: "Modbus slave address. Factory units answer address 1 (and the 0xF8 broadcast); re-address via ESPHome's pzemac.reset_energy/set_address services when stacking meters."
+  update_interval:
+    type: string
+    default: "10s"
+
+notes: |
+  The de-facto DIY mains monitor: clamp CT or shunt on the AC side,
+  optocoupled 5V TTL UART on ours. Interface side draws ~10mA from 5V;
+  the measurement side connects to live mains -- enclose it, fuse the
+  voltage tap, and keep the CT low-voltage side separated. UART runs
+  9600 baud through ESPHome's modbus hub (uart -> modbus -> pzemac).
+  Note the TTL header wants 5V VCC but its RX needs only 3.3V-safe
+  drive -- it works directly off ESP32/ESP8266 pins.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical
+  value: PZEM-004T

--- a/wirestudio/library/components/remote_receiver.yaml
+++ b/wirestudio/library/components/remote_receiver.yaml
@@ -1,0 +1,68 @@
+id: remote_receiver
+name: IR receiver (TSOP38238/VS1838B, 38kHz demodulated)
+category: input
+use_cases: [ir, remote_control, media_control, learning_remote]
+aliases: ["tsop38238", "vs1838b", "tsop4838", "ir-receiver"]
+
+electrical:
+  vcc_min: 2.5
+  vcc_max: 5.5
+  current_ma_typical: 0.45
+  current_ma_peak: 1.5
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - {role: OUT, kind: digital_out, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling per datasheet app circuit}
+    - {kind: resistor, value: "100R", between: [VCC, VCC], purpose: supply filter (datasheet RC) -- optional on clean rails}
+
+esphome:
+  required_components: []
+  yaml_template: |
+    remote_receiver:
+      id: {{ id }}
+      pin:
+        number: {{ pins.OUT | tojson }}
+        inverted: {{ params.inverted | default(true) | tojson }}
+        mode:
+          input: true
+      dump: {{ params.dump | default('all') }}
+    {%- if params.on_nec is defined %}
+      on_nec: {{ params.on_nec | tojson }}
+    {%- endif %}
+
+tasmota:
+  pins:
+    OUT: IRrecv
+
+capability:
+  role: input
+  provides:
+    - {event: on_nec, kind: event}
+
+params_schema:
+  dump:
+    type: string
+    default: "all"
+    description: "Protocols to log for learning codes ('all' while setting up, then narrow or remove)."
+  inverted:
+    type: boolean
+    default: true
+    description: "Demodulating receivers idle high and pull low on carrier -- leave true."
+  on_nec:
+    type: object
+    description: "NEC automation, e.g. {address: 0x407F, command: 0xC03F, then: [...]}"
+
+notes: |
+  Counterpart to the remote_transmitter entry: a demodulating 38kHz
+  receiver module on one GPIO. Start with dump: all, press the remote,
+  copy the decoded protocol/address/command from the log into a
+  binary_sensor or automation. On ESP32 the RMT peripheral does the
+  timing; on ESP8266 pick a pin that tolerates interrupts (avoid
+  GPIO16).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x03
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x03_P2.54mm_Vertical
+  value: TSOP38238

--- a/wirestudio/library/components/scd4x.yaml
+++ b/wirestudio/library/components/scd4x.yaml
@@ -1,0 +1,67 @@
+id: scd4x
+name: Sensirion SCD4x true-CO2 sensor (photoacoustic NDIR, I2C)
+category: sensor
+use_cases: [co2, air_quality, ventilation, indoor_air]
+aliases: ["scd40", "scd41", "adafruit-5187"]
+
+electrical:
+  vcc_min: 2.4
+  vcc_max: 5.5
+  current_ma_typical: 15
+  current_ma_peak: 205
+  pins:
+  - {role: VCC, kind: power}
+  - {role: GND, kind: ground}
+  - role: SDA
+    kind: i2c_sda
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  - role: SCL
+    kind: i2c_scl
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+  - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+  - {kind: capacitor, value: "10uF", between: [VCC, GND], purpose: bulk decoupling for measurement bursts}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: scd4x
+        i2c_id: {{ bus.id }}
+        co2:
+          id: {{ id }}_co2
+          name: "{{ label }} CO2"
+        temperature:
+          name: "{{ label }} Temperature"
+        humidity:
+          name: "{{ label }} Humidity"
+        update_interval: {{ params.update_interval | default('60s') }}
+    {%- if params.altitude_compensation is defined %}
+        altitude_compensation: {{ params.altitude_compensation }}
+    {%- endif %}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+
+params_schema:
+  update_interval:
+    type: string
+    default: "60s"
+  altitude_compensation:
+    type: string
+    description: "Site altitude (e.g. '450m') -- CO2 reading shifts ~3% per 1000m without it."
+
+notes: |
+  Photoacoustic NDIR, so it measures actual CO2 rather than inferring
+  eCO2 from VOCs -- the difference matters for ventilation control.
+  Draws up to ~200mA in 1A bursts during measurement: budget the rail
+  and keep the bulk cap close. SCD41 adds single-shot mode for battery
+  use. Automatic self-calibration assumes weekly exposure to fresh-air
+  ~400ppm; disable it for greenhouses or continuously occupied spaces.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical
+  value: SCD4x

--- a/wirestudio/library/components/servo.yaml
+++ b/wirestudio/library/components/servo.yaml
@@ -1,0 +1,74 @@
+id: servo
+name: Hobby servo (SG90/MG90S class, 50Hz PWM)
+category: actuator
+use_cases: [servo, valve, lock, pan_tilt, damper, dispenser]
+aliases: ["sg90", "mg90s", "mg996r", "micro-servo"]
+
+electrical:
+  vcc_min: 4.8
+  vcc_max: 6.0
+  current_ma_typical: 200
+  current_ma_peak: 750
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - {role: PWM, kind: digital_in, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "470uF", between: [VCC, GND], purpose: bulk decoupling for stall surges}
+
+esphome:
+  required_components: []
+  yaml_template: |
+    output:
+      - platform: {{ params.output_platform | default(('ledc' if board and board.chip_variant.startswith('esp32') else 'esp8266_pwm')) }}
+        id: {{ id }}_pwm
+        pin: {{ pins.PWM | tojson }}
+        frequency: 50 Hz
+    servo:
+      - id: {{ id }}
+        output: {{ id }}_pwm
+        auto_detach_time: {{ params.auto_detach_time | default('2s') }}
+        transition_length: {{ params.transition_length | default('1s') }}
+    number:
+      - platform: template
+        name: "{{ label }} Position"
+        min_value: -100
+        max_value: 100
+        step: 1
+        optimistic: true
+        set_action:
+          then:
+            - servo.write:
+                id: {{ id }}
+                level: "!lambda return x / 100.0;"
+
+capability:
+  role: output
+  accepts:
+    - {action: write,  esphome: servo.write}
+    - {action: detach, esphome: servo.detach}
+
+params_schema:
+  auto_detach_time:
+    type: string
+    default: "2s"
+    description: "Stop driving the signal after reaching position -- quiets buzz and saves power. '0s' holds torque continuously."
+  transition_length:
+    type: string
+    default: "1s"
+  output_platform:
+    type: string
+    enum: [ledc, esp8266_pwm]
+    description: "Defaults by chip: ledc on ESP32-family, esp8266_pwm on ESP8266."
+
+notes: |
+  Standard 50Hz hobby servo on a single GPIO; the template exposes a
+  -100..100 position slider in Home Assistant. Power from 5V, never
+  the 3.3V rail -- a stalled SG90 pulls ~750mA and an MG996R several
+  amps (size the supply and cap accordingly). The 3.3V signal is fine
+  for practically every 5V servo.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x03
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x03_P2.54mm_Vertical
+  value: Servo

--- a/wirestudio/library/components/sgp4x.yaml
+++ b/wirestudio/library/components/sgp4x.yaml
@@ -1,0 +1,63 @@
+id: sgp4x
+name: Sensirion SGP40/SGP41 VOC/NOx index sensor (I2C)
+category: sensor
+use_cases: [voc, air_quality, nox, odor, indoor_air]
+aliases: ["sgp40", "sgp41", "adafruit-4829"]
+
+electrical:
+  vcc_min: 1.7
+  vcc_max: 3.6
+  current_ma_typical: 2.6
+  current_ma_peak: 3.4
+  pins:
+  - {role: VCC, kind: power}
+  - {role: GND, kind: ground}
+  - role: SDA
+    kind: i2c_sda
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  - role: SCL
+    kind: i2c_scl
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+  - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: sgp4x
+        i2c_id: {{ bus.id }}
+        voc:
+          name: "{{ label }} VOC Index"
+    {%- if params.model | default('sgp40') == 'sgp41' %}
+        nox:
+          name: "{{ label }} NOx Index"
+    {%- endif %}
+        update_interval: {{ params.update_interval | default('60s') }}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+
+params_schema:
+  model:
+    type: string
+    enum: [sgp40, sgp41]
+    default: sgp40
+    description: "SGP41 adds the NOx index channel."
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  Reports Sensirion's VOC Index (1-500, 100 = typical air), not ppb --
+  the on-chip gas algorithm baselines itself over ~24h. Pair with an
+  SHT4x on the same bus and set humidity_source for compensated
+  readings. The hotplate runs continuously; ~2.6mA is the price of a
+  stable index.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical
+  value: SGP4x

--- a/wirestudio/library/components/sht4x.yaml
+++ b/wirestudio/library/components/sht4x.yaml
@@ -1,0 +1,61 @@
+id: sht4x
+name: Sensirion SHT4x temperature/humidity sensor (I2C)
+category: sensor
+use_cases: [temperature, humidity, climate, indoor_air]
+aliases: ["sht40", "sht41", "sht45", "adafruit-4885"]
+
+electrical:
+  vcc_min: 1.08
+  vcc_max: 3.6
+  current_ma_typical: 0.4
+  current_ma_peak: 0.6
+  pins:
+  - {role: VCC, kind: power}
+  - {role: GND, kind: ground}
+  - role: SDA
+    kind: i2c_sda
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  - role: SCL
+    kind: i2c_scl
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+  - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: sht4x
+        i2c_id: {{ bus.id }}
+        address: {{ params.address | default('0x44') }}
+        temperature:
+          name: "{{ label }} Temperature"
+        humidity:
+          name: "{{ label }} Humidity"
+        update_interval: {{ params.update_interval | default('60s') }}
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+
+params_schema:
+  address:
+    type: string
+    default: "0x44"
+    description: "SHT40-AD variant is 0x45; everything common is 0x44."
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  Sensirion's current-generation replacement for the SHT3x/DHT lines:
+  factory-calibrated, +/-0.2C / +/-1.8%RH (SHT40), no warm-up. 3.3V
+  only -- most breakouts have no level shifter. The optional on-die
+  heater (creep recovery in condensing environments) is exposed by
+  ESPHome's heater_* options if needed.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical
+  value: SHT4x

--- a/wirestudio/library/components/sn74hc595.yaml
+++ b/wirestudio/library/components/sn74hc595.yaml
@@ -1,0 +1,59 @@
+id: sn74hc595
+name: TI SN74HC595 8-bit shift register (output expander, daisy-chainable)
+category: io_expander
+use_cases: [gpio_expansion, led_outputs, relay_banks, seven_segment]
+aliases: ["74hc595", "595"]
+
+electrical:
+  vcc_min: 2.0
+  vcc_max: 6.0
+  current_ma_typical: 1
+  current_ma_peak: 70
+  pins:
+  - {role: VCC, kind: power}
+  - {role: GND, kind: ground}
+  - {role: DATA, kind: digital_in, voltage: 3.3}
+  - {role: CLOCK, kind: digital_in, voltage: 3.3}
+  - {role: LATCH, kind: digital_in, voltage: 3.3}
+  - {role: OE, kind: digital_in, voltage: 3.3}
+  passives:
+  - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: []
+  expander_pin_key: sn74hc595
+  yaml_template: |
+    sn74hc595:
+      - id: {{ id }}
+        data_pin: {{ pins.DATA | tojson }}
+        clock_pin: {{ pins.CLOCK | tojson }}
+        latch_pin: {{ pins.LATCH | tojson }}
+    {%- if pins.OE is defined %}
+        oe_pin: {{ pins.OE | tojson }}
+    {%- endif %}
+        sr_count: {{ params.sr_count | default(1) }}
+
+params_schema:
+  sr_count:
+    type: integer
+    minimum: 1
+    maximum: 4
+    default: 1
+    description: "Daisy-chained register count; pins number 0..(8*sr_count - 1)."
+
+notes: |
+  Three MCU pins buy 8 outputs per chip, chainable to 32. Output-only:
+  wire downstream gpio_output/switch components to expander pins 0-7
+  (chip QA-QH). Leave OE unconnected (module boards strap it low) or
+  wire it for a hardware blank-on-boot -- outputs float during MCU
+  reset otherwise. Per-pin sink/source is 35mA absolute max but keep
+  the whole chip under ~70mA; drive relay modules, not relay coils.
+kicad:
+  symbol_lib: 74xx
+  symbol: 74HC595
+  footprint: Package_DIP:DIP-16_W7.62mm
+  pin_map:
+    DATA: SER
+    CLOCK: SRCLK
+    LATCH: RCLK
+    OE: ~{OE}

--- a/wirestudio/library/components/tm1637.yaml
+++ b/wirestudio/library/components/tm1637.yaml
@@ -1,0 +1,56 @@
+id: tm1637
+name: TM1637 4-digit 7-segment display module
+category: display
+use_cases: [display, seven_segment, clock, counter, numeric_readout]
+aliases: ["4-digit-display", "grove-4-digit"]
+
+electrical:
+  vcc_min: 3.3
+  vcc_max: 5.5
+  current_ma_typical: 30
+  current_ma_peak: 80
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - {role: CLK, kind: digital_in, voltage: 3.3}
+    - {role: DIO, kind: digital_in, voltage: 3.3}
+  passives:
+    - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: []
+  yaml_template: |
+    display:
+      - platform: tm1637
+        id: {{ id }}
+        clk_pin: {{ pins.CLK | tojson }}
+        dio_pin: {{ pins.DIO | tojson }}
+        intensity: {{ params.intensity | default(4) }}
+        update_interval: {{ params.update_interval | default('1s') }}
+        lambda: |-
+          {{ params.lambda | default('it.print("----");') }}
+
+params_schema:
+  intensity:
+    type: integer
+    minimum: 0
+    maximum: 7
+    default: 4
+  update_interval:
+    type: string
+    default: "1s"
+  lambda:
+    type: string
+    description: "Display lambda body, e.g. `it.printf(\"%4.0f\", id(co2_val).state);` or `it.strftime(\"%H.%M\", id(my_time).now());`"
+
+notes: |
+  The ubiquitous 4-digit LED module (clocks, counters, CO2 readouts).
+  Two-wire protocol that looks like I2C but isn't -- CLK/DIO take any
+  two GPIOs, no bus. Runs at 3.3V logic fine; brightness at 5V VCC is
+  noticeably higher. The colon variant maps to the decimal point of
+  digit 2 (`it.print("12.34")` style).
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical
+  value: TM1637

--- a/wirestudio/library/components/veml7700.yaml
+++ b/wirestudio/library/components/veml7700.yaml
@@ -1,0 +1,53 @@
+id: veml7700
+name: Vishay VEML7700 ambient light sensor (lux, I2C)
+category: sensor
+use_cases: [light, illuminance, lux, ambient_light, brightness]
+aliases: ["adafruit-4162", "veml6030"]
+
+electrical:
+  vcc_min: 2.5
+  vcc_max: 3.6
+  current_ma_typical: 0.045
+  current_ma_peak: 0.06
+  pins:
+  - {role: VCC, kind: power}
+  - {role: GND, kind: ground}
+  - role: SDA
+    kind: i2c_sda
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  - role: SCL
+    kind: i2c_scl
+    pull_up: {required: true, value: "4.7k", to: VCC}
+  passives:
+  - {kind: capacitor, value: "100nF", between: [VCC, GND], purpose: decoupling}
+
+esphome:
+  required_components: [i2c]
+  yaml_template: |
+    sensor:
+      - platform: veml7700
+        i2c_id: {{ bus.id }}
+        update_interval: {{ params.update_interval | default('60s') }}
+        ambient_light:
+          name: "{{ label }} Illuminance"
+
+capability:
+  role: sensor
+  provides:
+    - {event: on_value, kind: value}
+
+params_schema:
+  update_interval:
+    type: string
+    default: "60s"
+
+notes: |
+  Successor tier to the BH1750: 16-bit, 0.005-120k lux with automatic
+  gain/integration ("auto_mode" is ESPHome's default), so it holds
+  accuracy from moonlight to direct sun without manual ranging. Fixed
+  address 0x10 -- one per bus.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical
+  value: VEML7700

--- a/wirestudio/library/components/wiegand.yaml
+++ b/wirestudio/library/components/wiegand.yaml
@@ -1,0 +1,58 @@
+id: wiegand
+name: Wiegand keypad / card reader interface (D0/D1)
+category: input
+use_cases: [access_control, rfid, keypad, door_entry]
+aliases: ["wiegand26", "wiegand34", "access-keypad"]
+
+electrical:
+  vcc_min: 5.0
+  vcc_max: 12.0
+  current_ma_typical: 60
+  current_ma_peak: 120
+  pins:
+    - {role: VCC, kind: power}
+    - {role: GND, kind: ground}
+    - {role: D0, kind: digital_out, voltage: 5.0}
+    - {role: D1, kind: digital_out, voltage: 5.0}
+  passives: []
+
+esphome:
+  required_components: []
+  yaml_template: |
+    wiegand:
+      - id: {{ id }}
+        d0: {{ pins.D0 | tojson }}
+        d1: {{ pins.D1 | tojson }}
+    {%- if params.on_tag is defined %}
+        on_tag: {{ params.on_tag | tojson }}
+    {%- endif %}
+    {%- if params.on_key is defined %}
+        on_key: {{ params.on_key | tojson }}
+    {%- endif %}
+
+capability:
+  role: input
+  provides:
+    - {event: on_tag, kind: event}
+    - {event: on_key, kind: event}
+
+params_schema:
+  on_tag:
+    type: array
+    description: "Actions on card/fob scan; `x` is the tag id string."
+  on_key:
+    type: array
+    description: "Actions on keypad digit; `x` is the key (0-9, * = 10, # = 11)."
+
+notes: |
+  The wall-reader standard: two open-collector lines pulsing bits.
+  Most readers run 5-12V and idle D0/D1 at their supply voltage --
+  check the reader's spec: many pull to 5V, which ESP32 pins are not
+  rated for. Safest wiring is a small level shifter or two resistor
+  dividers on D0/D1; some readers are fine idling at 3.3V with the
+  MCU's internal pull-ups. Keep the run under ~10m.
+kicad:
+  symbol_lib: Connector_Generic
+  symbol: Conn_01x04
+  footprint: Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical
+  value: Wiegand reader


### PR DESCRIPTION
Sweep for library gaps, sourced two ways: the maintainer fleet's real device configs (PN532 NFC, IR receivers, access hardware in actual use) and the most-requested ESPHome hardware missing from the library. 18 new components (65 → 83), each with full electrical metadata, and six new bundled examples so every component clears the coverage gate and upstream `esphome config`.

**Environment:** SHT4x, SCD4x (true NDIR CO2), SGP4x VOC/NOx index, VEML7700 lux, BME680, MH-Z19 (UART), PMS5003/PMSX003 particulate (UART).
**Presence:** LD2410 mmWave — its own entry with the richer channel set; the stale `ld2410` alias moved off ld2420.
**Power:** INA219, PZEM-004T v3 (`pzemac` riding the modbus hub like sdm_meter), SCT-013 CT clamp with burden/bias passives modeled.
**Input:** PN532 (I2C), Wiegand keypad/reader (5V-level caveat surfaced), IR receiver (with a Tasmota IRrecv mapping).
**Output:** TM1637 7-segment, hobby servo (per-chip ledc/esp8266_pwm output + an HA position slider), PCA9685, and SN74HC595 as a first-class expander (`expander_pin_key`; the output-hub example wires a gpio_output to its pin 0 through an `expander_pin` connection).

Examples: air-quality-station, co2-display (MH-Z19 value on the TM1637 via the new `<id>_co2` sensor id), presence-media-node, energy-monitor, access-panel, output-hub.

Validation: all 68 examples pass `esphome config` under the pinned 2025.12.7 locally; `coverage_matrix --strict` clean (baseline unchanged); 1073 Python tests pass — the only local failures are environmental (chmod-based unwritability tests that can't fail under a root sandbox; they pass in CI).

Config-key accuracy was checked against the pinned ESPHome's own component sources rather than docs-from-memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLucY2SKuBDPFaDAJnnYs1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLucY2SKuBDPFaDAJnnYs1)_