### PR TITLE
Tasmota mappings for the library-sweep components; D-label fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tasmota coverage for the library-sweep components.** Eight new
+  entries in the verified FUNC table (values recomputed from
+  `tasmota_template.h` enum indexes, anchors cross-checked against the
+  existing table): TM1637 CLK/DIO, MH-Z19 and PMS5003 Tx/Rx, Wiegand
+  D0/D1, LD2410 Tx/Rx, SN74HC595 Shift595 SER/SRCLK/RCLK/OE, and
+  ADC_CT_POWER for the CT clamp; the servo maps its pin to PWM. UART
+  parts map through the bus block like CSE7766. MicroPython added to
+  the target backlog (after Meshtastic config push and full
+  CircuitPython codegen).
+
+### Fixed
+
+- **Tasmota templates put ESP8266 D-labeled pins in the right slots.**
+  `D1` used to parse as GPIO1; it is GPIO5. The D0-D8/RX/TX/A0
+  convention now resolves to real GPIO numbers, fixing every D1
+  Mini / NodeMCU design's template.
+- **A component with two connections to one UART bus (TX and RX roles)
+  mapped the bus pins twice**, leaving spurious "already assigned"
+  warnings on the template.
+
 - **Library sweep: 18 new components** (65 -> 83), drawn from the
   maintainer fleet's real device configs plus the most-requested
   ESPHome hardware, each validated end-to-end through upstream

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,7 +159,9 @@ a pure mapping of solved pins to Tasmota GPIO function ids -- via
 template layouts are sourced from `tasmota_template.h`; unit tests pin
 the Sonoff S31 convention for the smart-plug example. Library
 components opt in with a `tasmota:` block; I2C sensors ride the bus
-pins via Tasmota autodetection.
+pins via Tasmota autodetection, and UART-attached parts (MH-Z19,
+PMS5003, LD2410, CSE7766) map their bus pins to the matching Tx/Rx
+functions. ESP8266 D-labels resolve to real GPIO numbers.
 
 **Meshtastic flashing (0.23).** *Works.* The unified flash dialog
 fetches the official Meshtastic release factory image through the
