### PR TITLE
Bump ESPHome pin to 2026.6.5; rename reserved spi0 bus id

### DIFF
--- a/.github/workflows/esphome-compile.yml
+++ b/.github/workflows/esphome-compile.yml
@@ -60,7 +60,7 @@ jobs:
         # bump both in the same PR.
         run: |
           pip install -e .
-          pip install 'esphome==2025.12.7'
+          pip install 'esphome==2026.6.5'
 
       - name: Cache PlatformIO + ESPHome build artifacts
         # The toolchain pull dominates wall-clock on a cold run.
@@ -71,7 +71,7 @@ jobs:
           path: |
             ~/.platformio
             ~/.cache/pip
-          key: pio-${{ runner.os }}-esphome-2025.12.7
+          key: pio-${{ runner.os }}-esphome-2026.6.5
           restore-keys: |
             pio-${{ runner.os }}-esphome-
 

--- a/.github/workflows/esphome-config.yml
+++ b/.github/workflows/esphome-config.yml
@@ -56,7 +56,7 @@ jobs:
         # match this pin.
         run: |
           pip install -e .
-          pip install 'esphome==2025.12.7'
+          pip install 'esphome==2026.6.5'
 
       - name: Print resolved ESPHome version
         run: esphome version

--- a/.github/workflows/esphome-matrix.yml
+++ b/.github/workflows/esphome-matrix.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         # The pinned baseline + the latest stables. Bump as releases land;
         # the pin itself lives in esphome-config.yml / esphome-compile.yml.
-        esphome_version: ["2025.12.7", "2026.4.5", "2026.5.0"]
+        esphome_version: ["2026.6.5"]
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ESPHome pin bumped 2025.12.7 -> 2026.6.5** (config gate, nightly
+  compile smoke, matrix, README/CONTRIBUTING). The one schema break:
+  2026.x reserves the id `spi0` internally, so the nine examples whose
+  SPI bus was named `spi0` rename it to `spi_bus` (goldens
+  regenerated). All 68 examples validate under the new pin.
+
 ### Added
 
 - **Tasmota coverage for the library-sweep components.** Eight new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **ESPHome pin bumped 2025.12.7 -> 2026.6.5** (config gate, nightly
-  compile smoke, matrix, README/CONTRIBUTING). The one schema break:
+  compile smoke, matrix, README/CONTRIBUTING). Two schema breaks:
   2026.x reserves the id `spi0` internally, so the nine examples whose
-  SPI bus was named `spi0` rename it to `spi_bus` (goldens
-  regenerated). All 68 examples validate under the new pin.
+  SPI bus was named `spi0` rename it to `spi_bus`; and the i2s_audio
+  media_player was removed upstream, so the max98357a template now
+  emits an i2s_audio speaker wrapped by the speaker media_player
+  (goldens regenerated). All 68 examples validate under the new pin.
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ at all:
 
 Every PR runs `.github/workflows/esphome-config.yml`, which:
 
-1. Installs the pinned ESPHome (currently `==2025.12.7`).
+1. Installs the pinned ESPHome (currently `==2026.6.5`).
 2. For every `examples/*.json`, renders YAML through
    `wirestudio.generate.yaml_gen` and runs `esphome config <file>` against
    it.
@@ -41,7 +41,7 @@ gate.** It's the gate the project can be judged by from the outside.
 
 ```sh
 pip install -e .[dev]
-pip install 'esphome==2025.12.7'
+pip install 'esphome==2026.6.5'
 python scripts/check_examples.py            # all examples
 python scripts/check_examples.py garage-motion oled    # just these two
 python scripts/check_examples.py --keep     # leave generated YAML on disk
@@ -108,7 +108,7 @@ single push with `git push --no-verify` when iterating on a WIP
 feature branch.
 
 The pre-commit config lives at `.pre-commit-config.yaml`. Same
-`esphome==2025.12.7` install applies; same Debian-host venv
+`esphome==2026.6.5` install applies; same Debian-host venv
 caveat above applies if the install trips on `paho-mqtt`.
 
 ### Bumping the pinned ESPHome

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the bar a change has to
 clear before merging, [`CHANGELOG.md`](CHANGELOG.md) for per-release
 deltas, and [`START.md`](START.md) for the longer-form design notes.
 
-Tested against ESPHome **`==2025.12.7`** (pinned in
+Tested against ESPHome **`==2026.6.5`** (pinned in
 `.github/workflows/esphome-config.yml` + bumped deliberately). When
 that pin moves, this line moves with it.
 
@@ -167,7 +167,7 @@ The [User guide](docs/user_guide.md) walks the panes and header actions.
 python -m pytest                          # ~1030 cases
 python -m ruff check .                    # lint
 cd web && npx vitest run                  # vitest + jsdom
-pip install 'esphome==2025.12.7'
+pip install 'esphome==2026.6.5'
 python scripts/check_examples.py          # the YAML gate -- every example through `esphome config`
 ```
 

--- a/tests/golden/atoms3-onboard.txt
+++ b/tests/golden/atoms3-onboard.txt
@@ -6,8 +6,8 @@
 |  onboard_display  [Sitronix ST7789V color TFT (SPI)]  -- Onboard display  |
 |    VCC   -> rail 3V3                                                      |
 |    GND   -> rail GND                                                      |
