### PR TITLE
CircuitPython code.py generation from the design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ESPHome pin bumped 2025.12.7 -> 2026.6.5** (config gate, nightly
+  compile smoke, matrix, README/CONTRIBUTING). Two schema breaks:
+  2026.x reserves the id `spi0` internally, so the nine examples whose
+  SPI bus was named `spi0` rename it to `spi_bus`; and the i2s_audio
+  media_player was removed upstream, so the max98357a template now
+  emits an i2s_audio speaker wrapped by the speaker media_player
+  (goldens regenerated). All 68 examples validate under the new pin.
+
 ### Added
 
 - **CircuitPython code.py generation from the design.** The
@@ -23,18 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   design-generated code over the board starter and lists the bundle
   libraries to copy to CIRCUITPY/lib plus any unmapped components.
   Every bundled example generates parseable code.
-
-### Changed
-
-- **ESPHome pin bumped 2025.12.7 -> 2026.6.5** (config gate, nightly
-  compile smoke, matrix, README/CONTRIBUTING). Two schema breaks:
-  2026.x reserves the id `spi0` internally, so the nine examples whose
-  SPI bus was named `spi0` rename it to `spi_bus`; and the i2s_audio
-  media_player was removed upstream, so the max98357a template now
-  emits an i2s_audio speaker wrapped by the speaker media_player
-  (goldens regenerated). All 68 examples validate under the new pin.
-
-### Added
 
 - **Tasmota coverage for the library-sweep components.** Eight new
   entries in the verified FUNC table (values recomputed from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CircuitPython code.py generation from the design.** The
+  LoRaWAN-fragment pattern applied to Python: 36 library components
+  gain a `circuitpython:` block -- explicit import lines, Adafruit
+  bundle deps, and Jinja2 setup/loop fragments -- and the new
+  generator (`wirestudio/generate/circuitpython_gen.py`) resolves the
+  design's buses to busio objects, renders each component's wiring
+  through the P() pin helper (IO/GPIO/D naming varies per build),
+  assembles one runnable file, and ast-validates it. Components
+  without a mapping degrade to a warning comment, and only buses a
+  mapped component uses are emitted. `POST /circuitpython/code`
+  returns {code, deps, warnings}; the flash dialog now prefers
+  design-generated code over the board starter and lists the bundle
+  libraries to copy to CIRCUITPY/lib plus any unmapped components.
+  Every bundled example generates parseable code.
+
 ### Changed
 
 - **ESPHome pin bumped 2025.12.7 -> 2026.6.5** (config gate, nightly

--- a/docs/index.md
+++ b/docs/index.md
@@ -184,11 +184,19 @@ and warned about in the UI); ESP8266 has no CircuitPython port.
 board's library metadata (Vext power-up, LED blink, I2C scan, pin
 listing) with save-to-CIRCUITPY and download buttons post-flash.
 