@@ -186,7 +188,11 @@ listing) with save-to-CIRCUITPY and download buttons post-flash.
 region/channel/key setup over the existing serial session), then full
 CircuitPython code.py generation from the design (per-component driver
 init + Adafruit bundle libs, the LoRaWAN-fragment pattern — the
-interpreter flash + starter above is the shipped first step).
+interpreter flash + starter above is the shipped first step), then
+MicroPython (the CircuitPython pattern applied upstream: proxy the
+micropython.org release port per chip, flash via the unified dialog,
+generate a main.py scaffold — differs in stdlib/driver sourcing, since
+there is no single blessed bundle like Adafruit's).
 Deliberately deferred: generic Arduino/PlatformIO scaffolds (per-driver
 maintenance sinkhole), Zephyr, Zigbee/Thread on the C6.
 

--- a/tests/test_tasmota.py
+++ b/tests/test_tasmota.py
@@ -129,3 +129,45 @@ def test_firmware_endpoint_upstream_failure_502(monkeypatch):
     client = TestClient(create_app())
     r = client.get("/tasmota/firmware?chip=esp8266")
     assert r.status_code == 502
+
+
+def test_co2_display_resolves_d_labels_and_uart_funcs(lib):
+    template, warnings = build_template(_design("co2-display"), lib)
+    slots = _CHIP_SLOTS["esp8266"]
+    gpio = template["GPIO"]
+    # TM1637 on D1/D2 = GPIO5/GPIO4, not GPIO1/GPIO2.
+    assert gpio[slots.index(5)] == FUNC["TM1637_CLK"]
+    assert gpio[slots.index(4)] == FUNC["TM1637_DIO"]
+    # MH-Z19 over the software UART: bus tx D6 = GPIO12, rx D5 = GPIO14.
+    assert gpio[slots.index(12)] == FUNC["MHZ_TXD"]
+    assert gpio[slots.index(14)] == FUNC["MHZ_RXD"]
+    # Two bus connections (TX + RX) map the bus once -- no duplicate warnings.
+    assert warnings == []
+
+
+def test_access_panel_wiegand_and_servo(lib):
+    template, _ = build_template(_design("access-panel"), lib)
+    slots = _CHIP_SLOTS["esp32"]
+    gpio = template["GPIO"]
+    assert gpio[slots.index(32)] == FUNC["Wiegand_D0"]
+    assert gpio[slots.index(33)] == FUNC["Wiegand_D1"]
+    assert gpio[slots.index(13)] == FUNC["PWM"]
+    assert gpio[slots.index(26)] == FUNC["Relay"]
+
+
+def test_output_hub_shift_register(lib):
+    template, _ = build_template(_design("output-hub"), lib)
+    slots = _CHIP_SLOTS["esp32"]
+    gpio = template["GPIO"]
+    assert gpio[slots.index(25)] == FUNC["Shift595_SER"]
+    assert gpio[slots.index(26)] == FUNC["Shift595_SRCLK"]
+    assert gpio[slots.index(27)] == FUNC["Shift595_RCLK"]
+
+
+def test_presence_media_node_ld2410_and_ir(lib):
+    template, _ = build_template(_design("presence-media-node"), lib)
+    slots = _CHIP_SLOTS["esp32"]
+    gpio = template["GPIO"]
+    assert gpio[slots.index(17)] == FUNC["LD2410_TX"]
+    assert gpio[slots.index(16)] == FUNC["LD2410_RX"]
+    assert gpio[slots.index(25)] == FUNC["IRrecv"]

--- a/wirestudio/library/components/ct_clamp.yaml
+++ b/wirestudio/library/components/ct_clamp.yaml
@@ -39,6 +39,10 @@ capability:
   provides:
     - {event: on_value, kind: value}
 
+tasmota:
+  pins:
+    OUT: ADC_CT_POWER
+
 params_schema:
   sample_duration:
     type: string

--- a/wirestudio/library/components/ld2410.yaml
+++ b/wirestudio/library/components/ld2410.yaml
@@ -50,6 +50,11 @@ capability:
     - {predicate: is_on,  esphome: binary_sensor.is_on}
     - {predicate: is_off, esphome: binary_sensor.is_off}
 
+tasmota:
+  bus:
+    tx: LD2410_TX
+    rx: LD2410_RX
+
 params_schema:
   throttle:
     type: string

--- a/wirestudio/library/components/mhz19.yaml
+++ b/wirestudio/library/components/mhz19.yaml
@@ -36,6 +36,11 @@ capability:
   provides:
     - {event: on_value, kind: value}
 
+tasmota:
+  bus:
+    tx: MHZ_TXD
+    rx: MHZ_RXD
+
 params_schema:
   update_interval:
     type: string

--- a/wirestudio/library/components/pmsx003.yaml
+++ b/wirestudio/library/components/pmsx003.yaml
@@ -37,6 +37,11 @@ capability:
   provides:
     - {event: on_value, kind: value}
 
+tasmota:
+  bus:
+    tx: PMS5003_TX
+    rx: PMS5003_RX
+
 params_schema:
   type:
     type: string

--- a/wirestudio/library/components/servo.yaml
+++ b/wirestudio/library/components/servo.yaml
@@ -48,6 +48,10 @@ capability:
     - {action: write,  esphome: servo.write}
     - {action: detach, esphome: servo.detach}
 
+tasmota:
+  pins:
+    PWM: PWM
+
 params_schema:
   auto_detach_time:
     type: string

--- a/wirestudio/library/components/sn74hc595.yaml
+++ b/wirestudio/library/components/sn74hc595.yaml
@@ -33,6 +33,13 @@ esphome:
     {%- endif %}
         sr_count: {{ params.sr_count | default(1) }}
 
+tasmota:
+  pins:
+    DATA: Shift595_SER
+    CLOCK: Shift595_SRCLK
+    LATCH: Shift595_RCLK
+    OE: Shift595_OE
+
 params_schema:
   sr_count:
     type: integer

--- a/wirestudio/library/components/tm1637.yaml
+++ b/wirestudio/library/components/tm1637.yaml
@@ -30,6 +30,11 @@ esphome:
         lambda: |-
           {{ params.lambda | default('it.print("----");') }}
 
+tasmota:
+  pins:
+    CLK: TM1637_CLK
+    DIO: TM1637_DIO
+
 params_schema:
   intensity:
     type: integer

--- a/wirestudio/library/components/wiegand.yaml
+++ b/wirestudio/library/components/wiegand.yaml
@@ -36,6 +36,11 @@ capability:
     - {event: on_tag, kind: event}
     - {event: on_key, kind: event}
 
+tasmota:
+  pins:
+    D0: Wiegand_D0
+    D1: Wiegand_D1
+
 params_schema:
   on_tag:
     type: array

--- a/wirestudio/targets/tasmota.py
+++ b/wirestudio/targets/tasmota.py
@@ -59,10 +59,25 @@ FUNC = {
     "CSE7766_RX": 3104,
     "Rotary_A": 3264,
     "Rotary_B": 3296,
+    "MHZ_TXD": 1408,
+    "MHZ_RXD": 1440,
+    "PMS5003_TX": 1664,
+    "PMS5003_RX": 1696,
     "ADC_Input": 4704,
+    "ADC_CT_POWER": 4896,
+    "Wiegand_D0": 6912,
+    "Wiegand_D1": 6944,
+    "TM1637_CLK": 7104,
+    "TM1637_DIO": 7136,
     "MAX7219_CLK": 7392,
     "MAX7219_DIN": 7424,
     "MAX7219_CS": 7456,
+    "Shift595_SRCLK": 8288,
+    "Shift595_RCLK": 8320,
+    "Shift595_OE": 8352,
+    "Shift595_SER": 8384,
+    "LD2410_TX": 9888,
+    "LD2410_RX": 9920,
 }
 
 # Families where repeated use numbers the unit (Relay1, Relay2, ...).
@@ -129,7 +144,18 @@ def firmware_status() -> dict:
     return {"available": available, "chips": sorted(_FIRMWARE), "reason": reason}
 
 
+# ESP8266 D-label convention (D1 Mini / NodeMCU): the digit is not the
+# GPIO number. A0 is Tasmota's ADC0 slot (17).
+_DPIN = {
+    "D0": 16, "D1": 5, "D2": 4, "D3": 0, "D4": 2,
+    "D5": 14, "D6": 12, "D7": 13, "D8": 15,
+    "RX": 3, "TX": 1, "A0": 17,
+}
+
+
 def _pin_number(pin: str) -> Optional[int]:
+    if pin in _DPIN:
+        return _DPIN[pin]
     digits = "".join(ch for ch in pin if ch.isdigit())
     return int(digits) if digits else None
 
@@ -147,6 +173,7 @@ def build_template(design: Design, library: Library) -> tuple[dict, list[str]]:
     assignments: dict[int, int] = {}
     warnings: list[str] = []
     unit_used: dict[str, int] = {}
+    bus_mapped: set[tuple[str, Optional[str]]] = set()
 
     def assign(pin: str, func_name: str, owner: str) -> None:
         num = _pin_number(pin)
@@ -202,9 +229,14 @@ def build_template(design: Design, library: Library) -> tuple[dict, list[str]]:
                         f"templatable (target is {t.kind})"
                     )
             elif spec.bus and t.kind == "bus":