-|    SCK   -> spi0 (GPIO17)                                                 |
-|    MOSI  -> spi0 (GPIO21)                                                 |
+|    SCK   -> spi_bus (GPIO17)                                              |
+|    MOSI  -> spi_bus (GPIO21)                                              |
 |    CS    -> GPIO15                                                        |
 |    DC    -> GPIO33                                                        |
 |    RESET -> GPIO34                                                        |

--- a/tests/golden/atoms3-onboard.yaml
+++ b/tests/golden/atoms3-onboard.yaml
@@ -17,7 +17,7 @@ wifi:
   password: !secret wifi_password
 captive_portal: {}
 spi:
-- id: spi0
+- id: spi_bus
   clk_pin: GPIO17
   miso_pin: GPIO13
   mosi_pin: GPIO21
@@ -27,7 +27,7 @@ i2c:
   scl: GPIO2
 display:
 - platform: st7789v
-  spi_id: spi0
+  spi_id: spi_bus
   cs_pin: GPIO15
   dc_pin: GPIO33
   reset_pin: GPIO34

--- a/tests/golden/esp32-audio.txt
+++ b/tests/golden/esp32-audio.txt
@@ -13,8 +13,8 @@
 |  screen  [Sitronix ST7789V color TFT (SPI)]  -- Esp32 Audio Display                                         |
 |    VCC   -> rail 3V3                                                                                        |
 |    GND   -> rail GND                                                                                        |
-|    SCK   -> spi0 (GPIO18)                                                                                   |
-|    MOSI  -> spi0 (GPIO23)                                                                                   |
+|    SCK   -> spi_bus (GPIO18)                                                                                |
+|    MOSI  -> spi_bus (GPIO23)                                                                                |
 |    CS    -> GPIO5                                                                                           |
 |    DC    -> GPIO17                                                                                          |
 |    RESET -> GPIO22                                                                                          |

--- a/tests/golden/esp32-audio.yaml
+++ b/tests/golden/esp32-audio.yaml
@@ -21,13 +21,19 @@ spi:
 i2s_audio:
   i2s_lrclk_pin: GPIO33
   i2s_bclk_pin: GPIO25
-media_player:
+speaker:
 - platform: i2s_audio
-  name: Esp32 Audio Media Player
-  id: amp
+  id: amp_spk
   dac_type: external
   i2s_dout_pin: GPIO32
-  mode: stereo
+  channel: stereo
+media_player:
+- platform: speaker
+  name: Esp32 Audio Media Player
+  id: amp
+  announcement_pipeline:
+    speaker: amp_spk
+    num_channels: 2
 display:
 - platform: st7789v
   spi_id: spi_bus

--- a/tests/golden/esp32-audio.yaml
+++ b/tests/golden/esp32-audio.yaml
@@ -15,7 +15,7 @@ wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 spi:
-- id: spi0
+- id: spi_bus
   clk_pin: GPIO18
   mosi_pin: GPIO23
 i2s_audio:
@@ -30,7 +30,7 @@ media_player:
   mode: stereo
 display:
 - platform: st7789v
-  spi_id: spi0
+  spi_id: spi_bus
   cs_pin: GPIO5
   dc_pin: GPIO17
   reset_pin: GPIO22

--- a/tests/golden/grill-probe.txt
+++ b/tests/golden/grill-probe.txt
@@ -6,8 +6,8 @@
 |  probe  [MAX31855 thermocouple amplifier (SPI, K-type)]  -- Grill probe  |
 |    VCC   -> rail 3V3                                                     |
 |    GND   -> rail GND                                                     |
-|    CLK   -> spi0 (GPIO18)                                                |
-|    MISO  -> spi0 (GPIO19)                                                |
+|    CLK   -> spi_bus (GPIO18)                                             |
+|    MISO  -> spi_bus (GPIO19)                                             |
 |    CS    -> GPIO5                                                        |
 |                                                                          |
 |  lid  [MPU6050 6-axis IMU (accel + gyro, I2C)]  -- Grill lid             |

--- a/tests/golden/grill-probe.yaml
+++ b/tests/golden/grill-probe.yaml
@@ -16,7 +16,7 @@ wifi:
   password: !secret wifi_password
 captive_portal: {}
 spi:
-- id: spi0
+- id: spi_bus
   clk_pin: GPIO18
   miso_pin: GPIO19
   mosi_pin: GPIO23
@@ -27,7 +27,7 @@ i2c:
   frequency: 100kHz
 sensor:
 - platform: max31855
-  spi_id: spi0
+  spi_id: spi_bus
   cs_pin: GPIO5
   name: Grill probe Thermocouple
   update_interval: 5s

--- a/tests/golden/led-display.txt
+++ b/tests/golden/led-display.txt
@@ -6,8 +6,8 @@
 |  matrix  [MAX7219 7-segment / 8x8 LED matrix driver (SPI)]  -- LED matrix  |
 |    VCC   -> rail 5V                                                        |
 |    GND   -> rail GND                                                       |