+**CircuitPython codegen.** *Works.* Full code.py generation from the
+design — the LoRaWAN-fragment pattern applied to Python. 36 library
+components carry a `circuitpython:` block (explicit imports, Adafruit
+bundle deps, Jinja2 setup/loop fragments); the generator resolves
+buses to busio objects, renders each component's wiring, lists the
+bundle libraries to copy to CIRCUITPY/lib, and ast-validates the
+output. `POST /circuitpython/code` returns {code, deps, warnings};
+the flash dialog prefers design code over the board starter and
+surfaces deps + unmapped-component warnings. Unmapped parts degrade
+to a comment, never a broken file.
+
 **Target backlog.** Next: Meshtastic config push (`@meshtastic/js`
-region/channel/key setup over the existing serial session), then full
-CircuitPython code.py generation from the design (per-component driver
-init + Adafruit bundle libs, the LoRaWAN-fragment pattern — the
-interpreter flash + starter above is the shipped first step), then
+region/channel/key setup over the existing serial session), then
 MicroPython (the CircuitPython pattern applied upstream: proxy the
 micropython.org release port per chip, flash via the unified dialog,
 generate a main.py scaffold — differs in stdlib/driver sourcing, since

--- a/tests/test_circuitpython.py
+++ b/tests/test_circuitpython.py
@@ -109,3 +109,71 @@ def test_code_generates_valid_python_for_every_board():
         r = client.get(f"/circuitpython/code?board={board}")
         assert r.status_code == 200, board
         ast.parse(r.text)
+
+
+def test_design_code_air_quality_station():
+    from wirestudio.generate.circuitpython_gen import generate_code
+    from wirestudio.library import default_library
+    from wirestudio.model import Design
+    import json
+    from pathlib import Path
+
+    examples = Path(__file__).resolve().parent.parent / "wirestudio" / "examples"
+    design = Design.model_validate(
+        json.loads((examples / "air-quality-station.json").read_text())
+    )
+    out = generate_code(design, default_library())
+    code = out["code"]
+    assert "i2c_i2c0 = busio.I2C(P(22), P(21))" in code
+    assert "adafruit_scd4x.SCD4X(i2c_i2c0)" in code
+    assert "adafruit_sht4x" in out["deps"]
+    # pmsx003 has no CP driver: warned, and its uart bus is not emitted.
+    assert any("pmsx003" in w for w in out["warnings"])
+    assert "busio.UART" not in code
+
+
+def test_design_code_every_example_is_valid_python():
+    import ast
+    import json
+    from pathlib import Path
+
+    from wirestudio.generate.circuitpython_gen import generate_code
+    from wirestudio.library import default_library
+    from wirestudio.model import Design
+
+    lib = default_library()
+    examples = Path(__file__).resolve().parent.parent / "wirestudio" / "examples"
+    mapped = 0
+    for path in sorted(examples.glob("*.json")):
+        design = Design.model_validate(json.loads(path.read_text()))
+        out = generate_code(design, lib)
+        ast.parse(out["code"])  # generator also parses; double-checked here
+        if "# Not generated" not in out["code"]:
+            mapped += 1
+    assert mapped > 15  # plenty of examples generate with zero gaps
+
+
+def test_design_code_endpoint():
+    import json
+    from pathlib import Path
+
+    client = TestClient(create_app())
+    examples = Path(__file__).resolve().parent.parent / "wirestudio" / "examples"
+    design = json.loads((examples / "access-panel.json").read_text())
+    r = client.post("/circuitpython/code", json=design)
+    assert r.status_code == 200
+    body = r.json()
+    assert "PN532_I2C" in body["code"]
+    assert "adafruit_pn532" in body["deps"]
+    assert any("wiegand" in w for w in body["warnings"])
+
+
+def test_design_code_endpoint_unknown_board_404():
+    import json
+    from pathlib import Path
+
+    client = TestClient(create_app())
+    examples = Path(__file__).resolve().parent.parent / "wirestudio" / "examples"
+    design = json.loads((examples / "access-panel.json").read_text())
+    design["board"]["library_id"] = "not-a-board"
+    assert client.post("/circuitpython/code", json=design).status_code == 404

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -240,6 +240,11 @@ export const api = {
   },
   circuitpythonCode: (board: string) =>
     requestText(`/circuitpython/code?board=${encodeURIComponent(board)}`),
+  circuitpythonDesignCode: (design: Design) =>
+    request<{ code: string; deps: string[]; warnings: string[] }>(
+      "/circuitpython/code",
+      { method: "POST", body: JSON.stringify(design) },
+    ),
   workbenchStatus: () => request<WorkbenchStatus>("/workbench/status"),
   workbenchSlots: () => request<{ slots: WorkbenchSlot[] }>("/workbench/slots"),
   kicadRouteStatus: () =>

--- a/web/src/components/FlashDialog.tsx
+++ b/web/src/components/FlashDialog.tsx
@@ -349,6 +349,9 @@ function CircuitPythonFlash({ design, boards }: { design: Design | null; boards:
   const [log, setLog] = useState<string[]>([]);
   const [serial, setSerial] = useState<string>("");
   const [starter, setStarter] = useState<string | null>(null);
+  const [codeDeps, setCodeDeps] = useState<string[]>([]);
+  const [codeWarnings, setCodeWarnings] = useState<string[]>([]);
+  const [fromDesign, setFromDesign] = useState(false);
   const [saved, setSaved] = useState<string | null>(null);
   const [target, setTarget] = useState<FlashTarget>({ kind: "usb" });
   const sessionRef = useRef<FlashSession | null>(null);
@@ -377,11 +380,25 @@ function CircuitPythonFlash({ design, boards }: { design: Design | null; boards:
   useEffect(() => {
     if (!supported) { setStarter(null); return; }
     let cancelled = false;
-    api.circuitpythonCode(boardLibraryId)
-      .then((code) => { if (!cancelled) setStarter(code); })
-      .catch(() => { if (!cancelled) setStarter(null); });
+    const fallback = () =>
+      api.circuitpythonCode(boardLibraryId)
+        .then((code) => { if (!cancelled) { setStarter(code); setCodeDeps([]); setCodeWarnings([]); setFromDesign(false); } })
+        .catch(() => { if (!cancelled) setStarter(null); });
+    if (design && (design.components as unknown[] | undefined)?.length) {
+      api.circuitpythonDesignCode(design)
+        .then((r) => {
+          if (cancelled) return;
+          setStarter(r.code);
+          setCodeDeps(r.deps);
+          setCodeWarnings(r.warnings);
+          setFromDesign(true);
+        })
+        .catch(() => { if (!cancelled) void fallback(); });
+    } else {
+      void fallback();
+    }
     return () => { cancelled = true; };
-  }, [supported, boardLibraryId]);
+  }, [supported, boardLibraryId, design]);
 
   useEffect(() => () => { void sessionRef.current?.close(); }, []);
 
@@ -499,7 +516,20 @@ function CircuitPythonFlash({ design, boards }: { design: Design | null; boards:
           </p>
           {starter && (
             <>
-              <div className="text-xs font-medium text-ink">Starter code.py for this board</div>
+              <div className="text-xs font-medium text-ink">
+                {fromDesign ? "code.py generated from this design" : "Starter code.py for this board"}
+              </div>
+              {fromDesign && codeDeps.length > 0 && (
+                <div className="text-[10px] text-ink-faint">
+                  Copy from the Adafruit bundle into CIRCUITPY/lib:{" "}
+                  <code className="font-mono text-ink-dim">{codeDeps.join("  ")}</code>
+                </div>
+              )}
+              {fromDesign && codeWarnings.length > 0 && (
+                <ul className="text-[10px] text-amber-200">
+                  {codeWarnings.map((w, i) => <li key={i}>{w}</li>)}
+                </ul>
+              )}
               <pre className="max-h-40 overflow-auto rounded-md bg-surface-0 p-2 font-mono text-[10px] text-ink-dim ring-1 ring-line">
                 {starter}
               </pre>

--- a/wirestudio/api/circuitpython.py
+++ b/wirestudio/api/circuitpython.py
@@ -20,8 +20,11 @@ CIRCUITPY drive.
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Response
+from pydantic import ValidationError
 
+from wirestudio.generate.circuitpython_gen import generate_code
 from wirestudio.library import Library, LibraryBoard
+from wirestudio.model import Design
 from wirestudio.errors import describe
 
 _RELEASES_LATEST = "https://api.github.com/repos/adafruit/circuitpython/releases/latest"
@@ -242,6 +245,20 @@ def router(lib: Library) -> APIRouter:
                 "Content-Disposition": f'attachment; filename="{filename}"',
             },
         )
+
+    @router.post("/code")
+    def circuitpython_design_code(design: dict) -> dict:
+        """code.py generated from the design: per-component driver init
+        from the library's `circuitpython:` fragments, plus the Adafruit
+        bundle libraries to copy to CIRCUITPY/lib."""
+        try:
+            d = Design.model_validate(design)
+        except ValidationError as e:
+            raise HTTPException(status_code=422, detail=e.errors()) from e
+        try:
+            return generate_code(d, lib)
+        except FileNotFoundError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
 
     @router.get("/code", response_class=Response)
     def circuitpython_code(board: str):

--- a/wirestudio/generate/circuitpython_gen.py
+++ b/wirestudio/generate/circuitpython_gen.py
@@ -1,0 +1,196 @@
+"""Design -> CircuitPython code.py.
+
+The LoRaWAN-fragment pattern applied to Python: each library component
+carries a `circuitpython:` block with a Jinja2 `setup` fragment (run
+once at boot) and an optional `loop` fragment (main while-loop body);
+the generator resolves buses to busio objects, renders every fragment
+with the component's wiring, and assembles one runnable file. Pure
+function of design + library, like every other generator.
+
+Pin objects go through the P() helper emitted into the file: builds
+name the same GPIO `IO21`, `GPIO21` or `D21` depending on the port, so
+fragments reference bare numbers and P() resolves at runtime.
+"""
+from __future__ import annotations
+
+import ast
+
+from jinja2 import Environment, StrictUndefined
+
+from wirestudio.library import Library
+from wirestudio.model import Design
+
+_jinja = Environment(undefined=StrictUndefined, keep_trailing_newline=False)
+
+_BUS_VAR_PREFIX = {"i2c": "i2c", "spi": "spi", "uart": "uart"}
+
+
+def _pin_num(pin: object) -> int | None:
+    s = str(pin or "")
+    digits = "".join(ch for ch in s if ch.isdigit())
+    return int(digits) if s.startswith("GPIO") and digits else None
+
+
+def _sanitize(name: str) -> str:
+    out = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in name)
+    return out if out and not out[0].isdigit() else f"b_{out}"
+
+
+def generate_code(design: Design, library: Library) -> dict:
+    """Return {"code": str, "deps": [str], "warnings": [str]}.
+
+    Raises FileNotFoundError for an unknown board. Components without a
+    `circuitpython:` block are skipped with a warning; the code still
+    runs with everything that is mapped.
+    """
+    library.board(design.board.library_id)  # unknown board raises here
+    warnings: list[str] = []
+    deps: list[str] = []
+    imports: set[str] = set()
+    setup_blocks: list[str] = []
+    loop_blocks: list[str] = []
+
+    bus_vars: dict[str, str] = {}
+    bus_setup: dict[str, str] = {}
+    used_bus_ids: set[str] = set()
+    for bus in design.buses:
+        prefix = _BUS_VAR_PREFIX.get(bus.type)
+        if prefix is None:
+            warnings.append(f"bus {bus.id}: no CircuitPython mapping for type '{bus.type}'")
+            continue
+        var = _sanitize(f"{prefix}_{bus.id}")
+        if bus.type == "i2c":
+            sda, scl = _pin_num(bus.sda), _pin_num(bus.scl)
+            if sda is None or scl is None:
+                warnings.append(f"bus {bus.id}: unassigned i2c pins; run Solve Pins")
+                continue
+            bus_setup[bus.id] = f"{var} = busio.I2C(P({scl}), P({sda}))"
+        elif bus.type == "spi":
+            clk, mosi, miso = _pin_num(bus.clk), _pin_num(bus.mosi), _pin_num(bus.miso)
+            if clk is None:
+                warnings.append(f"bus {bus.id}: unassigned spi clk; run Solve Pins")
+                continue
+            args = [f"P({clk})"]
+            args.append(f"MOSI=P({mosi})" if mosi is not None else "MOSI=None")
+            args.append(f"MISO=P({miso})" if miso is not None else "MISO=None")
+            bus_setup[bus.id] = f"{var} = busio.SPI({', '.join(args)})"
+        elif bus.type == "uart":
+            tx, rx = _pin_num(bus.tx), _pin_num(bus.rx)
+            if tx is None and rx is None:
+                warnings.append(f"bus {bus.id}: unassigned uart pins; run Solve Pins")
+                continue
+            args = [
+                f"TX=P({tx})" if tx is not None else "TX=None",
+                f"RX=P({rx})" if rx is not None else "RX=None",
+                f"baudrate={bus.baud_rate or 9600}",
+            ]
+            bus_setup[bus.id] = f"{var} = busio.UART({', '.join(args)})"
+        bus_vars[bus.id] = var
+
+    for comp in design.components:
+        lib_comp = library.component(comp.library_id)
+        spec = lib_comp.circuitpython
+        if spec is None:
+            warnings.append(
+                f"{comp.id} ({comp.library_id}): no CircuitPython driver mapping; skipped"
+            )
+            continue
+
+        pins: dict[str, int] = {}
+        bus_var = None
+        bus_dump = None
+        skip = None
+        for conn in design.connections:
+            if conn.component_id != comp.id:
+                continue
+            t = conn.target
+            if t.kind == "gpio" and t.pin:
+                num = _pin_num(t.pin)
+                if num is None:
+                    skip = f"{comp.id}.{conn.pin_role}: pin {t.pin} is not a GPIO number"
+                else:
+                    pins[conn.pin_role] = num
+            elif t.kind == "bus":
+                bus_var = bus_vars.get(t.bus_id or "")
+                if bus_var and t.bus_id:
+                    used_bus_ids.add(t.bus_id)
+                for b in design.buses:
+                    if b.id == t.bus_id:
+                        bus_dump = b.model_dump()
+            elif t.kind == "expander_pin":
+                skip = f"{comp.id}.{conn.pin_role}: expander pins have no CircuitPython path"
+        if skip:
+            warnings.append(f"{skip}; skipped")
+            continue
+
+        ctx = {
+            "id": _sanitize(comp.id),
+            "label": comp.label,
+            "params": dict(comp.params or {}),
+            "pins": pins,
+            "bus": bus_dump,
+            "bus_var": bus_var,
+        }
+        try:
+            setup = _jinja.from_string(spec.setup).render(**ctx).strip("\n")
+        except Exception as e:
+            warnings.append(f"{comp.id}: fragment failed to render ({e}); skipped")
+            continue
+        setup_blocks.append(f"# {comp.label or comp.id} ({comp.library_id})\n{setup}")
+        if spec.loop:
+            loop = _jinja.from_string(spec.loop).render(**ctx).strip("\n")
+            if loop:
+                loop_blocks.append(loop)
+        for d in spec.deps:
+            if d not in deps:
+                deps.append(d)
+        imports.update(spec.imports)
+
+    emitted_buses = [bus_setup[b] for b in bus_setup if b in used_bus_ids]
+    needs_busio = bool(emitted_buses)
+    lines: list[str] = [
+        f'"""{design.name or design.id} -- generated by wirestudio."""',
+    ]
+    if deps:
+        lines += [
+            "# Copy these Adafruit bundle libraries into CIRCUITPY/lib:",
+            *[f"#   {d}" for d in sorted(deps)],
+        ]
+    if warnings:
+        lines += ["# Not generated (no CircuitPython mapping):",
+                  *[f"#   {w}" for w in warnings]]
+    lines += ["", "import time", "", "import board"]
+    if needs_busio:
+        lines.append("import busio")
+    for imp in sorted(imports):
+        lines.append(imp)
+    lines += [
+        "",
+        "",
+        "def find_pin(*names):",
+        "    for n in names:",
+        "        p = getattr(board, n, None)",
+        "        if p is not None:",
+        "            return p",
+        '    raise AttributeError("none of %s on this build" % (names,))',
+        "",
+        "",
+        "def P(n):",
+        '    return find_pin("IO%d" % n, "GPIO%d" % n, "D%d" % n)',
+        "",
+    ]
+    if emitted_buses:
+        lines += ["", "# Buses", *emitted_buses]
+    for block in setup_blocks:
+        lines += ["", block]
+    lines += ["", "", "while True:"]
+    if loop_blocks:
+        for block in loop_blocks:
+            lines += [f"    {ln}" if ln else "" for ln in block.split("\n")]
+    else:
+        lines.append('    print("alive")')
+    lines += ["    time.sleep(5)", ""]
+
+    code = "\n".join(lines)
+    ast.parse(code)  # a fragment that breaks the file is a library bug
+    return {"code": code, "deps": sorted(deps), "warnings": warnings}

--- a/wirestudio/library/__init__.py
+++ b/wirestudio/library/__init__.py
@@ -160,6 +160,20 @@ class TasmotaSpec(_Strict):
     bus: dict[str, str] = Field(default_factory=dict)
 
 
+class CircuitPythonSpec(_Strict):
+    """CircuitPython code.py generation. `setup` is a Jinja2 Python
+    fragment run once at boot (context: id, label, params, pins as
+    role->GPIO-number, bus, bus_var); `loop` an optional fragment for
+    the main while-loop body. `imports` are the exact import lines the
+    fragments need; `deps` names the Adafruit bundle libraries to copy
+    to CIRCUITPY/lib (core modules need no entry). Explicit rather than
+    inferred so the mapping is reviewed code, not a runtime guess."""
+    imports: list[str] = Field(default_factory=list)
+    deps: list[str] = Field(default_factory=list)
+    setup: str
+    loop: Optional[str] = None
+
+
 class LibraryComponent(_Strict):
     id: str
     name: str
@@ -174,6 +188,7 @@ class LibraryComponent(_Strict):
     notes: Optional[str] = None
     kicad: Optional[KicadSymbolRef] = None
     tasmota: Optional[TasmotaSpec] = None
+    circuitpython: Optional[CircuitPythonSpec] = None
 
 
 class Rail(_Strict):

--- a/wirestudio/library/components/adc.yaml
+++ b/wirestudio/library/components/adc.yaml
@@ -54,6 +54,13 @@ capability:
     - {event: on_value, kind: value}
     - {event: on_value_range, kind: event}
 
+circuitpython:
+  imports: ["import analogio"]
+  setup: |
+    {{ id }} = analogio.AnalogIn(P({{ pins.IN }}))
+  loop: |
+    print("{{ label }}: %.2fV" % ({{ id }}.value * {{ id }}.reference_voltage / 65535))
+
 params_schema:
   attenuation:
     type: string

--- a/wirestudio/library/components/aht10.yaml
+++ b/wirestudio/library/components/aht10.yaml
@@ -54,6 +54,14 @@ capability:
     - {event: on_value, kind: value, channel: humidity}
     - {event: on_value_range, kind: event, channel: humidity}
 
+circuitpython:
+  imports: ["import adafruit_ahtx0"]
+  deps: [adafruit_ahtx0, adafruit_bus_device]
+  setup: |
+    {{ id }} = adafruit_ahtx0.AHTx0({{ bus_var }})
+  loop: |
+    print("{{ label }}: %.1fC %.0f%%" % ({{ id }}.temperature, {{ id }}.relative_humidity))
+
 params_schema:
   variant:
     type: string

--- a/wirestudio/library/components/apa102.yaml
+++ b/wirestudio/library/components/apa102.yaml
@@ -37,6 +37,13 @@ esphome:
         default_transition_length: {{ params.default_transition_length }}
     {%- endif %}
 
+circuitpython:
+  imports: ["import adafruit_dotstar"]
+  deps: [adafruit_dotstar, adafruit_pixelbuf]
+  setup: |
+    {{ id }} = adafruit_dotstar.DotStar(P({{ pins.CI }}), P({{ pins.DI }}), {{ params.num_leds | default(1) }}, auto_write=True)
+    {{ id }}.fill((0, 8, 0))
+
 params_schema:
   chipset:
     type: string

--- a/wirestudio/library/components/bh1750.yaml
+++ b/wirestudio/library/components/bh1750.yaml
@@ -44,6 +44,14 @@ capability:
     - {event: on_value, kind: value}
     - {event: on_value_range, kind: event}
 
+circuitpython:
+  imports: ["import adafruit_bh1750"]
+  deps: [adafruit_bh1750, adafruit_bus_device, adafruit_register]
+  setup: |
+    {{ id }} = adafruit_bh1750.BH1750({{ bus_var }}, address={{ params.address | default('0x23') }})
+  loop: |
+    print("{{ label }}: %.0f lux" % {{ id }}.lux)
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/bme280.yaml
+++ b/wirestudio/library/components/bme280.yaml
@@ -63,6 +63,14 @@ capability:
     - {event: on_value, kind: value, channel: pressure}
     - {event: on_value_range, kind: event, channel: pressure}
 
+circuitpython:
+  imports: ["from adafruit_bme280 import basic as adafruit_bme280"]
+  deps: [adafruit_bme280, adafruit_bus_device, adafruit_register]
+  setup: |
+    {{ id }} = adafruit_bme280.Adafruit_BME280_I2C({{ bus_var }}, address={{ params.address | default('0x76') }})
+  loop: |
+    print("{{ label }}: %.1fC %.0f%% %.1fhPa" % ({{ id }}.temperature, {{ id }}.relative_humidity, {{ id }}.pressure))
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/bme680.yaml
+++ b/wirestudio/library/components/bme680.yaml
@@ -43,6 +43,14 @@ capability:
   provides:
     - {event: on_value, kind: value}
 
+circuitpython:
+  imports: ["import adafruit_bme680"]
+  deps: [adafruit_bme680, adafruit_bus_device]
+  setup: |
+    {{ id }} = adafruit_bme680.Adafruit_BME680_I2C({{ bus_var }}, address={{ params.address | default('0x76') }})
+  loop: |
+    print("{{ label }}: %.1fC %.0f%% %.1fhPa gas=%d" % ({{ id }}.temperature, {{ id }}.humidity, {{ id }}.pressure, {{ id }}.gas))
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/bmp280.yaml
+++ b/wirestudio/library/components/bmp280.yaml
@@ -59,6 +59,14 @@ capability:
     - {event: on_value, kind: value, channel: pressure}
     - {event: on_value_range, kind: event, channel: pressure}
 
+circuitpython:
+  imports: ["import adafruit_bmp280"]
+  deps: [adafruit_bmp280, adafruit_bus_device, adafruit_register]
+  setup: |
+    {{ id }} = adafruit_bmp280.Adafruit_BMP280_I2C({{ bus_var }}, address={{ params.address | default('0x76') }})
+  loop: |
+    print("{{ label }}: %.1fC %.1fhPa" % ({{ id }}.temperature, {{ id }}.pressure))
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/dht.yaml
+++ b/wirestudio/library/components/dht.yaml
@@ -95,6 +95,17 @@ capability:
     - {event: on_value, kind: value, channel: humidity}
     - {event: on_value_range, kind: event, channel: humidity}
 
+circuitpython:
+  imports: ["import adafruit_dht"]
+  deps: [adafruit_dht]
+  setup: |
+    {{ id }} = adafruit_dht.{{ 'DHT11' if (params.model | default('DHT22')) == 'DHT11' else 'DHT22' }}(P({{ pins.DATA }}))
+  loop: |
+    try:
+        print("{{ label }}: %sC %s%%" % ({{ id }}.temperature, {{ id }}.humidity))
+    except RuntimeError as e:
+        print("{{ label }}:", e)
+
 params_schema:
   model:
     type: string

--- a/wirestudio/library/components/ds18b20.yaml
+++ b/wirestudio/library/components/ds18b20.yaml
@@ -43,6 +43,15 @@ capability:
     - {event: on_value, kind: value}
     - {event: on_value_range, kind: event}
 
+circuitpython:
+  imports: ["from adafruit_onewire.bus import OneWireBus", "from adafruit_ds18x20 import DS18X20"]
+  deps: [adafruit_onewire, adafruit_ds18x20]
+  setup: |
+    {{ id }}_ow = OneWireBus(P({{ pins.DATA }}))
+    {{ id }} = DS18X20({{ id }}_ow, {{ id }}_ow.scan()[0])
+  loop: |
+    print("{{ label }}: %.1fC" % {{ id }}.temperature)
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/esp32_rmt_led_strip.yaml
+++ b/wirestudio/library/components/esp32_rmt_led_strip.yaml
@@ -28,6 +28,13 @@ esphome:
         name: "{{ label }}"
         id: {{ id }}
 
+circuitpython:
+  imports: ["import neopixel"]
+  deps: [neopixel, adafruit_pixelbuf]
+  setup: |
+    {{ id }} = neopixel.NeoPixel(P({{ pins.DIN }}), {{ params.num_leds | default(1) }}, auto_write=True)
+    {{ id }}.fill((0, 8, 0))
+
 params_schema:
   rgb_order:
     type: string

--- a/wirestudio/library/components/gpio_input.yaml
+++ b/wirestudio/library/components/gpio_input.yaml
@@ -58,6 +58,15 @@ capability:
     - {predicate: is_on,  esphome: binary_sensor.is_on}
     - {predicate: is_off, esphome: binary_sensor.is_off}
 
+circuitpython:
+  imports: ["import digitalio"]
+  setup: |
+    {{ id }} = digitalio.DigitalInOut(P({{ pins.IN }}))
+    {{ id }}.direction = digitalio.Direction.INPUT
+    {{ id }}.pull = digitalio.Pull.UP
+  loop: |
+    print("{{ label }}:", "open" if {{ id }}.value else "closed")
+
 params_schema:
   device_class:
     type: string

--- a/wirestudio/library/components/gpio_output.yaml
+++ b/wirestudio/library/components/gpio_output.yaml
@@ -50,6 +50,12 @@ capability:
     - {predicate: is_on,  esphome: switch.is_on}
     - {predicate: is_off, esphome: switch.is_off}
 
+circuitpython:
+  imports: ["import digitalio"]
+  setup: |
+    {{ id }} = digitalio.DigitalInOut(P({{ pins.OUT }}))
+    {{ id }}.direction = digitalio.Direction.OUTPUT
+
 params_schema:
   icon:
     type: string

--- a/wirestudio/library/components/grove-aht20.yaml
+++ b/wirestudio/library/components/grove-aht20.yaml
@@ -66,6 +66,14 @@ capability:
     - {event: on_value, kind: value, channel: humidity}
     - {event: on_value_range, kind: event, channel: humidity}
 
+circuitpython:
+  imports: ["import adafruit_ahtx0"]
+  deps: [adafruit_ahtx0, adafruit_bus_device]
+  setup: |
+    {{ id }} = adafruit_ahtx0.AHTx0({{ bus_var }})
+  loop: |
+    print("{{ label }}: %.1fC %.0f%%" % ({{ id }}.temperature, {{ id }}.relative_humidity))
+
 params_schema:
   update_interval:
     type: string

--- a/wirestudio/library/components/hc-sr04.yaml
+++ b/wirestudio/library/components/hc-sr04.yaml
@@ -47,6 +47,17 @@ capability:
   provides:
     - {event: on_value, kind: value}
 
+circuitpython:
+  imports: ["import adafruit_hcsr04"]
+  deps: [adafruit_hcsr04]
+  setup: |
+    {{ id }} = adafruit_hcsr04.HCSR04(trigger_pin=P({{ pins.TRIGGER }}), echo_pin=P({{ pins.ECHO }}))
+  loop: |
+    try:
+        print("{{ label }}: %.1f cm" % {{ id }}.distance)
+    except RuntimeError:
+        print("{{ label }}: no echo")
+
 params_schema:
   update_interval: { type: string, default: "60s" }
   unit_of_measurement: { type: string, default: "m" }

--- a/wirestudio/library/components/hc-sr501.yaml
+++ b/wirestudio/library/components/hc-sr501.yaml
@@ -42,6 +42,14 @@ capability:
     - {predicate: is_on,  esphome: binary_sensor.is_on}
     - {predicate: is_off, esphome: binary_sensor.is_off}
 
+circuitpython:
+  imports: ["import digitalio"]
+  setup: |
+    {{ id }} = digitalio.DigitalInOut(P({{ pins.OUT }}))
+    {{ id }}.direction = digitalio.Direction.INPUT
+  loop: |
+    print("{{ label }}: motion" if {{ id }}.value else "{{ label }}: clear")
+
 params_schema:
   retrigger:
     type: string

--- a/wirestudio/library/components/htu21d.yaml
+++ b/wirestudio/library/components/htu21d.yaml
@@ -53,6 +53,14 @@ capability:
     - {event: on_value, kind: value, channel: humidity}
     - {event: on_value_range, kind: event, channel: humidity}
 
+circuitpython:
+  imports: ["import adafruit_htu21d"]
+  deps: [adafruit_htu21d, adafruit_bus_device]
+  setup: |
+    {{ id }} = adafruit_htu21d.HTU21D({{ bus_var }})
+  loop: |
+    print("{{ label }}: %.1fC %.0f%%" % ({{ id }}.temperature, {{ id }}.relative_humidity))
+
 params_schema:
   update_interval:
     type: string

--- a/wirestudio/library/components/ina219.yaml
+++ b/wirestudio/library/components/ina219.yaml
@@ -46,6 +46,14 @@ capability:
   provides:
     - {event: on_value, kind: value}
 
+circuitpython:
+  imports: ["import adafruit_ina219"]
+  deps: [adafruit_ina219, adafruit_bus_device, adafruit_register]
+  setup: |
+    {{ id }} = adafruit_ina219.INA219({{ bus_var }}, addr={{ params.address | default('0x40') }})
+  loop: |
+    print("{{ label }}: %.2fV %.0fmA" % ({{ id }}.bus_voltage, {{ id }}.current))
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/max31855.yaml
+++ b/wirestudio/library/components/max31855.yaml
@@ -45,6 +45,15 @@ capability:
     - {event: on_value, kind: value}
     - {event: on_value_range, kind: event}
 
+circuitpython:
+  imports: ["import digitalio", "import adafruit_max31855"]
+  deps: [adafruit_max31855]
+  setup: |
+    {{ id }}_cs = digitalio.DigitalInOut(P({{ pins.CS }}))
+    {{ id }} = adafruit_max31855.MAX31855({{ bus_var }}, {{ id }}_cs)
+  loop: |
+    print("{{ label }}: %.1fC" % {{ id }}.temperature)
+
 params_schema:
   update_interval:
     type: string

--- a/wirestudio/library/components/mcp23008.yaml
+++ b/wirestudio/library/components/mcp23008.yaml
@@ -35,6 +35,12 @@ esphome:
         address: "{{ params.address | default('0x20') }}"
         i2c_id: {{ bus.id }}
 
+circuitpython:
+  imports: ["from adafruit_mcp230xx.mcp23008 import MCP23008"]
+  deps: [adafruit_mcp230xx, adafruit_bus_device]
+  setup: |
+    {{ id }} = MCP23008({{ bus_var }}, address={{ params.address | default('0x20') }})
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/mcp23017.yaml
+++ b/wirestudio/library/components/mcp23017.yaml
@@ -35,6 +35,12 @@ esphome:
         address: "{{ params.address | default('0x20') }}"
         i2c_id: {{ bus.id }}
 
+circuitpython:
+  imports: ["from adafruit_mcp230xx.mcp23017 import MCP23017"]
+  deps: [adafruit_mcp230xx, adafruit_bus_device]
+  setup: |
+    {{ id }} = MCP23017({{ bus_var }}, address={{ params.address | default('0x20') }})
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/mpu6050.yaml
+++ b/wirestudio/library/components/mpu6050.yaml
@@ -44,6 +44,14 @@ esphome:
         temperature:
           name: "{{ label }} Die Temp"
 
+circuitpython:
+  imports: ["import adafruit_mpu6050"]
+  deps: [adafruit_mpu6050, adafruit_bus_device, adafruit_register]
+  setup: |
+    {{ id }} = adafruit_mpu6050.MPU6050({{ bus_var }})
+  loop: |
+    print("{{ label }}: accel %s gyro %s" % ({{ id }}.acceleration, {{ id }}.gyro))
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/pca9685.yaml
+++ b/wirestudio/library/components/pca9685.yaml
@@ -50,6 +50,16 @@ capability:
     - {action: turn_on,  esphome: light.turn_on}
     - {action: turn_off, esphome: light.turn_off}
 
+circuitpython:
+  imports: ["from adafruit_pca9685 import PCA9685"]
+  deps: [adafruit_pca9685, adafruit_bus_device, adafruit_register]
+  setup: |
+    {{ id }} = PCA9685({{ bus_var }}, address={{ params.address | default('0x40') }})
+    {{ id }}.frequency = {{ (params.frequency | default('500Hz')) | replace('Hz','') | int }}
+    {%- for ch in params.channels | default([{"channel": 0}]) %}
+    {{ id }}.channels[{{ ch.channel }}].duty_cycle = 0
+    {%- endfor %}
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/pcf8574.yaml
+++ b/wirestudio/library/components/pcf8574.yaml
@@ -31,6 +31,12 @@ esphome:
         address: "{{ params.address | default('0x20') }}"
         pcf8575: {{ params.variant | default('pcf8574') == 'pcf8575' | string | lower }}
 
+circuitpython:
+  imports: ["import adafruit_pcf8574"]
+  deps: [adafruit_pcf8574]
+  setup: |
+    {{ id }} = adafruit_pcf8574.PCF8574({{ bus_var }}, address={{ params.address | default('0x20') }})
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/pn532.yaml
+++ b/wirestudio/library/components/pn532.yaml
@@ -44,6 +44,17 @@ capability:
   provides:
     - {event: on_tag, kind: event}
 
+circuitpython:
+  imports: ["from adafruit_pn532.i2c import PN532_I2C"]
+  deps: [adafruit_pn532, adafruit_bus_device]
+  setup: |
+    {{ id }} = PN532_I2C({{ bus_var }})
+    {{ id }}.SAM_configuration()
+  loop: |
+    {{ id }}_uid = {{ id }}.read_passive_target(timeout=0.5)
+    if {{ id }}_uid is not None:
+        print("{{ label }}: tag", "-".join("%02x" % b for b in {{ id }}_uid))
+
 params_schema:
   update_interval:
     type: string

--- a/wirestudio/library/components/potentiometer.yaml
+++ b/wirestudio/library/components/potentiometer.yaml
@@ -53,6 +53,13 @@ capability:
     - {event: on_value, kind: value}
     - {event: on_value_range, kind: event}
 
+circuitpython:
+  imports: ["import analogio"]
+  setup: |
+    {{ id }} = analogio.AnalogIn(P({{ pins.WIPER }}))
+  loop: |
+    print("{{ label }}: %d%%" % ({{ id }}.value * 100 // 65535))
+
 params_schema:
   update_interval:
     type: string

--- a/wirestudio/library/components/rcwl-0516.yaml
+++ b/wirestudio/library/components/rcwl-0516.yaml
@@ -45,6 +45,14 @@ capability:
     - {predicate: is_on,  esphome: binary_sensor.is_on}
     - {predicate: is_off, esphome: binary_sensor.is_off}
 
+circuitpython:
+  imports: ["import digitalio"]
+  setup: |
+    {{ id }} = digitalio.DigitalInOut(P({{ pins.OUT }}))
+    {{ id }}.direction = digitalio.Direction.INPUT
+  loop: |
+    print("{{ label }}: motion" if {{ id }}.value else "{{ label }}: clear")
+
 params_schema: {}
 
 notes: |

--- a/wirestudio/library/components/rotary_encoder.yaml
+++ b/wirestudio/library/components/rotary_encoder.yaml
@@ -66,6 +66,13 @@ capability:
     - {event: on_anticlockwise}
     - {event: on_value, kind: value}
 
+circuitpython:
+  imports: ["import rotaryio"]
+  setup: |
+    {{ id }} = rotaryio.IncrementalEncoder(P({{ pins.A }}), P({{ pins.B }}))
+  loop: |
+    print("{{ label }}: %d" % {{ id }}.position)
+
 params_schema:
   min_value:
     type: integer

--- a/wirestudio/library/components/scd4x.yaml
+++ b/wirestudio/library/components/scd4x.yaml
@@ -45,6 +45,16 @@ capability:
   provides:
     - {event: on_value, kind: value}
 
+circuitpython:
+  imports: ["import adafruit_scd4x"]
+  deps: [adafruit_scd4x, adafruit_bus_device]
+  setup: |
+    {{ id }} = adafruit_scd4x.SCD4X({{ bus_var }})
+    {{ id }}.start_periodic_measurement()
+  loop: |
+    if {{ id }}.data_ready:
+        print("{{ label }}: %d ppm CO2 %.1fC %.0f%%" % ({{ id }}.CO2, {{ id }}.temperature, {{ id }}.relative_humidity))
+
 params_schema:
   update_interval:
     type: string

--- a/wirestudio/library/components/servo.yaml
+++ b/wirestudio/library/components/servo.yaml
@@ -52,6 +52,14 @@ tasmota:
   pins:
     PWM: PWM
 
+circuitpython:
+  imports: ["import pwmio", "from adafruit_motor import servo as motor_servo"]
+  deps: [adafruit_motor]
+  setup: |
+    {{ id }}_pwm = pwmio.PWMOut(P({{ pins.PWM }}), frequency=50)
+    {{ id }} = motor_servo.Servo({{ id }}_pwm)
+    {{ id }}.angle = 90
+
 params_schema:
   auto_detach_time:
     type: string

--- a/wirestudio/library/components/sgp4x.yaml
+++ b/wirestudio/library/components/sgp4x.yaml
@@ -40,6 +40,14 @@ capability:
   provides:
     - {event: on_value, kind: value}
 
+circuitpython:
+  imports: ["import adafruit_sgp40"]
+  deps: [adafruit_sgp40, adafruit_bus_device]
+  setup: |
+    {{ id }} = adafruit_sgp40.SGP40({{ bus_var }})
+  loop: |
+    print("{{ label }}: raw VOC %d" % {{ id }}.raw)
+
 params_schema:
   model:
     type: string

--- a/wirestudio/library/components/sht3xd.yaml
+++ b/wirestudio/library/components/sht3xd.yaml
@@ -54,6 +54,14 @@ capability:
     - {event: on_value, kind: value, channel: humidity}
     - {event: on_value_range, kind: event, channel: humidity}
 
+circuitpython:
+  imports: ["import adafruit_sht31d"]
+  deps: [adafruit_sht31d, adafruit_bus_device]
+  setup: |
+    {{ id }} = adafruit_sht31d.SHT31D({{ bus_var }}, address={{ params.address | default('0x44') }})
+  loop: |
+    print("{{ label }}: %.1fC %.0f%%" % ({{ id }}.temperature, {{ id }}.relative_humidity))
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/sht4x.yaml
+++ b/wirestudio/library/components/sht4x.yaml
@@ -39,6 +39,14 @@ capability:
   provides:
     - {event: on_value, kind: value}
 
+circuitpython:
+  imports: ["import adafruit_sht4x"]
+  deps: [adafruit_sht4x, adafruit_bus_device]
+  setup: |
+    {{ id }} = adafruit_sht4x.SHT4x({{ bus_var }}, address={{ params.address | default('0x44') }})
+  loop: |
+    print("{{ label }}: %.1fC %.0f%%" % {{ id }}.measurements)
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/tsl2561.yaml
+++ b/wirestudio/library/components/tsl2561.yaml
@@ -49,6 +49,14 @@ capability:
     - {event: on_value, kind: value}
     - {event: on_value_range, kind: event}
 
+circuitpython:
+  imports: ["import adafruit_tsl2561"]
+  deps: [adafruit_tsl2561, adafruit_bus_device]
+  setup: |
+    {{ id }} = adafruit_tsl2561.TSL2561({{ bus_var }})
+  loop: |
+    print("{{ label }}: %s lux" % {{ id }}.lux)
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/veml7700.yaml
+++ b/wirestudio/library/components/veml7700.yaml
@@ -36,6 +36,14 @@ capability:
   provides:
     - {event: on_value, kind: value}
 
+circuitpython:
+  imports: ["import adafruit_veml7700"]
+  deps: [adafruit_veml7700, adafruit_bus_device, adafruit_register]
+  setup: |
+    {{ id }} = adafruit_veml7700.VEML7700({{ bus_var }})
+  loop: |
+    print("{{ label }}: %.0f lux" % {{ id }}.lux)
+
 params_schema:
   update_interval:
     type: string

--- a/wirestudio/library/components/vl53l0x.yaml
+++ b/wirestudio/library/components/vl53l0x.yaml
@@ -47,6 +47,14 @@ capability:
     - {event: on_value, kind: value}
     - {event: on_value_range, kind: event}
 
+circuitpython:
+  imports: ["import adafruit_vl53l0x"]
+  deps: [adafruit_vl53l0x, adafruit_bus_device]
+  setup: |
+    {{ id }} = adafruit_vl53l0x.VL53L0X({{ bus_var }})
+  loop: |
+    print("{{ label }}: %d mm" % {{ id }}.range)
+
 params_schema:
   address:
     type: string

--- a/wirestudio/library/components/ws2812b.yaml
+++ b/wirestudio/library/components/ws2812b.yaml
@@ -50,6 +50,13 @@ capability:
     - {predicate: is_on,  esphome: light.is_on}
     - {predicate: is_off, esphome: light.is_off}
 
+circuitpython:
+  imports: ["import neopixel"]
+  deps: [neopixel, adafruit_pixelbuf]
+  setup: |
+    {{ id }} = neopixel.NeoPixel(P({{ pins.DIN }}), {{ params.num_leds | default(1) }}, auto_write=True)
+    {{ id }}.fill((0, 8, 0))
+
 params_schema:
   variant: {type: string, default: "WS2812", enum: ["WS2811", "WS2812", "WS2812X", "400KBPS", "SK6812",
       "TM1814"]}


### PR DESCRIPTION
The roadmap's CircuitPython step two: full `code.py` generation from the design, completing what the 0.24 interpreter-flash + board-starter tier began. The LoRaWAN-fragment pattern applied to Python.

**Library:** 36 components gain a `circuitpython:` block — explicit import lines, Adafruit bundle deps, and Jinja2 `setup`/`loop` fragments (explicit rather than inferred, so the mapping is reviewed code). Coverage: the I2C sensor fleet (BME280/680, BMP280, SHT3x/4x, SCD4x, SGP4x, AHT10/20, HTU21D, BH1750, VEML7700, TSL2561, VL53L0X, INA219, MPU6050), GPIO parts (inputs/outputs, PIR/radar, HC-SR04, DHT, DS18B20, rotary encoder, ADC/potentiometer), pixels (NeoPixel, DotStar), actuators (servo via adafruit_motor, PCA9685), expander hubs (MCP23008/17, PCF8574), PN532, MAX31855.

**Generator** (`wirestudio/generate/circuitpython_gen.py`): resolves design buses to `busio` objects, renders each component's wiring through the emitted `P()` helper (builds name the same GPIO `IO21`/`GPIO21`/`D21` depending on port), collects deps, and `ast.parse`s the assembled file — a fragment that breaks the file is a library bug, not a runtime surprise. Unmapped components degrade to a warning comment; only buses a mapped component uses are emitted.

**API/UI:** `POST /circuitpython/code` → `{code, deps, warnings}` (the GET board-starter stays). The flash dialog's CircuitPython panel prefers design-generated code, shows the bundle libraries to copy to `CIRCUITPY/lib`, and surfaces unmapped-component warnings; falls back to the starter for empty designs.

Tests: 4 new Python tests including a sweep asserting every bundled example generates parseable code; 1113 Python tests and 213 web tests pass (the 2 local failures are the known root-sandbox chmod tests, green in CI). Roadmap backlog shrinks to Meshtastic config push, then MicroPython.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLucY2SKuBDPFaDAJnnYs1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLucY2SKuBDPFaDAJnnYs1)_