+                # A component with several connections to the same bus (TX
+                # and RX roles) maps the bus pins once, not per connection.
+                if (comp.id, t.bus_id) in bus_mapped:
+                    continue
                 bus = buses.get(t.bus_id or "")
                 if bus is None:
                     continue
+                bus_mapped.add((comp.id, t.bus_id))
                 for bus_role, bus_func in spec.bus.items():
                     pin = getattr(bus, bus_role, None)
                     if pin:


### PR DESCRIPTION
Extends the shipped Tasmota target (0.22) to cover the library-sweep components, and fixes two real bugs found while wiring the mappings.

**New FUNC entries** — recomputed from `tasmota_template.h`'s `UserSelectablePins` enum indexes (`value = index << 5`), with the existing verified entries (Button/Switch/Relay/SDA/SCL/IRrecv) re-derived as anchors to validate the extraction: TM1637 CLK/DIO, MH-Z19 Tx/Rx, PMS5003 Tx/Rx, Wiegand D0/D1, LD2410 Tx/Rx, Shift595 SER/SRCLK/RCLK/OE, ADC_CT_POWER. Eight components gain `tasmota:` blocks (servo maps its pin to the existing PWM function); UART parts map through the bus block like CSE7766. The sweep's I2C sensors already ride autodetection.

**Fixes:**
- ESP8266 D-labels parsed their digit as the GPIO number — `D1` landed in the GPIO1 slot instead of GPIO5, so every D1 Mini / NodeMCU design's template had functions on the wrong pins. The D0–D8/RX/TX/A0 convention now resolves to real GPIOs.
- A component with TX and RX connections to the same UART bus mapped the bus pins once per connection, leaving spurious "already assigned; skipped" warnings.

**Roadmap:** MicroPython added to the target backlog (after Meshtastic config push and full CircuitPython codegen) — the CircuitPython pattern applied upstream, with the caveat that driver sourcing has no single blessed bundle.

Tests: four new template assertions over the sweep examples (D-label resolution, UART bus funcs, no duplicate warnings, Wiegand/servo/Shift595 slots); 1107 Python tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLucY2SKuBDPFaDAJnnYs1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLucY2SKuBDPFaDAJnnYs1)_