-|    CLK   -> spi0 (GPIO18)                                                  |
-|    MOSI  -> spi0 (GPIO23)                                                  |
+|    CLK   -> spi_bus (GPIO18)                                               |
+|    MOSI  -> spi_bus (GPIO23)                                               |
 |    CS    -> GPIO5                                                          |
 |                                                                            |
 |  panel  [TM1638 8-digit 7-segment + 8 LEDs + 8 buttons]  -- LED&KEY        |

--- a/tests/golden/led-display.yaml
+++ b/tests/golden/led-display.yaml
@@ -16,7 +16,7 @@ wifi:
   password: !secret wifi_password
 captive_portal: {}
 spi:
-- id: spi0
+- id: spi_bus
   clk_pin: GPIO18
   miso_pin: GPIO19
   mosi_pin: GPIO23

--- a/tests/golden/rc522.txt
+++ b/tests/golden/rc522.txt
@@ -6,9 +6,9 @@
 |  reader  [NXP MFRC522 RFID reader (SPI)]  -- RFID Reader                                                      |
 |    VCC   -> rail 3V3                                                                                          |
 |    GND   -> rail GND                                                                                          |
-|    SCK   -> spi0 (D5)                                                                                         |
-|    MISO  -> spi0 (D6)                                                                                         |
-|    MOSI  -> spi0 (D7)                                                                                         |
+|    SCK   -> spi_bus (D5)                                                                                      |
+|    MISO  -> spi_bus (D6)                                                                                      |
+|    MOSI  -> spi_bus (D7)                                                                                      |
 |    CS    -> D8                                                                                                |
 |    RESET -> D4                                                                                                |
 |                                                                                                               |

--- a/tests/golden/rc522.yaml
+++ b/tests/golden/rc522.yaml
@@ -32,14 +32,14 @@ wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 spi:
-- id: spi0
+- id: spi_bus
   clk_pin: D5
   miso_pin: D6
   mosi_pin: D7
 rc522_spi:
   cs_pin: D8
   reset_pin: D4
-  spi_id: spi0
+  spi_id: spi_bus
   update_interval: 2s
   on_tag:
     then:

--- a/tests/golden/subghz-rfid.txt
+++ b/tests/golden/subghz-rfid.txt
@@ -6,9 +6,9 @@
 |  radio  [Texas Instruments CC1101 sub-GHz transceiver (SPI)]  -- Sub-GHz radio  |
 |    VCC   -> rail 3V3                                                            |
 |    GND   -> rail GND                                                            |
-|    SCK   -> spi0 (GPIO18)                                                       |
-|    MISO  -> spi0 (GPIO19)                                                       |
-|    MOSI  -> spi0 (GPIO23)                                                       |
+|    SCK   -> spi_bus (GPIO18)                                                    |
+|    MISO  -> spi_bus (GPIO19)                                                    |
+|    MOSI  -> spi_bus (GPIO23)                                                    |
 |    CS    -> GPIO5                                                               |
 |    GDO0  -> GPIO4                                                               |
 |    GDO2  -> GPIO2                                                               |

--- a/tests/golden/subghz-rfid.yaml
+++ b/tests/golden/subghz-rfid.yaml
@@ -16,7 +16,7 @@ wifi:
   password: !secret wifi_password
 captive_portal: {}
 spi:
-- id: spi0
+- id: spi_bus
   clk_pin: GPIO18
   miso_pin: GPIO19
   mosi_pin: GPIO23
@@ -28,7 +28,7 @@ uart:
 cc1101:
   cs_pin: GPIO5
   gdo0_pin: GPIO4
-  spi_id: spi0
+  spi_id: spi_bus
   frequency: 433920000
   modulation_type: ASK/OOK
 rdm6300:

--- a/tests/golden/t-beam.txt
+++ b/tests/golden/t-beam.txt
@@ -6,14 +6,14 @@
 |  onboard_lora  [Semtech SX1276/SX1278 LoRa radio (SPI)]  -- Onboard LoRa radio                             |
 |    VCC   -> rail 3V3                                                                                       |
 |    GND   -> rail GND                                                                                       |
-|    SCK   -> spi0 (GPIO5)                                                                                   |
-|    MISO  -> spi0 (GPIO19)                                                                                  |
-|    MOSI  -> spi0 (GPIO27)                                                                                  |
+|    SCK   -> spi_bus (GPIO5)                                                                                |
+|    MISO  -> spi_bus (GPIO19)                                                                               |
+|    MOSI  -> spi_bus (GPIO27)                                                                               |
 |    CS    -> GPIO18                                                                                         |
 |    RST   -> GPIO23                                                                                         |
 |    DIO0  -> GPIO26                                                                                         |
 |                                                                                                            |
-|  onboard_gps  [Generic UART GPS module (NEO-6M / NEO-8M)]  -- Onboard GPS                                  |
+|  onboard_gps  [Generic UART GPS / GNSS module (NEO-6M / NEO-8M / UC6580)]  -- Onboard GPS                  |
 |    VCC   -> rail 3V3                                                                                       |
 |    GND   -> rail GND                                                                                       |
 |    TX    -> gps_uart (GPIO34)                                                                              |
@@ -25,7 +25,7 @@
 |  BOM:                                                                                                      |
 |    - LilyGO TTGO T-Beam (v1.x)                                                                             |
 |    - Semtech SX1276/SX1278 LoRa radio (SPI)  (onboard_lora)                                                |
-|    - Generic UART GPS module (NEO-6M / NEO-8M)  (onboard_gps)                                              |
+|    - Generic UART GPS / GNSS module (NEO-6M / NEO-8M / UC6580)  (onboard_gps)                              |
 |    - Generic GPIO binary sensor  (onboard_button)                                                          |
 |                                                                                                            |
 |  Power: ~42mA typical, ~210mA peak (budget 500mA)  OK                                                      |

--- a/tests/golden/t-beam.yaml
+++ b/tests/golden/t-beam.yaml
@@ -16,7 +16,7 @@ wifi:
   password: !secret wifi_password
 captive_portal: {}
 spi:
-- id: spi0
+- id: spi_bus
   clk_pin: GPIO5
   miso_pin: GPIO19
   mosi_pin: GPIO27
@@ -29,7 +29,7 @@ sx127x:
   cs_pin: GPIO18
   rst_pin: GPIO23
   dio0_pin: GPIO26
-  spi_id: spi0
+  spi_id: spi_bus
   frequency: 433000000
   modulation: LORA
   preamble_size: 8

--- a/tests/golden/tft-touch.txt
+++ b/tests/golden/tft-touch.txt
@@ -6,9 +6,9 @@
 |  tft  [ILI9341 / ILI9486 / ILI9488 SPI TFT display]  -- TFT         |
 |    VCC   -> rail 3V3                                                |
 |    GND   -> rail GND                                                |
-|    SCK   -> spi0 (GPIO18)                                           |
-|    MOSI  -> spi0 (GPIO23)                                           |
-|    MISO  -> spi0 (GPIO19)                                           |
+|    SCK   -> spi_bus (GPIO18)                                        |
+|    MOSI  -> spi_bus (GPIO23)                                        |
+|    MISO  -> spi_bus (GPIO19)                                        |
 |    CS    -> GPIO5                                                   |
 |    DC    -> GPIO16                                                  |
 |    RESET -> GPIO17                                                  |
@@ -17,9 +17,9 @@
 |  touch  [XPT2046 resistive touchscreen controller (SPI)]  -- Touch  |
 |    VCC   -> rail 3V3                                                |
 |    GND   -> rail GND                                                |
-|    SCK   -> spi0 (GPIO18)                                           |
-|    MOSI  -> spi0 (GPIO23)                                           |
-|    MISO  -> spi0 (GPIO19)                                           |
+|    SCK   -> spi_bus (GPIO18)                                        |
+|    MOSI  -> spi_bus (GPIO23)                                        |
+|    MISO  -> spi_bus (GPIO19)                                        |
 |    CS    -> GPIO21                                                  |
 |    IRQ   -> GPIO22                                                  |
 |                                                                     |

--- a/tests/golden/tft-touch.yaml
+++ b/tests/golden/tft-touch.yaml
@@ -16,14 +16,14 @@ wifi:
   password: !secret wifi_password
 captive_portal: {}
 spi:
-- id: spi0
+- id: spi_bus
   clk_pin: GPIO18
   miso_pin: GPIO19
   mosi_pin: GPIO23
 display:
 - platform: ili9xxx
   model: ILI9341
-  spi_id: spi0
+  spi_id: spi_bus
   cs_pin: GPIO5
   dc_pin: GPIO16
   reset_pin: GPIO17
@@ -35,7 +35,7 @@ touchscreen:
   id: touch
   cs_pin: GPIO21
   interrupt_pin: GPIO22
-  spi_id: spi0
+  spi_id: spi_bus
   calibration:
     x_min: 280
     x_max: 3860

--- a/tests/golden/ttgo-lora32.txt
+++ b/tests/golden/ttgo-lora32.txt
@@ -6,9 +6,9 @@
 |  lora  [Semtech SX1276/SX1278 LoRa radio (SPI)]  -- LoRa Radio                                                 |
 |    VCC   -> rail 3V3                                                                                           |
 |    GND   -> rail GND                                                                                           |
-|    SCK   -> spi0 (GPIO5)                                                                                       |
-|    MISO  -> spi0 (GPIO19)                                                                                      |
-|    MOSI  -> spi0 (GPIO27)                                                                                      |
+|    SCK   -> spi_bus (GPIO5)                                                                                    |
+|    MISO  -> spi_bus (GPIO19)                                                                                   |
+|    MOSI  -> spi_bus (GPIO27)                                                                                   |
 |    CS    -> GPIO18                                                                                             |
 |    RST   -> GPIO23                                                                                             |
 |    DIO0  -> GPIO26                                                                                             |

--- a/tests/golden/ttgo-lora32.yaml
+++ b/tests/golden/ttgo-lora32.yaml
@@ -15,7 +15,7 @@ wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 spi:
-- id: spi0
+- id: spi_bus
   clk_pin: GPIO5
   miso_pin: GPIO19
   mosi_pin: GPIO27
@@ -28,7 +28,7 @@ sx127x:
   cs_pin: GPIO18
   rst_pin: GPIO23
   dio0_pin: GPIO26
-  spi_id: spi0
+  spi_id: spi_bus
   frequency: 915000000
   modulation: LORA
   bandwidth: 125_0kHz

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -241,10 +241,10 @@ def test_ttgo_lora32_warning_is_about_gpio5(lib):
     boot = _by_code(warnings, "boot_strap_output")
     assert len(boot) == 1
     assert boot[0].pin == "GPIO5"
-    # The warning fires at the bus level (spi0.CLK), not the per-component
+    # The warning fires at the bus level (spi_bus.CLK), not the per-component
     # SCK connection -- the bus is what assigns GPIO5 to the line.
     assert boot[0].pin_role == "CLK"
-    assert boot[0].component_id == "spi0"
+    assert boot[0].component_id == "spi_bus"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_gen.py
+++ b/tests/test_yaml_gen.py
@@ -189,16 +189,15 @@ def test_esp32_audio_i2s_bus_emits_singleton(esp32_audio_design, library):
     assert isinstance(parsed["i2s_audio"], dict)
     assert parsed["i2s_audio"]["i2s_lrclk_pin"] == "GPIO33"
     assert parsed["i2s_audio"]["i2s_bclk_pin"] == "GPIO25"
-    assert parsed["media_player"][0]["dac_type"] == "external"
-    assert parsed["media_player"][0]["i2s_dout_pin"] == "GPIO32"
+    # 2026.x removed the i2s_audio media_player; the DAC is now an
+    # i2s_audio speaker fronted by the speaker media_player.
+    assert parsed["speaker"][0]["dac_type"] == "external"
+    assert parsed["speaker"][0]["i2s_dout_pin"] == "GPIO32"
+    assert parsed["media_player"][0]["platform"] == "speaker"
+    assert parsed["media_player"][0]["announcement_pipeline"]["speaker"] == "amp_spk"
 
 
 def test_esp32_audio_uses_arduino_framework(esp32_audio_design, library):
-    # max98357a's media_player platform is arduino-only in upstream ESPHome
-    # (`cv.only_with_arduino`); the example used to set framework=esp-idf,
-    # which `esphome config` rejected. Revisit when esp-idf gains the
-    # platform or we route audio through speaker: + media_player: speaker
-    # chained.
     parsed = yaml.unsafe_load(render_yaml(esp32_audio_design, library))
     assert parsed["esp32"]["framework"]["type"] == "arduino"
 

--- a/tests/test_yaml_gen.py
+++ b/tests/test_yaml_gen.py
@@ -175,7 +175,7 @@ def test_rc522_spi_block_emitted(rc522_design, library):
     assert parsed["spi"][0]["clk_pin"] == "D5"
     assert parsed["spi"][0]["miso_pin"] == "D6"
     assert parsed["rc522_spi"]["cs_pin"] == "D8"
-    assert parsed["rc522_spi"]["spi_id"] == "spi0"
+    assert parsed["rc522_spi"]["spi_id"] == "spi_bus"
 
 
 def test_esp32_audio_matches_golden(esp32_audio_design, library, golden_dir):
@@ -269,7 +269,7 @@ def test_ttgo_lora32_radio_block(ttgo_lora32_design, library):
     assert radio["cs_pin"] == "GPIO18"
     assert radio["rst_pin"] == "GPIO23"
     assert radio["dio0_pin"] == "GPIO26"
-    assert radio["spi_id"] == "spi0"
+    assert radio["spi_id"] == "spi_bus"
     assert radio["frequency"] == 915000000
 
 

--- a/wirestudio/examples/atoms3-onboard.json
+++ b/wirestudio/examples/atoms3-onboard.json
@@ -65,7 +65,7 @@
   ],
   "buses": [
     {
-      "id": "spi0",
+      "id": "spi_bus",
       "type": "spi",
       "clk": "GPIO17",
       "mosi": "GPIO21",
@@ -100,7 +100,7 @@
       "pin_role": "SCK",
       "target": {
         "kind": "bus",
-        "bus_id": "spi0"
+        "bus_id": "spi_bus"
       }
     },
     {
@@ -108,7 +108,7 @@
       "pin_role": "MOSI",
       "target": {
         "kind": "bus",
-        "bus_id": "spi0"
+        "bus_id": "spi_bus"
       }
     },
     {

--- a/wirestudio/examples/esp32-audio.json
+++ b/wirestudio/examples/esp32-audio.json
@@ -48,7 +48,7 @@
   ],
 
   "buses": [
-    { "id": "spi0", "type": "spi", "clk": "GPIO18", "mosi": "GPIO23" },
+    { "id": "spi_bus", "type": "spi", "clk": "GPIO18", "mosi": "GPIO23" },
     { "id": "i2s0", "type": "i2s", "lrclk": "GPIO33", "bclk": "GPIO25" }
   ],
 
@@ -61,8 +61,8 @@
 
     { "component_id": "screen", "pin_role": "VCC",       "target": { "kind": "rail", "rail": "3V3" } },
     { "component_id": "screen", "pin_role": "GND",       "target": { "kind": "rail", "rail": "GND" } },
-    { "component_id": "screen", "pin_role": "SCK",       "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "screen", "pin_role": "MOSI",      "target": { "kind": "bus",  "bus_id": "spi0" } },
+    { "component_id": "screen", "pin_role": "SCK",       "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "screen", "pin_role": "MOSI",      "target": { "kind": "bus",  "bus_id": "spi_bus" } },
     { "component_id": "screen", "pin_role": "CS",        "target": { "kind": "gpio", "pin": "GPIO5"  } },
     { "component_id": "screen", "pin_role": "DC",        "target": { "kind": "gpio", "pin": "GPIO17" } },
     { "component_id": "screen", "pin_role": "RESET",     "target": { "kind": "gpio", "pin": "GPIO22" } },

--- a/wirestudio/examples/grill-probe.json
+++ b/wirestudio/examples/grill-probe.json
@@ -41,15 +41,15 @@
   ],
 
   "buses": [
-    { "id": "spi0", "type": "spi", "clk": "GPIO18", "miso": "GPIO19", "mosi": "GPIO23" },
+    { "id": "spi_bus", "type": "spi", "clk": "GPIO18", "miso": "GPIO19", "mosi": "GPIO23" },
     { "id": "i2c0", "type": "i2c", "frequency_hz": 100000, "sda": "GPIO21", "scl": "GPIO22" }
   ],
 
   "connections": [
     { "component_id": "probe", "pin_role": "VCC",  "target": { "kind": "rail", "rail": "3V3" } },
     { "component_id": "probe", "pin_role": "GND",  "target": { "kind": "rail", "rail": "GND" } },
-    { "component_id": "probe", "pin_role": "CLK",  "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "probe", "pin_role": "MISO", "target": { "kind": "bus",  "bus_id": "spi0" } },
+    { "component_id": "probe", "pin_role": "CLK",  "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "probe", "pin_role": "MISO", "target": { "kind": "bus",  "bus_id": "spi_bus" } },
     { "component_id": "probe", "pin_role": "CS",   "target": { "kind": "gpio", "pin": "GPIO5" } },
 
     { "component_id": "lid",   "pin_role": "VCC",  "target": { "kind": "rail", "rail": "3V3" } },

--- a/wirestudio/examples/led-display.json
+++ b/wirestudio/examples/led-display.json
@@ -22,14 +22,14 @@
   ],
 
   "buses": [
-    { "id": "spi0", "type": "spi", "clk": "GPIO18", "mosi": "GPIO23", "miso": "GPIO19" }
+    { "id": "spi_bus", "type": "spi", "clk": "GPIO18", "mosi": "GPIO23", "miso": "GPIO19" }
   ],
 
   "connections": [
     { "component_id": "matrix", "pin_role": "VCC",  "target": { "kind": "rail", "rail": "5V" } },
     { "component_id": "matrix", "pin_role": "GND",  "target": { "kind": "rail", "rail": "GND" } },
-    { "component_id": "matrix", "pin_role": "CLK",  "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "matrix", "pin_role": "MOSI", "target": { "kind": "bus",  "bus_id": "spi0" } },
+    { "component_id": "matrix", "pin_role": "CLK",  "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "matrix", "pin_role": "MOSI", "target": { "kind": "bus",  "bus_id": "spi_bus" } },
     { "component_id": "matrix", "pin_role": "CS",   "target": { "kind": "gpio", "pin": "GPIO5" } },
 
     { "component_id": "panel", "pin_role": "VCC", "target": { "kind": "rail", "rail": "5V" } },

--- a/wirestudio/examples/rc522.json
+++ b/wirestudio/examples/rc522.json
@@ -55,15 +55,15 @@
   ],
 
   "buses": [
-    { "id": "spi0", "type": "spi", "clk": "D5", "miso": "D6", "mosi": "D7" }
+    { "id": "spi_bus", "type": "spi", "clk": "D5", "miso": "D6", "mosi": "D7" }
   ],
 
   "connections": [
     { "component_id": "reader", "pin_role": "VCC",   "target": { "kind": "rail", "rail": "3V3" } },
     { "component_id": "reader", "pin_role": "GND",   "target": { "kind": "rail", "rail": "GND" } },
-    { "component_id": "reader", "pin_role": "SCK",   "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "reader", "pin_role": "MISO",  "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "reader", "pin_role": "MOSI",  "target": { "kind": "bus",  "bus_id": "spi0" } },
+    { "component_id": "reader", "pin_role": "SCK",   "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "reader", "pin_role": "MISO",  "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "reader", "pin_role": "MOSI",  "target": { "kind": "bus",  "bus_id": "spi_bus" } },
     { "component_id": "reader", "pin_role": "CS",    "target": { "kind": "gpio", "pin": "D8" } },
     { "component_id": "reader", "pin_role": "RESET", "target": { "kind": "gpio", "pin": "D4" } },
 

--- a/wirestudio/examples/subghz-rfid.json
+++ b/wirestudio/examples/subghz-rfid.json
@@ -21,16 +21,16 @@
   ],
 
   "buses": [
-    { "id": "spi0", "type": "spi", "clk": "GPIO18", "mosi": "GPIO23", "miso": "GPIO19" },
+    { "id": "spi_bus", "type": "spi", "clk": "GPIO18", "mosi": "GPIO23", "miso": "GPIO19" },
     { "id": "rfid_uart", "type": "uart", "rx": "GPIO16", "tx": "GPIO17", "baud_rate": 9600 }
   ],
 
   "connections": [
     { "component_id": "radio", "pin_role": "VCC",  "target": { "kind": "rail", "rail": "3V3" } },
     { "component_id": "radio", "pin_role": "GND",  "target": { "kind": "rail", "rail": "GND" } },
-    { "component_id": "radio", "pin_role": "SCK",  "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "radio", "pin_role": "MISO", "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "radio", "pin_role": "MOSI", "target": { "kind": "bus",  "bus_id": "spi0" } },
+    { "component_id": "radio", "pin_role": "SCK",  "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "radio", "pin_role": "MISO", "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "radio", "pin_role": "MOSI", "target": { "kind": "bus",  "bus_id": "spi_bus" } },
     { "component_id": "radio", "pin_role": "CS",   "target": { "kind": "gpio", "pin": "GPIO5" } },
     { "component_id": "radio", "pin_role": "GDO0", "target": { "kind": "gpio", "pin": "GPIO4" } },
     { "component_id": "radio", "pin_role": "GDO2", "target": { "kind": "gpio", "pin": "GPIO2" } },

--- a/wirestudio/examples/t-beam.json
+++ b/wirestudio/examples/t-beam.json
@@ -70,7 +70,7 @@
   ],
   "buses": [
     {
-      "id": "spi0",
+      "id": "spi_bus",
       "type": "spi",
       "clk": "GPIO5",
       "miso": "GPIO19",
@@ -106,7 +106,7 @@
       "pin_role": "SCK",
       "target": {
         "kind": "bus",
-        "bus_id": "spi0"
+        "bus_id": "spi_bus"
       }
     },
     {
@@ -114,7 +114,7 @@
       "pin_role": "MISO",
       "target": {
         "kind": "bus",
-        "bus_id": "spi0"
+        "bus_id": "spi_bus"
       }
     },
     {
@@ -122,7 +122,7 @@
       "pin_role": "MOSI",
       "target": {
         "kind": "bus",
-        "bus_id": "spi0"
+        "bus_id": "spi_bus"
       }
     },
     {

--- a/wirestudio/examples/tft-touch.json
+++ b/wirestudio/examples/tft-touch.json
@@ -22,15 +22,15 @@
   ],
 
   "buses": [
-    { "id": "spi0", "type": "spi", "clk": "GPIO18", "mosi": "GPIO23", "miso": "GPIO19" }
+    { "id": "spi_bus", "type": "spi", "clk": "GPIO18", "mosi": "GPIO23", "miso": "GPIO19" }
   ],
 
   "connections": [
     { "component_id": "tft", "pin_role": "VCC",       "target": { "kind": "rail", "rail": "3V3" } },
     { "component_id": "tft", "pin_role": "GND",       "target": { "kind": "rail", "rail": "GND" } },
-    { "component_id": "tft", "pin_role": "SCK",       "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "tft", "pin_role": "MOSI",      "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "tft", "pin_role": "MISO",      "target": { "kind": "bus",  "bus_id": "spi0" } },
+    { "component_id": "tft", "pin_role": "SCK",       "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "tft", "pin_role": "MOSI",      "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "tft", "pin_role": "MISO",      "target": { "kind": "bus",  "bus_id": "spi_bus" } },
     { "component_id": "tft", "pin_role": "CS",        "target": { "kind": "gpio", "pin": "GPIO5" } },
     { "component_id": "tft", "pin_role": "DC",        "target": { "kind": "gpio", "pin": "GPIO16" } },
     { "component_id": "tft", "pin_role": "RESET",     "target": { "kind": "gpio", "pin": "GPIO17" } },
@@ -38,9 +38,9 @@
 
     { "component_id": "touch", "pin_role": "VCC",  "target": { "kind": "rail", "rail": "3V3" } },
     { "component_id": "touch", "pin_role": "GND",  "target": { "kind": "rail", "rail": "GND" } },
-    { "component_id": "touch", "pin_role": "SCK",  "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "touch", "pin_role": "MOSI", "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "touch", "pin_role": "MISO", "target": { "kind": "bus",  "bus_id": "spi0" } },
+    { "component_id": "touch", "pin_role": "SCK",  "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "touch", "pin_role": "MOSI", "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "touch", "pin_role": "MISO", "target": { "kind": "bus",  "bus_id": "spi_bus" } },
     { "component_id": "touch", "pin_role": "CS",   "target": { "kind": "gpio", "pin": "GPIO21" } },
     { "component_id": "touch", "pin_role": "IRQ",  "target": { "kind": "gpio", "pin": "GPIO22" } }
   ],

--- a/wirestudio/examples/ttgo-lora32.json
+++ b/wirestudio/examples/ttgo-lora32.json
@@ -57,16 +57,16 @@
   ],
 
   "buses": [
-    { "id": "spi0", "type": "spi", "clk": "GPIO5",  "miso": "GPIO19", "mosi": "GPIO27" },
+    { "id": "spi_bus", "type": "spi", "clk": "GPIO5",  "miso": "GPIO19", "mosi": "GPIO27" },
     { "id": "i2c0", "type": "i2c", "frequency_hz": 400000, "sda": "GPIO21", "scl": "GPIO22" }
   ],
 
   "connections": [
     { "component_id": "lora", "pin_role": "VCC",  "target": { "kind": "rail", "rail": "3V3" } },
     { "component_id": "lora", "pin_role": "GND",  "target": { "kind": "rail", "rail": "GND" } },
-    { "component_id": "lora", "pin_role": "SCK",  "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "lora", "pin_role": "MISO", "target": { "kind": "bus",  "bus_id": "spi0" } },
-    { "component_id": "lora", "pin_role": "MOSI", "target": { "kind": "bus",  "bus_id": "spi0" } },
+    { "component_id": "lora", "pin_role": "SCK",  "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "lora", "pin_role": "MISO", "target": { "kind": "bus",  "bus_id": "spi_bus" } },
+    { "component_id": "lora", "pin_role": "MOSI", "target": { "kind": "bus",  "bus_id": "spi_bus" } },
     { "component_id": "lora", "pin_role": "CS",   "target": { "kind": "gpio", "pin":   "GPIO18" } },
     { "component_id": "lora", "pin_role": "RST",  "target": { "kind": "gpio", "pin":   "GPIO23" } },
     { "component_id": "lora", "pin_role": "DIO0", "target": { "kind": "gpio", "pin":   "GPIO26" } },

--- a/wirestudio/library/components/max98357a.yaml
+++ b/wirestudio/library/components/max98357a.yaml
@@ -23,21 +23,31 @@ electrical:
 
 esphome:
   required_components: [i2s_audio]
+  # ESPHome 2026.x removed the i2s_audio media_player; the replacement
+  # is an i2s_audio speaker wrapped by the speaker media_player, whose
+  # announcement_pipeline is the one required key.
   yaml_template: |
-    media_player:
+    speaker:
       - platform: i2s_audio
-        name: "{{ label }}"
-        id: {{ id }}
+        id: {{ id }}_spk
         dac_type: external
         i2s_dout_pin: {{ pins.DIN | tojson }}
-        mode: {{ params.mode | default('mono') }}
+        channel: {{ params.mode | default('mono') }}
+    media_player:
+      - platform: speaker
+        name: "{{ label }}"
+        id: {{ id }}
+        announcement_pipeline:
+          speaker: {{ id }}_spk
+          num_channels: {{ 2 if params.mode | default('mono') == 'stereo' else 1 }}
 
 params_schema:
   mode: {type: string, enum: [mono, stereo, left, right], default: "mono"}
 
-notes: "MAX98357A is mono Class-D. For stereo use two boards with one wired left, one right -- ESPHome
-  doesn't support that yet (one media_player per device). DIN, BCLK, LRCLK come from the i2s_audio bus
-  and i2s_dout_pin connection. SD pin (shutdown) is optional; tie high or omit for always-on."
+notes: "MAX98357A is mono Class-D. For stereo use two boards with one wired left, one right. DIN, BCLK,
+  LRCLK come from the i2s_audio bus and i2s_dout_pin connection. SD pin (shutdown) is optional; tie high
+  or omit for always-on. The speaker media_player decodes on-device; enable PSRAM on boards that have it
+  for longer buffers."
 # KiCad symbol mapping (0.9 schematic export). KiCad bundles MAX98357A
 # in the Amplifier_Audio library for newer releases; older installs
 # may need an alias or an external addon library.


### PR DESCRIPTION
Bumps the ESPHome pin 2025.12.7 → 2026.6.5, evidence-driven per the P1 roadmap policy: the full examples gate was run locally under 2026.6.5 first.

**Two schema breaks between the pins:**
1. ESPHome 2026.x reserves the id `spi0` internally. Nine examples failed for that reason — atoms3-onboard, esp32-audio, grill-probe, led-display, rc522, subghz-rfid, t-beam, tft-touch, ttgo-lora32. Their SPI bus is renamed `spi0` → `spi_bus`; the 18 affected goldens were regenerated with `python -m wirestudio.generate` per the CONTRIBUTING procedure, and the three test assertions naming the example bus id updated.
2. The `i2s_audio` media_player was removed upstream (masked locally by the spi0 error until that was fixed; surfaced by this PR's first CI run). The max98357a template now emits an `i2s_audio` speaker fronted by the `speaker` media_player with its required `announcement_pipeline`; the `mode` param maps onto the speaker's `channel`.

Pin citations updated together, as the config gate requires: `esphome-config.yml`, `esphome-compile.yml` (install + PlatformIO cache key), README's tested-against line and install snippet, CONTRIBUTING. The `esphome-matrix` list shrinks to the pin alone (2026.6.5 is the newest stable); it grows again as releases land.

Validation: examples gate 68/68 under 2026.6.5 locally and in this PR's CI; 1109 Python tests pass (the only 2 local failures are the chmod-based unwritability tests that can't fail under a root sandbox and pass in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLucY2SKuBDPFaDAJnnYs1